### PR TITLE
feat: adopt Option B workspace (ADR 0001) — rescue + ratatui + kexec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,30 @@
+[workspace]
+resolver = "2"
+members = [
+    "crates/iso-parser",
+    "crates/iso-probe",
+    "crates/rescue-tui",
+    "crates/kexec-loader",
+]
+exclude = ["crates/iso-parser/fuzz"]
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.85"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/williamzujkowski/aegis-boot"
+
+[workspace.dependencies]
+thiserror = { version = "2.0", features = ["std"] }
+serde = { version = "1.0", features = ["derive"] }
+tracing = "0.1"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "warn"

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 Reproducible UEFI Secure Boot orchestration infrastructure.
 
+## Architecture
+
+The runtime is a **signed Linux rescue environment + ratatui TUI + kexec** (Option B). See [ADR 0001](./docs/adr/0001-runtime-architecture.md) for the full decision record and the vote that produced it.
+
+Boot chain: `UEFI firmware → shim → signed rescue kernel → initramfs → rescue-tui → kexec_file_load → selected ISO's kernel`.
+
 ## Components
 
 - **[BUILDING.md](./BUILDING.md)** — Reproducible build setup (Docker + Nix)
 - **[THREAT_MODEL.md](./THREAT_MODEL.md)** — UEFI Secure Boot threat model (PK/KEK/MOK/SBAT)
+- **[docs/adr/](./docs/adr/)** — Architecture Decision Records
 - **[Dockerfile.locked](./Dockerfile.locked)** — Pinned base image (Ubuntu 22.04, Rust 1.75.0, EDK II stable202311)
 - **[flake.nix](./flake.nix)** — Nix flake for declarative dev environments
-- **[scripts/scaffold-aegis-boot.sh](./scripts/scaffold-aegis-boot.sh)** — Bootstraps Rust workspace
-- **[crates/iso-parser](./crates/iso-parser)** — ISO installation media parser
+- **[crates/iso-parser](./crates/iso-parser)** — ISO media parser (on-media analysis, `std`-compatible)
+- **[crates/iso-probe](./crates/iso-probe)** — Runtime ISO discovery on the live rescue environment
+- **[crates/rescue-tui](./crates/rescue-tui)** — ratatui application the user sees
+- **[crates/kexec-loader](./crates/kexec-loader)** — Safe wrapper over `kexec_file_load(2)`
 
 ## Status
 
-Work in progress. See BUILDING.md for setup and THREAT_MODEL.md for security boundaries.
+Work in progress. Architecture decided (ADR 0001); `iso-parser` is the only crate with real functionality. `iso-probe`, `rescue-tui`, and `kexec-loader` are skeleton-only — implementation tracked from [#4](https://github.com/williamzujkowski/aegis-boot/issues/4).
 
 ## License
 

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "iso-probe"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Runtime ISO discovery on the live rescue environment (loopback + GPT/ISO9660)"
+
+[lib]
+
+[dependencies]
+iso-parser = { path = "../iso-parser" }
+thiserror.workspace = true
+serde = { workspace = true }
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -1,0 +1,60 @@
+//! Runtime ISO discovery on the live aegis-boot rescue environment.
+//!
+//! Walks attached block devices, loop-mounts candidates, and returns a
+//! structured list of bootable ISOs using the lower-level `iso-parser` crate
+//! for on-media analysis.
+//!
+//! # Scope
+//!
+//! This crate is the runtime-side consumer of `iso-parser`. It is meant to
+//! run inside the signed Linux rescue initramfs (see
+//! [ADR 0001](../../../docs/adr/0001-runtime-architecture.md)), not in a
+//! pre-OS UEFI context.
+//!
+//! # Status
+//!
+//! Skeleton only. Implementation is tracked in follow-up issues.
+
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// A discovered, loop-mountable ISO with enough metadata to render in the TUI
+/// and to hand off to `kexec-loader`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveredIso {
+    /// Absolute path to the ISO file on the probed filesystem.
+    pub path: PathBuf,
+    /// Best-effort human label (volume id, distro name).
+    pub label: Option<String>,
+    /// Extracted kernel path inside the ISO, if discovery succeeded.
+    pub kernel: Option<PathBuf>,
+    /// Extracted initrd path inside the ISO, if present.
+    pub initrd: Option<PathBuf>,
+    /// Kernel command line the ISO expects (from isolinux/grub config).
+    pub cmdline: Option<String>,
+}
+
+/// Errors returned during probing.
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// Underlying I/O failure.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// ISO did not match any known layout.
+    #[error("unsupported ISO layout")]
+    UnsupportedLayout,
+}
+
+/// Discover all bootable ISOs reachable from the given roots.
+///
+/// # Errors
+///
+/// Returns [`ProbeError`] on I/O failure. Unrecognized layouts are skipped
+/// silently and do not abort the scan.
+pub fn discover(_roots: &[PathBuf]) -> Result<Vec<DiscoveredIso>, ProbeError> {
+    // TODO(#4): loop-device enumeration, GPT/ISO9660 sniffing, El Torito walk.
+    Ok(Vec::new())
+}

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kexec-loader"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Thin safe wrapper over kexec_file_load(2) for the aegis-boot rescue TUI"
+
+[lib]
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kexec-loader/src/lib.rs
+++ b/crates/kexec-loader/src/lib.rs
@@ -1,0 +1,66 @@
+//! Thin wrapper around `kexec_file_load(2)` for the aegis-boot rescue TUI.
+//!
+//! # Scope
+//!
+//! Only the file-descriptor-based [`kexec_file_load(2)`] syscall is supported.
+//! The classic `kexec_load(2)` is intentionally **not** exposed:
+//!
+//! - It is blocked under `lockdown=integrity` (which we require).
+//! - It has no upstream signature-verification story — `KEXEC_SIG` only
+//!   applies to `kexec_file_load`.
+//!
+//! See [ADR 0001](../../../docs/adr/0001-runtime-architecture.md) for the
+//! Secure Boot rationale.
+//!
+//! # Status
+//!
+//! Skeleton only. Implementation will wire `libc::syscall(SYS_kexec_file_load, ...)`
+//! behind a typed API and surface the kernel's signature-verification result.
+//!
+//! [`kexec_file_load(2)`]: https://man7.org/linux/man-pages/man2/kexec_file_load.2.html
+
+#![forbid(unsafe_code)]
+
+use std::path::PathBuf;
+
+/// Parameters for a `kexec_file_load` invocation.
+#[derive(Debug, Clone)]
+pub struct KexecRequest {
+    /// Path to the target kernel image (must be signed by a key in the
+    /// platform or MOK keyring when SB is enforced).
+    pub kernel: PathBuf,
+    /// Optional initrd path.
+    pub initrd: Option<PathBuf>,
+    /// Kernel command line.
+    pub cmdline: String,
+}
+
+/// Errors returned while preparing or invoking kexec.
+#[derive(Debug, thiserror::Error)]
+pub enum KexecError {
+    /// Underlying syscall failure.
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Kernel signature verification failed (KEXEC_SIG).
+    #[error("kernel signature verification failed (KEXEC_SIG rejected image)")]
+    SignatureRejected,
+    /// Lockdown / SB refused the operation.
+    #[error("operation refused by kernel lockdown")]
+    LockdownRefused,
+}
+
+/// Load and immediately exec the requested kernel via `kexec_file_load(2)`.
+///
+/// This function does not return on success — the calling process is replaced
+/// by the new kernel once `reboot(LINUX_REBOOT_CMD_KEXEC)` is issued. On
+/// failure it returns a classified [`KexecError`] so the TUI can present a
+/// specific diagnostic (bad signature vs lockdown vs I/O) instead of a black
+/// screen.
+///
+/// # Errors
+///
+/// See [`KexecError`].
+pub fn load_and_exec(_req: &KexecRequest) -> Result<std::convert::Infallible, KexecError> {
+    // TODO(#4): bind libc::SYS_kexec_file_load + LINUX_REBOOT_CMD_KEXEC.
+    Err(KexecError::LockdownRefused)
+}

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rescue-tui"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ratatui application for the aegis-boot signed Linux rescue environment"
+
+[[bin]]
+name = "rescue-tui"
+path = "src/main.rs"
+
+[dependencies]
+iso-probe = { path = "../iso-probe" }
+kexec-loader = { path = "../kexec-loader" }
+thiserror.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -1,0 +1,14 @@
+//! `rescue-tui` — ratatui application shown inside the aegis-boot signed Linux
+//! rescue environment. Lets the user pick a discovered ISO and hands off to
+//! `kexec-loader`.
+//!
+//! See [ADR 0001](../../../../docs/adr/0001-runtime-architecture.md).
+
+#![forbid(unsafe_code)]
+
+fn main() {
+    // TODO(#4): initialize tracing, run iso_probe::discover, render ratatui,
+    // read user selection, invoke kexec_loader::load_and_exec.
+    eprintln!("rescue-tui: skeleton only. See ADR 0001.");
+    std::process::exit(1);
+}

--- a/docs/adr/0001-runtime-architecture.md
+++ b/docs/adr/0001-runtime-architecture.md
@@ -1,0 +1,100 @@
+# ADR 0001: Runtime Architecture — Signed Linux Rescue + ratatui + kexec
+
+**Status:** Accepted
+**Date:** 2026-04-14
+**Deciders:** 5-agent consensus vote (higher_order, supermajority) on [issue #4](https://github.com/williamzujkowski/aegis-boot/issues/4)
+**Result:** Option B, 4–1 (80%)
+
+## Context
+
+Aegis-boot's product goal: drop any bootable ISO into a drive, boot the machine, show a TUI listing discovered ISOs, select one, boot it — under UEFI Secure Boot guarantees.
+
+At the point of this decision the repo has `iso-parser` (ingestion) and a Secure Boot threat model, but the runtime (TUI + boot-time integration) is unspecified. Three architectures were evaluated:
+
+- **A — Custom UEFI app** (Rust + `uefi-rs`, TUI pre-OS, chainload via `LoadImage`/`StartImage`)
+- **B — Signed Linux rescue + ratatui + kexec** (small signed kernel + initramfs, kexec into selected ISO's kernel)
+- **C — GRUB menu generator** (`iso-parser` emits `grub.cfg`; shim→GRUB→loopback ISO)
+
+## Decision
+
+**Adopt Option B.**
+
+## Rationale
+
+Four of five voters (security, systems/firmware, product, architecture, devil's-advocate roles) converged on B; security specialist dissented for A.
+
+Primary drivers:
+
+1. **Operational Secure Boot burden is outsourced.** shim + signed distro kernel inherits Fedora/Debian/SUSE's revocation response, SBAT bumps, and Microsoft CA rotation (2026 "Windows UEFI CA 2023" cutover). Option A would make us our own shim, responsible for every dbx update.
+2. **"Real TUI" is only met by ratatui.** GOP framebuffer text (A) or `EFI_SIMPLE_TEXT_OUTPUT` is a `println` loop; GRUB's menu (C) fails the product goal on day zero.
+3. **Driver ecosystem is non-trivial.** xHCI USB HID, ISO9660 + El Torito + UDF hybrid parsing (Rock Ridge, Joliet), NVMe, GOP quirks across AMI/Insyde/Phoenix firmware. The kernel has already solved this; reimplementing in `uefi-rs` is a perpetual cost for a small team.
+4. **Testability.** `cargo test` + `ratatui::TestBackend` + existing `iso-parser` (std-compatible) drops in unchanged. Option A requires a `no_std` rewrite of the IO layer.
+5. **Graceful degradation.** If `kexec` fails on exotic hardware, the user still has a working rescue shell with networking, `dmesg`, `lsblk`. A and C leave a black screen.
+
+## Consequences
+
+### Crate layout
+
+- `crates/iso-parser/` — existing, std-compatible ISO parser (kept)
+- `crates/iso-probe/` — loopback + GPT/ISO9660 discovery on the live rescue environment; wraps `iso-parser` for the runtime caller
+- `crates/rescue-tui/` — ratatui application; the TUI the user sees
+- `crates/kexec-loader/` — thin wrapper over `kexec_file_load(2)`; must refuse `kexec_load` (lockdown blocks it anyway)
+
+### Boot chain
+
+```
+UEFI firmware
+  → shim (vendor-signed, Microsoft UEFI CA)
+    → signed Linux rescue kernel (Canonical / Debian / Fedora CA)
+      → initramfs (contains rescue-tui + iso-probe + kexec-loader)
+        → rescue-tui (user selects ISO)
+          → kexec-loader → kexec_file_load → selected ISO's kernel + initrd
+```
+
+### Required kernel config (rescue kernel)
+
+- `CONFIG_KEXEC_FILE=y`
+- `CONFIG_KEXEC_SIG=y`
+- `CONFIG_KEXEC_BZIMAGE_VERIFY_SIG=y`
+- `CONFIG_LOCKDOWN_LSM=y` with `lockdown=integrity`
+
+Explicitly **not** used: `kexec_load(2)` (classic syscall — blocked under lockdown, weaker signature story).
+
+### Risks we accept and must mitigate
+
+| Risk | Mitigation |
+|---|---|
+| `kexec_file_load` + `KEXEC_SIG` lockdown-bypass CVEs (e.g. CVE-2022-21505 class) | Pin minimum rescue kernel version; track kernel security advisories; document update cadence. |
+| Unsigned / self-built ISO kernels fail signature check | Honest UX: present a clear "this ISO's kernel is not signed by a trusted CA; enroll its key via `mokutil` to boot it" message. Never suggest disabling SB. |
+| Cross-distro kexec refusal (RHEL-family may reject non-RHEL-CA kernels even with `KEXEC_SIG` satisfied) | Maintain a per-distro compatibility matrix (tracking issue forthcoming). |
+| Hybrid ISOs assuming `dd`-to-block-device or BIOS isolinux-only | Per-distro quirks table in `iso-probe`; fail gracefully with a specific diagnostic, not a black screen. |
+| Image size 80–150 MB vs ~2 MB UEFI app | Acceptable tradeoff; documented in README. |
+| Initramfs supply chain | Reproducible build pipeline (issue #2) must cover initramfs content, not just binaries. |
+
+### Preserved dissenting view (Option A)
+
+The security voter argued that chainloading via `LoadImage`/`StartImage` sidesteps SBAT/MOK/kexec entirely, minimizes TCB to a single signed PE, and eliminates the GRUB/shim/kernel CVE lineage (BootHole family: CVE-2020-10713, CVE-2024-45774..45783; shim CVE-2023-40547; kernel lockdown CVE-2022-21505).
+
+This dissent shapes Option B's implementation:
+
+- `kexec-loader` is deliberately the smallest crate — its CVE blast radius is our largest residual TCB concern.
+- Future revisit trigger: if upstream kexec-under-SB accumulates more than one critical CVE per year for two consecutive years, revisit Option A.
+
+## Alternatives considered
+
+### Option A — Custom UEFI app (rejected)
+
+- Rejected primarily because (a) the stated "TUI" requirement degrades to framebuffer text, (b) driver re-implementation cost (USB HID, ISO9660/UDF) dominates project bandwidth for a 2-person team, (c) we become our own shim with full signing/revocation responsibility.
+- Preserved as the long-term revisit option if kexec-under-SB becomes untenable.
+
+### Option C — GRUB menu generator (unanimously rejected)
+
+- GRUB's stock menu is explicitly **not** a TUI — fails product goal on day zero.
+- GRUB under Secure Boot is the single largest CVE surface in the ecosystem (BootHole lineage).
+- `grub.cfg` loopback coverage is distro-specific and silently broken for many ISOs (Windows, VMware ESXi, memdisk-dependent live images).
+
+## References
+
+- Issue [#4](https://github.com/williamzujkowski/aegis-boot/issues/4) — architecture decision
+- Issue [#2](https://github.com/williamzujkowski/aegis-boot/issues/2) — reproducible build (must cover rescue kernel + initramfs + signing)
+- `THREAT_MODEL.md` — pending update to reflect the chosen chain


### PR DESCRIPTION
## Summary

Resolves #4. The 5-agent consensus vote chose **Option B** (Signed Linux rescue + ratatui + kexec) 4–1 over the custom UEFI app (A) and GRUB generator (C). This PR codifies that decision and scaffolds the workspace — no runtime behavior yet.

## What's in the PR

- **Root \`Cargo.toml\`** as a resolver-2 workspace with shared lints (\`unsafe_code = forbid\`, clippy pedantic).
- **[ADR 0001](./docs/adr/0001-runtime-architecture.md)** — full decision record including the vote tally, convergent rationale, preserved security-voter dissent, explicit revisit trigger (\"if kexec-under-SB accumulates > 1 critical CVE/year for 2 consecutive years, revisit A\"), and the mitigation plan for the residual risks voters called out.
- **\`crates/iso-probe\`** — runtime ISO discovery, wraps the existing \`iso-parser\`. Skeleton only.
- **\`crates/rescue-tui\`** — ratatui binary. Skeleton only.
- **\`crates/kexec-loader\`** — thin wrapper over \`kexec_file_load(2)\`. **Deliberately does not expose \`kexec_load(2)\`** — lockdown blocks it anyway, and it has no \`KEXEC_SIG\` story. Skeleton only.
- **README** — architecture section, boot chain, crate map.

## What's NOT in the PR

- Any real implementation — three follow-up issues will track \`iso-probe\` discovery, \`kexec-loader\` syscall wiring, and \`rescue-tui\` UI.
- \`THREAT_MODEL.md\` updates — separate PR (the current doc assumes systemd-boot; needs rework for the rescue+kexec chain).
- Per-distro ISO quirks compatibility matrix — separate tracking issue.

## Test plan

- [x] \`cargo check --workspace\` passes locally.
- [ ] CI: fmt, clippy, test, fuzz-smoke all green.
- [ ] Existing \`iso-parser\` tests unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)