### PR TITLE
feat(#13): structured tracing events across discover/prepare/kexec path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -853,10 +864,13 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -899,6 +913,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -18,7 +18,7 @@ thiserror.workspace = true
 tracing.workspace = true
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 crossterm = "0.28"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -42,14 +42,24 @@ fn main() -> ExitCode {
 }
 
 fn tracing_subscriber_init() {
-    // Logs to stderr only if RUST_LOG is set. The TUI owns stdout.
-    let _ = tracing_subscriber::fmt()
-        .with_writer(io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
-        .try_init();
+    // systemd-journald captures stderr from services it runs, so stderr is
+    // the right destination even for "structured" output — the journal
+    // handles it. `AEGIS_LOG_JSON=1` switches to a machine-readable format
+    // suited to `journalctl --output=json`; the default stays human-readable.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("rescue_tui=info,iso_probe=info,kexec_loader=info"));
+    if std::env::var("AEGIS_LOG_JSON").is_ok() {
+        let _ = tracing_subscriber::fmt()
+            .with_writer(io::stderr)
+            .with_env_filter(filter)
+            .json()
+            .try_init();
+    } else {
+        let _ = tracing_subscriber::fmt()
+            .with_writer(io::stderr)
+            .with_env_filter(filter)
+            .try_init();
+    }
 }
 
 fn parse_roots(env_var: Option<&str>) -> Vec<PathBuf> {
@@ -60,18 +70,42 @@ fn parse_roots(env_var: Option<&str>) -> Vec<PathBuf> {
 }
 
 fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        roots = ?roots,
+        "rescue-tui starting"
+    );
     let isos = match iso_probe::discover(roots) {
         Ok(v) => v,
-        Err(iso_probe::ProbeError::NoIsosFound) => Vec::new(),
-        Err(e) => return Err(e.into()),
+        Err(iso_probe::ProbeError::NoIsosFound) => {
+            tracing::info!("no ISOs discovered under any root");
+            Vec::new()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "ISO discovery failed");
+            return Err(e.into());
+        }
     };
-    // Startup banner to stderr — visible on the serial console before the TUI
-    // takes over stdout, useful for smoke tests and operator triage on
-    // hardware where the terminal emulator doesn't report a usable size.
+    // Startup banner to stderr — mirrored via tracing::info! so structured
+    // consumers (journald, CI smoke greps) see the same signal as humans
+    // reading the serial console directly.
     eprintln!(
         "aegis-boot rescue-tui starting: discovered {} ISO(s)",
         isos.len()
     );
+    tracing::info!(
+        discovered = isos.len(),
+        "ISO discovery complete"
+    );
+    for iso in &isos {
+        tracing::debug!(
+            label = %iso.label,
+            path = %iso.iso_path.display(),
+            distribution = ?iso.distribution,
+            quirks = ?iso.quirks,
+            "discovered ISO"
+        );
+    }
     let mut state = AppState::new(isos);
 
     enable_raw_mode()?;
@@ -130,12 +164,25 @@ fn event_loop<B: ratatui::backend::Backend>(
 
 fn attempt_kexec(state: &mut AppState, idx: usize) {
     let Some(iso) = state.isos.get(idx).cloned() else {
+        tracing::warn!(idx, "attempt_kexec called with out-of-range index");
         return;
     };
+    tracing::info!(
+        label = %iso.label,
+        iso_path = %iso.iso_path.display(),
+        "user confirmed kexec"
+    );
     let prepared = match iso_probe::prepare(&iso) {
-        Ok(p) => p,
+        Ok(p) => {
+            tracing::info!(
+                mount = %p.mount_point().display(),
+                kernel = %p.kernel.display(),
+                "prepared ISO for kexec"
+            );
+            p
+        }
         Err(e) => {
-            tracing::warn!("iso_probe::prepare failed: {e}");
+            tracing::warn!(error = %e, "iso_probe::prepare failed");
             state.record_kexec_error(&kexec_loader::KexecError::Io(io::Error::other(
                 e.to_string(),
             )));
@@ -147,11 +194,20 @@ fn attempt_kexec(state: &mut AppState, idx: usize) {
         initrd: prepared.initrd.clone(),
         cmdline: prepared.cmdline.clone().unwrap_or_default(),
     };
+    tracing::info!(
+        kernel = %req.kernel.display(),
+        initrd = ?req.initrd.as_ref().map(|p| p.display().to_string()),
+        cmdline = %req.cmdline,
+        "invoking kexec_file_load"
+    );
     // Drop guard: prepared lives until kexec_file_load + reboot replace the
     // process. On error, prepared drops here and unmounts.
     match kexec_loader::load_and_exec(&req) {
         Ok(_unreachable) => unreachable!("load_and_exec returns Infallible on success"),
-        Err(e) => state.record_kexec_error(&e),
+        Err(e) => {
+            tracing::error!(error = %e, "kexec failed");
+            state.record_kexec_error(&e);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Part of #24 (v0.2.0 epic) — closes the "structured tracing to journald" must-have.

Every user-visible state transition in \`rescue-tui\` now emits a \`tracing\` event with stable structured field names. systemd-journald captures stderr from services, so when aegis-boot ships as a rescue initramfs under systemd, operators can triage with \`journalctl\` out of the box.

## Events added

| Level | Event | Fields |
|---|---|---|
| INFO | \`rescue-tui starting\` | \`version\`, \`roots\` |
| INFO | \`ISO discovery complete\` | \`discovered\` (count) |
| DEBUG | \`discovered ISO\` | \`label\`, \`path\`, \`distribution\`, \`quirks\` |
| INFO | \`user confirmed kexec\` | \`label\`, \`iso_path\` |
| INFO | \`prepared ISO for kexec\` | \`mount\`, \`kernel\` |
| INFO | \`invoking kexec_file_load\` | \`kernel\`, \`initrd\`, \`cmdline\` |
| ERROR | \`kexec failed\` | \`error\` |
| WARN | \`ISO discovery failed\` | \`error\` |
| INFO | \`no ISOs discovered under any root\` | — |

## JSON output

\`AEGIS_LOG_JSON=1\` switches the \`tracing-subscriber\` formatter to JSON. Journal entries look like:

\`\`\`json
{"timestamp":"2026-04-14T...","level":"INFO","fields":{"message":"prepared ISO for kexec","mount":"/run/media/.../mount_fixture","kernel":"/run/media/.../mount_fixture/casper/vmlinuz"},"target":"rescue_tui"}
\`\`\`

## Default filter

Raised from \`warn\` to \`rescue_tui=info,iso_probe=info,kexec_loader=info\` so operators get useful output without setting \`RUST_LOG\`. Users who want verbose detail can still opt into \`debug\` or module-specific filters.

## Test plan

- [x] \`cargo test --workspace\` — 49/49 pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] QEMU smoke test still passes (tracing startup event + existing eprintln banner both visible).
- [ ] CI: 11 checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)