### PR TITLE
feat(#14): TUI kernel cmdline editor

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -144,16 +144,33 @@ fn event_loop<B: ratatui::backend::Backend>(
             continue;
         }
 
+        // In the cmdline editor, typing characters (including 'q') should
+        // insert, not quit. Keep 'q' as global quit only outside the editor.
+        let in_editor = matches!(state.screen, Screen::EditCmdline { .. });
+        if !in_editor && key.code == KeyCode::Char('q') {
+            state.quit();
+            continue;
+        }
+
         match (&state.screen, key.code) {
-            (_, KeyCode::Char('q')) => state.quit(),
             (Screen::List { .. }, KeyCode::Up) => state.move_selection(-1),
             (Screen::List { .. }, KeyCode::Down) => state.move_selection(1),
             (Screen::List { .. }, KeyCode::Enter) => state.confirm_selection(),
+
             (Screen::Confirm { .. }, KeyCode::Esc) => state.cancel_confirmation(),
+            (Screen::Confirm { .. }, KeyCode::Char('e')) => state.enter_cmdline_editor(),
             (Screen::Confirm { selected }, KeyCode::Enter) => {
                 let idx = *selected;
                 attempt_kexec(state, idx);
             }
+
+            (Screen::EditCmdline { .. }, KeyCode::Enter) => state.commit_cmdline_edit(),
+            (Screen::EditCmdline { .. }, KeyCode::Esc) => state.cancel_cmdline_edit(),
+            (Screen::EditCmdline { .. }, KeyCode::Left) => state.cmdline_cursor_left(),
+            (Screen::EditCmdline { .. }, KeyCode::Right) => state.cmdline_cursor_right(),
+            (Screen::EditCmdline { .. }, KeyCode::Backspace) => state.cmdline_backspace(),
+            (Screen::EditCmdline { .. }, KeyCode::Char(c)) => state.cmdline_insert(c),
+
             (Screen::Error { .. }, _) => {
                 state.screen = Screen::List { selected: 0 };
             }
@@ -189,10 +206,18 @@ fn attempt_kexec(state: &mut AppState, idx: usize) {
             return;
         }
     };
+    // User override takes precedence over the ISO-declared default; fall
+    // back to whatever iso-probe extracted from the ISO's own boot config.
+    let cmdline = state
+        .cmdline_overrides
+        .get(&idx)
+        .cloned()
+        .or_else(|| prepared.cmdline.clone())
+        .unwrap_or_default();
     let req = kexec_loader::KexecRequest {
         kernel: prepared.kernel.clone(),
         initrd: prepared.initrd.clone(),
-        cmdline: prepared.cmdline.clone().unwrap_or_default(),
+        cmdline,
     };
     tracing::info!(
         kernel = %req.kernel.display(),

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -17,6 +17,11 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
     match &state.screen {
         Screen::List { selected } => draw_list(frame, area, state, *selected),
         Screen::Confirm { selected } => draw_confirm(frame, area, state, *selected),
+        Screen::EditCmdline {
+            selected,
+            buffer,
+            cursor,
+        } => draw_edit_cmdline(frame, area, state, *selected, buffer, *cursor),
         Screen::Error { message, remedy } => draw_error(frame, area, message, remedy.as_deref()),
         Screen::Quitting => {}
     }
@@ -70,6 +75,18 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
     let Some(iso) = state.isos.get(selected) else {
         return;
     };
+    let override_active = state.cmdline_overrides.contains_key(&selected);
+    let effective_cmdline = state.effective_cmdline(selected);
+    let cmdline_display = if effective_cmdline.is_empty() {
+        "(none)".to_string()
+    } else {
+        effective_cmdline
+    };
+    let cmdline_label = if override_active {
+        "Cmdline*: "
+    } else {
+        "Cmdline:  "
+    };
     let lines: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("Label:    ", Style::default().add_modifier(Modifier::BOLD)),
@@ -92,8 +109,8 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             ),
         ]),
         Line::from(vec![
-            Span::styled("Cmdline:  ", Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(iso.cmdline.clone().unwrap_or_else(|| "(none)".to_string())),
+            Span::styled(cmdline_label, Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(cmdline_display),
         ]),
         Line::from(""),
         Line::from(vec![
@@ -105,13 +122,65 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             }),
         ]),
         Line::from(""),
-        Line::from("Press Enter to kexec into this ISO, Esc to cancel."),
+        Line::from("Enter: kexec · e: edit cmdline · Esc: cancel"),
     ];
     let para = Paragraph::new(lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title("Confirm kexec"),
+                .title(if override_active {
+                    "Confirm kexec (cmdline overridden)"
+                } else {
+                    "Confirm kexec"
+                }),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+fn draw_edit_cmdline(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    selected: usize,
+    buffer: &str,
+    cursor: usize,
+) {
+    let default_cmdline = state
+        .isos
+        .get(selected)
+        .and_then(|i| i.cmdline.clone())
+        .unwrap_or_default();
+    let cursor_marker = "│"; // U+2502 BOX DRAWINGS LIGHT VERTICAL — one grapheme
+    let (before, after) = buffer.split_at(cursor.min(buffer.len()));
+    let rendered_buffer = format!("{before}{cursor_marker}{after}");
+
+    let lines = vec![
+        Line::from(vec![Span::styled(
+            "Edit kernel command line",
+            Style::default().add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Default: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(if default_cmdline.is_empty() {
+                "(none)".to_string()
+            } else {
+                default_cmdline
+            }),
+        ]),
+        Line::from(vec![
+            Span::styled("Current: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(rendered_buffer),
+        ]),
+        Line::from(""),
+        Line::from("Enter: save · Esc: cancel · ←/→: move · Backspace: delete"),
+    ];
+    let para = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Edit cmdline"),
         )
         .wrap(Wrap { trim: false });
     frame.render_widget(para, area);

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -19,6 +19,15 @@ pub enum Screen {
         /// Index into [`AppState::isos`] of the ISO under confirmation.
         selected: usize,
     },
+    /// Editing the kernel command line before kexec.
+    EditCmdline {
+        /// Index into [`AppState::isos`] of the ISO under edit.
+        selected: usize,
+        /// Current buffer (starts with the ISO-declared cmdline).
+        buffer: String,
+        /// Byte-offset cursor position within the buffer.
+        cursor: usize,
+    },
     /// Showing a fatal-or-classified error after attempted kexec.
     Error {
         /// User-facing diagnostic copied from [`error_diagnostic`].
@@ -37,6 +46,9 @@ pub struct AppState {
     pub isos: Vec<DiscoveredIso>,
     /// Current screen.
     pub screen: Screen,
+    /// Per-ISO cmdline overrides keyed by index. When absent the
+    /// ISO-declared default from `iso-probe` is used.
+    pub cmdline_overrides: std::collections::HashMap<usize, String>,
 }
 
 impl AppState {
@@ -46,7 +58,112 @@ impl AppState {
         Self {
             isos,
             screen: Screen::List { selected: 0 },
+            cmdline_overrides: std::collections::HashMap::new(),
         }
+    }
+
+    /// Effective cmdline for the ISO at `idx` — the user's override if one
+    /// exists, otherwise the ISO-declared default (or empty string).
+    #[must_use]
+    pub fn effective_cmdline(&self, idx: usize) -> String {
+        self.cmdline_overrides
+            .get(&idx)
+            .cloned()
+            .or_else(|| self.isos.get(idx)?.cmdline.clone())
+            .unwrap_or_default()
+    }
+
+    /// Transition confirm → edit-cmdline, seeding the buffer with whatever
+    /// is currently effective for the selected ISO.
+    pub fn enter_cmdline_editor(&mut self) {
+        let Screen::Confirm { selected } = self.screen else {
+            return;
+        };
+        let buffer = self.effective_cmdline(selected);
+        let cursor = buffer.len();
+        self.screen = Screen::EditCmdline {
+            selected,
+            buffer,
+            cursor,
+        };
+    }
+
+    /// Commit the editor's buffer as the override and return to Confirm.
+    pub fn commit_cmdline_edit(&mut self) {
+        let Screen::EditCmdline {
+            selected, buffer, ..
+        } = std::mem::replace(&mut self.screen, Screen::Quitting)
+        else {
+            return;
+        };
+        self.cmdline_overrides.insert(selected, buffer);
+        self.screen = Screen::Confirm { selected };
+    }
+
+    /// Cancel the editor and return to Confirm without saving.
+    pub fn cancel_cmdline_edit(&mut self) {
+        if let Screen::EditCmdline { selected, .. } = self.screen {
+            self.screen = Screen::Confirm { selected };
+        }
+    }
+
+    /// Insert a single character at the cursor.
+    pub fn cmdline_insert(&mut self, ch: char) {
+        let Screen::EditCmdline {
+            buffer, cursor, ..
+        } = &mut self.screen
+        else {
+            return;
+        };
+        buffer.insert(*cursor, ch);
+        *cursor += ch.len_utf8();
+    }
+
+    /// Delete one char before the cursor (backspace).
+    pub fn cmdline_backspace(&mut self) {
+        let Screen::EditCmdline {
+            buffer, cursor, ..
+        } = &mut self.screen
+        else {
+            return;
+        };
+        if *cursor == 0 {
+            return;
+        }
+        let new_cursor = prev_char_boundary(buffer, *cursor);
+        buffer.replace_range(new_cursor..*cursor, "");
+        *cursor = new_cursor;
+    }
+
+    /// Move cursor left one char (saturating).
+    pub fn cmdline_cursor_left(&mut self) {
+        let Screen::EditCmdline {
+            buffer, cursor, ..
+        } = &mut self.screen
+        else {
+            return;
+        };
+        if *cursor == 0 {
+            return;
+        }
+        *cursor = prev_char_boundary(buffer, *cursor);
+    }
+
+    /// Move cursor right one char (saturating).
+    pub fn cmdline_cursor_right(&mut self) {
+        let Screen::EditCmdline {
+            buffer, cursor, ..
+        } = &mut self.screen
+        else {
+            return;
+        };
+        if *cursor >= buffer.len() {
+            return;
+        }
+        let new_cursor = (*cursor + 1..=buffer.len())
+            .find(|candidate| buffer.is_char_boundary(*candidate))
+            .unwrap_or(buffer.len());
+        *cursor = new_cursor;
     }
 
     /// Advance the highlighted row up (negative) or down (positive), saturating
@@ -99,11 +216,24 @@ impl AppState {
     #[must_use]
     #[cfg(test)]
     pub fn selected_iso(&self) -> Option<&DiscoveredIso> {
-        let (Screen::List { selected } | Screen::Confirm { selected }) = self.screen else {
-            return None;
+        let selected = match &self.screen {
+            Screen::List { selected }
+            | Screen::Confirm { selected }
+            | Screen::EditCmdline { selected, .. } => *selected,
+            _ => return None,
         };
         self.isos.get(selected)
     }
+}
+
+/// Find the byte offset of the nearest char boundary before `cursor`.
+///
+/// UTF-8 chars are 1-4 bytes; step back 1 byte at a time looking for the
+/// previous boundary. Walks up to 4 bytes in the worst case.
+fn prev_char_boundary(buffer: &str, cursor: usize) -> usize {
+    (1..=cursor.min(4))
+        .find(|step| buffer.is_char_boundary(cursor - step))
+        .map_or(0, |step| cursor - step)
 }
 
 /// Map a [`KexecError`] to (user-facing message, optional remedy hint).
@@ -262,6 +392,111 @@ mod tests {
         let mut s = AppState::new(vec![fake_iso("a")]);
         s.quit();
         assert_eq!(s.screen, Screen::Quitting);
+    }
+
+    #[test]
+    fn enter_cmdline_editor_seeds_with_iso_default() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        let Screen::EditCmdline { buffer, cursor, selected } = &s.screen else {
+            panic!("expected EditCmdline screen");
+        };
+        assert_eq!(*selected, 0);
+        assert_eq!(buffer, "boot=casper"); // from fake_iso
+        assert_eq!(*cursor, buffer.len());
+    }
+
+    #[test]
+    fn cmdline_insert_at_cursor() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        s.cmdline_insert(' ');
+        s.cmdline_insert('q');
+        s.cmdline_insert('u');
+        s.cmdline_insert('i');
+        s.cmdline_insert('e');
+        s.cmdline_insert('t');
+        let Screen::EditCmdline { buffer, .. } = &s.screen else {
+            panic!("expected EditCmdline")
+        };
+        assert_eq!(buffer, "boot=casper quiet");
+    }
+
+    #[test]
+    fn cmdline_backspace_and_cursor_navigation() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        // Buffer is "boot=casper", cursor at end (11).
+        s.cmdline_backspace(); // remove 'r'
+        s.cmdline_backspace(); // remove 'e'
+        let Screen::EditCmdline { buffer, cursor, .. } = &s.screen else {
+            panic!()
+        };
+        assert_eq!(buffer, "boot=casp");
+        assert_eq!(*cursor, 9);
+        s.cmdline_cursor_left();
+        s.cmdline_cursor_left();
+        s.cmdline_insert('X');
+        let Screen::EditCmdline { buffer, .. } = &s.screen else {
+            panic!()
+        };
+        // cursor=9 after backspaces → left→left moves to 7 (before 's');
+        // inserting 'X' there gives "boot=ca" + "X" + "sp".
+        assert_eq!(buffer, "boot=caXsp");
+    }
+
+    #[test]
+    fn commit_cmdline_stores_override_and_returns_to_confirm() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        s.cmdline_insert(' ');
+        s.cmdline_insert('q');
+        s.commit_cmdline_edit();
+        assert_eq!(s.screen, Screen::Confirm { selected: 0 });
+        assert_eq!(s.cmdline_overrides.get(&0), Some(&"boot=casper q".to_string()));
+        assert_eq!(s.effective_cmdline(0), "boot=casper q");
+    }
+
+    #[test]
+    fn cancel_cmdline_edit_preserves_original() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        s.cmdline_insert('X');
+        s.cancel_cmdline_edit();
+        assert_eq!(s.screen, Screen::Confirm { selected: 0 });
+        assert!(s.cmdline_overrides.is_empty());
+        assert_eq!(s.effective_cmdline(0), "boot=casper"); // unchanged default
+    }
+
+    #[test]
+    fn backspace_on_empty_buffer_is_noop() {
+        let mut s = AppState::new(vec![{
+            let mut i = fake_iso("a");
+            i.cmdline = None; // no default
+            i
+        }]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        s.cmdline_backspace();
+        s.cmdline_cursor_left();
+        let Screen::EditCmdline { buffer, cursor, .. } = &s.screen else {
+            panic!()
+        };
+        assert_eq!(buffer, "");
+        assert_eq!(*cursor, 0);
+    }
+
+    #[test]
+    fn effective_cmdline_prefers_override() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        assert_eq!(s.effective_cmdline(0), "boot=casper");
+        s.cmdline_overrides.insert(0, "override=yes".to_string());
+        assert_eq!(s.effective_cmdline(0), "override=yes");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes part of #24 — the "TUI cmdline editor" must-have for v0.2.0.

Before this PR, \`rescue-tui\` silently used whatever cmdline \`iso-probe\` extracted from the ISO's boot config. Users had no way to override (e.g. add \`quiet\`, change \`console=\` for serial rescue, pass \`single\` for emergency boot). This PR adds an in-TUI editor.

## Flow

\`\`\`
List ──Enter──▶ Confirm ──e──▶ EditCmdline
                   ▲                │
                   └──Enter/Esc─────┘
\`\`\`

- **Enter** in the editor: commit buffer as override for the selected ISO, return to Confirm (which now shows \`Cmdline*:\` to flag the override).
- **Esc** in the editor: cancel without saving; ISO's default cmdline remains effective.
- Overrides are per-ISO and preserved across cancel/re-enter of Confirm.

## UTF-8 correctness

Edit operations walk \`String::is_char_boundary\` up to 4 bytes backward before splitting. Inserting / deleting multi-byte sequences (UTF-8 or emoji in kernel cmdlines would be unusual but is safe) never panics.

## Render

- **Confirm screen**: overridden cmdline is marked with \`Cmdline*:\` and the title appends \`(cmdline overridden)\`.
- **Edit screen**: shows both the ISO-declared default and the current buffer, with a \`│\` marker at the cursor byte offset.

## Key bindings

| Context | Key | Action |
|---|---|---|
| List | Up/Down | navigate |
| List | Enter | confirm selection |
| Confirm | Enter | kexec |
| Confirm | \`e\` | enter editor |
| Confirm | Esc | back to list |
| EditCmdline | Enter | save override |
| EditCmdline | Esc | discard, back to Confirm |
| EditCmdline | Left/Right | move cursor |
| EditCmdline | Backspace | delete previous char |
| EditCmdline | any char | insert at cursor |
| * (not editing) | \`q\` | quit |

Note \`q\` is deliberately inhibited while editing so users can type \`q\` into the buffer.

## Tests

7 new unit tests (56 total workspace, was 49):
- editor seed with ISO default
- character insert
- backspace + cursor navigation with multi-step traversal
- commit stores override + returns to Confirm
- cancel preserves original default
- no-op on empty buffer
- effective_cmdline prefers override over default

## Test plan

- [x] \`cargo test --workspace\` — 56/56 pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [ ] CI: 11 checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)