### PR TITLE
release: v0.2.0 — feature-complete rescue runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] — 2026-04-14
+
+Tracks progress of the [v0.2.0 epic (#24)](https://github.com/williamzujkowski/aegis-boot/issues/24). Closes must-haves for:
+
+- **Structured tracing to journald** — every discover/prepare/kexec step emits a `tracing` event with stable fields. `AEGIS_LOG_JSON=1` opts into JSON format for `journalctl --output=json` triage. Default filter raised to `info` so operators see useful output without setting `RUST_LOG`.
+- **TUI kernel cmdline editor** — Confirm → `e` enters an in-TUI editor; Enter commits, Esc cancels. Per-ISO override map preserved across cancel/re-enter. UTF-8 cursor walking via `String::is_char_boundary`. The override takes precedence over the ISO-declared default at kexec time.
+- **ISO hash verification against sibling checksum files** — `iso-probe` looks for `<iso>.sha256` (sidecar) first, then `SHA256SUMS` in the same directory. First match wins. Confirm screen renders a colored status: green `✓ verified`, red bold `✗ MISMATCH — do NOT kexec`, or default `(no sibling checksum)`. **Not** crypto-grade signing — that's a separate follow-up. Module docstring is explicit about what hash verification buys and what it doesn't.
+- **Real kexec_file_load integration test** — `kexec_loader::load_dry` exercises the real syscall against a real kernel in CI, asserting `/sys/kernel/kexec_loaded` transitions 0 → 1. First time the kexec syscall path is end-to-end-verified rather than just errno-classification-unit-tested.
+- **Distribution enum extended** — Alpine / NixOS / RHEL (Rocky / AlmaLinux) promoted from `Unknown`-detected to named variants with specific detection + quirk mappings. `docs/compatibility/iso-matrix.md` updated.
+
+### What did NOT land in 0.2.0
+
+- **OVMF SecBoot CI verification** — deferred to v0.3.0. Requires end-to-end shim+signed-kernel+MOK plumbing that doesn't fit a small CI job cleanly; needs a dedicated design doc.
+- **True crypto-grade ISO signature verification** (minisign / sigstore) — the module boundary is in place; the verifier itself is follow-up work.
+- **UDF filesystem, kernel module loading, TPM PCR extension** — all should-haves / nice-to-haves in #24 that didn't fit.
+
+### Test tally
+
+- **v0.1.0 baseline:** 35 tests
+- **v0.2.0:** 71 tests (+36)
+
+### CI tally
+
+11 checks per PR, all green on `main`:
+Test (1.85) · Test (stable) · SAST (semgrep) · cargo-deny · gitleaks · CycloneDX SBOM · Nix smoke · reproducible-build · initramfs build · loop-mount integration · QEMU smoke boot.
+
+### Upgrade notes
+
+- `iso_probe::DiscoveredIso` gained a `hash_verification` field — consumers that construct the struct manually must populate it (use `HashVerification::NotPresent` if you don't want hash checks).
+- `Distribution` enum added three variants (`Alpine`, `NixOS`, `RedHat`) — `match` expressions on `Distribution` must add arms or use a wildcard.
+
 ## [0.1.0] — 2026-04-14
 
 First release. The rescue runtime boots end-to-end in CI: a real kernel unpacks a reproducible `initramfs.cpio.gz`, PID 1 runs, `rescue-tui` reaches first render, and the whole chain is verified on every PR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -373,7 +373,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kexec-loader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -591,7 +591,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossterm",
  "iso-probe",

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Cuts **v0.2.0**. Closes the must-haves in the [v0.2.0 epic #24](https://github.com/williamzujkowski/aegis-boot/issues/24).

## Must-haves landed (merged as separate PRs)

| PR | Feature | Issue |
|---|---|---|
| #25 | Structured tracing to journald | #13 |
| #23 | \`load_dry\` + real kexec_file_load integration test | — |
| #22 | Distribution enum: Alpine / NixOS / RedHat | — |
| #26 | TUI kernel cmdline editor | #14 |
| #27 | ISO hash verification (SHA256SUMS / .sha256) | #15 |

## Deferred to v0.3.0 (documented)

- OVMF SecBoot CI verification (#16) — needs a dedicated design doc
- True crypto-grade ISO signature verification (minisign / sigstore)
- UDF filesystem support in iso-parser
- Kernel module loading in initramfs
- TPM PCR extension

All documented in the CHANGELOG under "What did NOT land in 0.2.0" — naming honestly beats claiming completeness we don't have.

## Stats

- **Tests:** 35 (v0.1.0) → **71** (v0.2.0), +36
- **CI checks per PR:** 11, all green on \`main\`
- **Reproducibility:** \`rescue-tui\` binary + \`initramfs.cpio.gz\` both byte-identical under \`SOURCE_DATE_EPOCH\`

## Release assets (after tag)

Release workflow (\`.github/workflows/release.yml\`) fires on \`v*\` tag push. Assets on \`v0.2.0\`:
- \`initramfs.cpio.gz\` + \`.sha256\`
- \`rescue-tui\` + \`.sha256\`
- \`sbom.cdx.json\` (CycloneDX)

## Upgrade notes

- \`iso_probe::DiscoveredIso\` gained \`hash_verification: HashVerification\` — consumers that construct the struct manually must populate it (use \`HashVerification::NotPresent\` if you don't want hash checks).
- \`iso_parser::Distribution\` gained three variants (\`Alpine\`, \`NixOS\`, \`RedHat\`) — \`match\` expressions on \`Distribution\` must add arms or use a wildcard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)