### PR TITLE
feat(#29): detect Windows installer ISOs + NotKexecBootable quirk

### DIFF
--- a/crates/iso-parser/src/detection_tests.rs
+++ b/crates/iso-parser/src/detection_tests.rs
@@ -78,3 +78,19 @@ fn arch_still_detected_from_generic_boot() {
         Distribution::Arch
     );
 }
+
+#[test]
+fn windows_detected_from_bootmgr() {
+    for path in [
+        "/bootmgr.efi",
+        "/sources/boot.wim",
+        "/efi/microsoft/boot/bootmgfw.efi",
+        "/windows/system32/boot/winload.efi",
+    ] {
+        assert_eq!(
+            Distribution::from_paths(&PathBuf::from(path)),
+            Distribution::Windows,
+            "{path} should be Windows"
+        );
+    }
+}

--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -84,6 +84,12 @@ pub enum Distribution {
     Alpine,
     /// NixOS install media (`boot/bzImage`).
     NixOS,
+    /// Windows installer media. Recognized by `bootmgr`, `sources/boot.wim`,
+    /// or `efi/microsoft/boot/`. **Not kexec-bootable**: Windows uses a
+    /// fundamentally different boot protocol (NT loader, not Linux kernel).
+    /// Surfaced so the TUI can give a specific diagnostic rather than fail
+    /// silently.
+    Windows,
     /// Layout not recognized.
     Unknown,
 }
@@ -98,7 +104,13 @@ impl Distribution {
         // their ISO volume labels and filenames, but at this path-only layer
         // we can't disambiguate from Fedora. Keep them separate variants; the
         // caller can upgrade detection once volume-label sniffing is added.
-        if path_str.contains("nixos") || path_str.ends_with("bzimage") {
+        if path_str.contains("bootmgr")
+            || path_str.contains("sources/boot.wim")
+            || path_str.contains("efi/microsoft")
+            || path_str.contains("windows")
+        {
+            Distribution::Windows
+        } else if path_str.contains("nixos") || path_str.ends_with("bzimage") {
             Distribution::NixOS
         } else if path_str.contains("alpine") || path_str.contains("vmlinuz-lts") {
             Distribution::Alpine
@@ -790,7 +802,10 @@ mod tests {
                 // (Alpine + NixOS behave like Arch at the path layer; RedHat
                 // like Fedora). The scan_directory tests only care about the
                 // 3 original categories, so nothing new to stage here.
-                Distribution::RedHat | Distribution::Alpine | Distribution::NixOS => {}
+                Distribution::RedHat
+                | Distribution::Alpine
+                | Distribution::NixOS
+                | Distribution::Windows => {}
                 Distribution::Unknown => {}
             }
 

--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -68,6 +68,10 @@ pub enum Quirk {
     /// Distro signs only its own CA's kernels and refuses kexec into
     /// foreign-CA kernels even with `KEXEC_SIG` satisfied (RHEL family).
     CrossDistroKexecRefused,
+    /// ISO uses a boot protocol incompatible with `kexec_file_load`
+    /// (Windows' NT loader, BSD bootloaders, etc.). The TUI should
+    /// disable kexec for these entries rather than fail silently.
+    NotKexecBootable,
 }
 
 /// Errors returned during probing.
@@ -226,6 +230,11 @@ pub fn lookup_quirks(distribution: Distribution) -> Vec<Quirk> {
         | Distribution::Alpine
         | Distribution::NixOS
         | Distribution::Unknown => vec![Quirk::UnsignedKernel],
+
+        // Windows uses the NT loader / UEFI bootmgfw, not a Linux kernel.
+        // Surface the non-bootability explicitly so the TUI can disable
+        // kexec rather than fail silently after the user picks it.
+        Distribution::Windows => vec![Quirk::NotKexecBootable],
     }
 }
 
@@ -329,6 +338,13 @@ mod tests {
         assert!(
             lookup_quirks(Distribution::NixOS).contains(&Quirk::UnsignedKernel)
         );
+    }
+
+    #[test]
+    fn windows_flags_not_kexec_bootable() {
+        let q = lookup_quirks(Distribution::Windows);
+        assert!(q.contains(&Quirk::NotKexecBootable));
+        assert!(!q.contains(&Quirk::UnsignedKernel));
     }
 
     #[test]

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -270,6 +270,7 @@ impl DistributionLabel for iso_probe::DiscoveredIso {
             iso_probe::Distribution::RedHat => "RHEL/Rocky/Alma",
             iso_probe::Distribution::Alpine => "Alpine",
             iso_probe::Distribution::NixOS => "NixOS",
+            iso_probe::Distribution::Windows => "Windows",
             iso_probe::Distribution::Unknown => "unknown",
         }
     }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -294,6 +294,7 @@ pub fn quirks_summary(iso: &DiscoveredIso) -> String {
             Quirk::BiosOnly => "bios-only",
             Quirk::RequiresWholeDeviceWrite => "needs-dd",
             Quirk::CrossDistroKexecRefused => "cross-distro-refused",
+            Quirk::NotKexecBootable => "not-kexec-bootable",
         })
         .collect();
     format!("[{}]", parts.join(","))


### PR DESCRIPTION
## Summary

Windows installers ship on hybrid ISOs that expect the NT loader (\`bootmgfw.efi\`), **not** a Linux kernel. Before this change, aegis-boot's ISO discovery would either misdetect them as \`Unknown\` (falling into the \`UnsignedKernel\` quirk bucket, which is the wrong diagnostic) or worse silently try to \`kexec\` a bootmgr binary.

## New variants

\`Distribution::Windows\` and \`Quirk::NotKexecBootable\`.

Detection (path-based, specific-first):
- \`bootmgr\` / \`bootmgr.efi\`
- \`sources/boot.wim\`
- \`efi/microsoft/\` paths
- any \`windows\` substring in the kernel path

## Quirk mapping

\`Distribution::Windows → vec![Quirk::NotKexecBootable]\` — explicitly NOT \`UnsignedKernel\`. The Windows kernel isn't the issue; the boot protocol is. Distinguishing the two means the TUI can show a specific diagnostic ("this ISO uses a non-Linux boot protocol") instead of the generic "unsigned kernel — enroll via mokutil" flow that wouldn't help here.

## TUI

- Distribution name row: "Windows".
- Quirks summary: \`[not-kexec-bootable]\`.

Actually disabling the kexec button when \`NotKexecBootable\` is set is a follow-up; for now the user sees the warning tag in the Confirm screen.

## Tests

- iso-parser: 1 new detection test (9 total).
- iso-probe: 1 new quirk-mapping test (28 total).

Clippy \`-D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)