### PR TITLE
feat: enforce NotKexecBootable quirk in TUI

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -163,7 +163,15 @@ fn event_loop<B: ratatui::backend::Backend>(
             (Screen::Confirm { .. }, KeyCode::Char('e')) => state.enter_cmdline_editor(),
             (Screen::Confirm { selected }, KeyCode::Enter) => {
                 let idx = *selected;
-                attempt_kexec(state, idx);
+                if state.is_kexec_blocked(idx) {
+                    tracing::warn!(
+                        idx,
+                        "rescue-tui: refused kexec — ISO carries NotKexecBootable quirk"
+                    );
+                    state.record_kexec_error(&kexec_loader::KexecError::UnsupportedImage);
+                } else {
+                    attempt_kexec(state, idx);
+                }
             }
 
             (Screen::EditCmdline { .. }, KeyCode::Enter) => state.commit_cmdline_edit(),

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -131,18 +131,21 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             signature_span(&iso.signature_verification),
         ]),
         Line::from(""),
-        Line::from("Enter: kexec · e: edit cmdline · Esc: cancel"),
+        Line::from(if state.is_kexec_blocked(selected) {
+            "Enter: BLOCKED (not kexec-bootable) · e: edit cmdline · Esc: cancel"
+        } else {
+            "Enter: kexec · e: edit cmdline · Esc: cancel"
+        }),
     ];
+    let title = if state.is_kexec_blocked(selected) {
+        "Confirm kexec — BLOCKED"
+    } else if override_active {
+        "Confirm kexec (cmdline overridden)"
+    } else {
+        "Confirm kexec"
+    };
     let para = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(if override_active {
-                    "Confirm kexec (cmdline overridden)"
-                } else {
-                    "Confirm kexec"
-                }),
-        )
+        .block(Block::default().borders(Borders::ALL).title(title))
         .wrap(Wrap { trim: false });
     frame.render_widget(para, area);
 }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -73,6 +73,16 @@ impl AppState {
             .unwrap_or_default()
     }
 
+    /// Whether the ISO at `idx` carries a quirk that blocks kexec entirely
+    /// (e.g. Windows installers — wrong boot protocol). The TUI uses this
+    /// to disable the Enter binding on the Confirm screen.
+    #[must_use]
+    pub fn is_kexec_blocked(&self, idx: usize) -> bool {
+        self.isos
+            .get(idx)
+            .is_some_and(|iso| iso.quirks.contains(&Quirk::NotKexecBootable))
+    }
+
     /// Transition confirm → edit-cmdline, seeding the buffer with whatever
     /// is currently effective for the selected ISO.
     pub fn enter_cmdline_editor(&mut self) {
@@ -395,6 +405,26 @@ mod tests {
         let mut s = AppState::new(vec![fake_iso("a")]);
         s.quit();
         assert_eq!(s.screen, Screen::Quitting);
+    }
+
+    #[test]
+    fn is_kexec_blocked_false_for_clean_iso() {
+        let s = AppState::new(vec![fake_iso("clean")]);
+        assert!(!s.is_kexec_blocked(0));
+    }
+
+    #[test]
+    fn is_kexec_blocked_true_when_quirk_present() {
+        let mut iso = fake_iso("windows");
+        iso.quirks = vec![Quirk::NotKexecBootable];
+        let s = AppState::new(vec![iso]);
+        assert!(s.is_kexec_blocked(0));
+    }
+
+    #[test]
+    fn is_kexec_blocked_false_for_unknown_index() {
+        let s = AppState::new(vec![fake_iso("a")]);
+        assert!(!s.is_kexec_blocked(99));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #32 added the \`NotKexecBootable\` quirk for Windows installer ISOs. This PR actually **uses** it.

Before: Windows ISO shows the \`not-kexec-bootable\` badge in the list, but pressing Enter still fires \`kexec_file_load\`, which fails with a generic \`UnsupportedImage\` error.

After: pressing Enter on a blocked ISO records an \`UnsupportedImage\` Error screen + WARN tracing event without ever attempting the syscall. Confirm screen title becomes \`Confirm kexec — BLOCKED\` and the help text changes to \`Enter: BLOCKED (not kexec-bootable)\`.

## Why split

Confirm screen still shows full ISO metadata so the user can verify they picked the right entry before being told they can't kexec it. \`Esc\` still navigates back to the list.

## API

\`\`\`rust
impl AppState {
    pub fn is_kexec_blocked(&self, idx: usize) -> bool;
}
\`\`\`

Returns true iff the ISO carries \`Quirk::NotKexecBootable\`.

## Tests

3 new (84 workspace total): clean ISO not blocked, quirk present blocks, out-of-range index returns false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)