### PR TITLE
release: v0.4.0 — real Secure Boot + NotKexecBootable enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.0] — 2026-04-14
+
+The "real Secure Boot" release. Closes the deferred OVMF SecBoot work from v0.2.0/v0.3.0 and lands the matching UX enforcement.
+
+### Headline
+
+**OVMF SecBoot end-to-end CI** (#16, PR #34 + #35). Every PR now boots a real signed shim → signed grub → Canonical-signed kernel chain under enforcing-mode Secure Boot, with our `initramfs.cpio.gz` concatenated onto the distro initrd. Pass criteria asserted from serial output:
+
+1. Linux kernel logs `Secure boot enabled` — proves SB is actually enforcing through the chain.
+2. `aegis-boot rescue-tui starting` banner appears — proves our binary survives the signed boot path and runs to completion.
+
+CI matrix: 11 → **13 checks per PR**.
+
+### Other landed
+
+- **Phase 1 OVMF SecBoot foundation** (#34) — fast smoke that loads `OVMF_CODE_4M.secboot.fd` + MS-enrolled vars and asserts firmware initializes without crashing. Stays as a quick gate alongside the deeper E2E.
+- **`NotKexecBootable` quirk enforcement** (#36) — Windows installer ISOs and other non-Linux-kernel media are now blocked from kexec at the TUI layer with a specific diagnostic, not a generic kexec failure. Confirm screen title becomes "BLOCKED"; Enter records `UnsupportedImage` without firing the syscall.
+
+### Deferred to v0.5.0
+
+- **TPM PCR extension** — measure ISO + cmdline into PCR 12/13 before kexec. Needs `swtpm` in CI to test; design forthcoming.
+- **MOK enrollment guidance** — currently surfaced as TUI text; future work could automate `mokutil --import` for the user.
+- **kexec end-to-end with a signed fixture ISO** — proves the rescue-tui-to-target-ISO handoff under SB. Distinct from this release's "rescue-tui runs under SB" proof.
+
+### Test tally
+
+- **v0.3.0:** 82 tests
+- **v0.4.0:** 84 tests (+2 — most v0.4.0 work was CI-side; the new tests cover the `is_kexec_blocked` enforcement)
+
+### CI tally
+
+13 checks per PR, all green on `main`. New: `OVMF SecBoot foundation`, `OVMF SecBoot E2E (signed chain → rescue-tui)`.
+
+### Upgrade notes
+
+- `AppState::is_kexec_blocked(idx)` is new public API for downstream TUI consumers (none in tree yet, but documented for future workflow templates).
+
 ## [0.3.0] — 2026-04-14
 
 Tracks progress of the [v0.3.0 epic (#29)](https://github.com/williamzujkowski/aegis-boot/issues/29). Raises the security floor (real cryptographic authentication) and the UX floor (last-choice persistence, explicit Windows-not-bootable diagnostic).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -374,7 +374,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kexec-loader"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -598,7 +598,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossterm",
  "iso-probe",

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Cuts **v0.4.0** — the "real Secure Boot" release.

## Headline

**OVMF SecBoot end-to-end CI (#16)** — deferred for two releases, finally landed:

- PR #34 — Phase 1 foundation: OVMF + MS-enrolled vars load cleanly
- PR #35 — Phase 2 E2E: signed shim → grub → kernel chain under enforcing SB; both \`Secure boot enabled\` and \`rescue-tui starting\` asserted from serial output

The QEMU CI now boots a real signed chain on every PR.

## Other landed

- PR #36 — \`NotKexecBootable\` quirk actually blocks the Enter key on Confirm screen with a specific diagnostic (was decorative since v0.3.0)

## Stats

- **Tests:** 82 (v0.3.0) → **84** (v0.4.0)
- **CI:** 11 → **13** checks per PR — adds \`OVMF SecBoot foundation\` + \`OVMF SecBoot E2E\`
- **Reproducibility:** \`rescue-tui\` + \`initramfs.cpio.gz\` byte-identical (unchanged from v0.3.0)

## Deferred to v0.5.0

- TPM PCR extension (needs \`swtpm\` in CI)
- MOK enrollment automation
- kexec E2E with a signed fixture ISO

## Release assets (after tag)

\`v0.4.0\` will carry: \`initramfs.cpio.gz\` + \`.sha256\`, \`rescue-tui\` + \`.sha256\`, \`sbom.cdx.json\`.

## Upgrade notes

\`AppState::is_kexec_blocked(idx)\` is new public API. No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)