### PR TITLE
feat(#40): mkusb image builder + USB layout + init label-aware auto-mount

### DIFF
--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -84,7 +84,9 @@ jobs:
           echo "--- mkusb QEMU serial output (last 60 lines) ---"
           tail -60 /tmp/mkusb-boot.log
           echo "--- end ---"
-          if grep -qiE 'secure boot enabled|secureboot.*enabled' /tmp/mkusb-boot.log \
+          # Kernel + EFI stub log "Secure Boot is enabled" (note 'is');
+          # accept that phrasing plus the tighter variants.
+          if grep -qiE 'secure boot (is )?enabled|secureboot.*enabled' /tmp/mkusb-boot.log \
              && grep -q 'aegis-boot rescue-tui starting' /tmp/mkusb-boot.log; then
             echo "mkusb image boots cleanly under SB + rescue-tui runs: PASS"
           else

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -34,7 +34,10 @@ jobs:
             mtools dosfstools gdisk \
             busybox-static cpio
           # Kernels mode 0600; we need them readable for mcopy.
-          sudo chmod 0644 /boot/vmlinuz-*-virtual /boot/initrd.img-*-virtual
+          # linux-image-virtual is a meta-package that pulls -generic on
+          # modern Ubuntu; chmod all vmlinuz+initrd files conservatively.
+          sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
+          ls -l /boot/vmlinuz-* /boot/initrd.img-*
 
       - name: Install Rust toolchain (pinned)
         run: |

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -1,0 +1,99 @@
+name: mkusb Image Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Build the mkusb image in CI and smoke-boot it under OVMF SecBoot. Proves:
+#   1. scripts/mkusb.sh runs cleanly with no root access required for the
+#      image construction itself (kernel read is the only sudo step).
+#   2. The output image boots under OVMF SecBoot enforcing.
+#   3. rescue-tui survives the whole chain and runs from the AEGIS_ISOS
+#      partition layout.
+
+jobs:
+  mkusb-build:
+    name: mkusb — build + boot smoke
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install signed boot chain + image tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools gdisk \
+            busybox-static cpio
+          # Kernels mode 0600; we need them readable for mcopy.
+          sudo chmod 0644 /boot/vmlinuz-*-virtual /boot/initrd.img-*-virtual
+
+      - name: Install Rust toolchain (pinned)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Build rescue-tui
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+        run: cargo build --release -p rescue-tui
+
+      - name: Build initramfs
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+        run: ./scripts/build-initramfs.sh
+
+      - name: Run mkusb
+        run: |
+          DISK_SIZE_MB=1024 ./scripts/mkusb.sh
+          ls -lh out/aegis-boot.img out/aegis-boot.img.sha256
+          # Verify partition table came out as expected.
+          sgdisk -p out/aegis-boot.img
+
+      - name: Boot the image under OVMF SecBoot
+        env:
+          TIMEOUT_SECONDS: "90"
+        run: |
+          # Reuse the OVMF SB boot setup but point the disk at our mkusb
+          # output. Expect kernel+rescue-tui banner in serial.
+          cp /usr/share/OVMF/OVMF_VARS_4M.ms.fd /tmp/vars.fd
+          chmod 0644 /tmp/vars.fd
+          timeout "$TIMEOUT_SECONDS" qemu-system-x86_64 \
+            -nographic \
+            -no-reboot \
+            -machine q35,smm=on \
+            -global driver=cfi.pflash01,property=secure,value=on \
+            -m 1024M \
+            -drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd,readonly=on \
+            -drive if=pflash,format=raw,unit=1,file=/tmp/vars.fd \
+            -drive if=ide,format=raw,file=out/aegis-boot.img \
+            -boot order=c \
+            -serial mon:stdio </dev/null > /tmp/mkusb-boot.log 2>&1 || true
+          echo "--- mkusb QEMU serial output (last 60 lines) ---"
+          tail -60 /tmp/mkusb-boot.log
+          echo "--- end ---"
+          if grep -qiE 'secure boot enabled|secureboot.*enabled' /tmp/mkusb-boot.log \
+             && grep -q 'aegis-boot rescue-tui starting' /tmp/mkusb-boot.log; then
+            echo "mkusb image boots cleanly under SB + rescue-tui runs: PASS"
+          else
+            echo "mkusb boot smoke FAILED"
+            exit 1
+          fi
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aegis-boot-img
+          path: |
+            out/aegis-boot.img
+            out/aegis-boot.img.sha256
+          retention-days: 14

--- a/docs/USB_LAYOUT.md
+++ b/docs/USB_LAYOUT.md
@@ -1,0 +1,127 @@
+# USB image layout
+
+This document describes the on-disk layout of an aegis-boot USB stick built by [`scripts/mkusb.sh`](../scripts/mkusb.sh), and explains how users drop ISO files onto the data partition.
+
+## At a glance
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  GPT partition table                                    │
+├─────────────────────────────────────────────────────────┤
+│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~400 MB)         │
+│    /EFI/BOOT/BOOTX64.EFI   ← MS-signed shim             │
+│    /EFI/BOOT/grubx64.efi   ← Canonical-signed grub      │
+│    /EFI/BOOT/grub.cfg                                   │
+│    /EFI/ubuntu/grub.cfg    (same; signed grub looks here) │
+│    /vmlinuz                ← Canonical-signed kernel    │
+│    /initrd.img             ← distro initrd + aegis initramfs │
+├─────────────────────────────────────────────────────────┤
+│  Part 2 — Data (FAT32, label AEGIS_ISOS, remainder)     │
+│    ubuntu-24.04.1-desktop-amd64.iso                     │
+│    fedora-workstation-41-x86_64.iso                     │
+│    debian-live-12.7.0-amd64-standard.iso                │
+│    (user drops .iso files here)                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Why two partitions
+
+- **ESP** holds the signed boot chain. Its contents don't change between boots — read-only in normal operation. FAT32 is required by the UEFI spec; partition type GUID is `C12A7328-F81F-11D2-BA4B-00A0C93EC93B` (sgdisk type `ef00`).
+- **AEGIS_ISOS** holds the user's own content. The user mounts this partition on their host, drops `.iso` files into it, unmounts, and boots. The rescue environment scans it and populates the TUI list.
+
+Splitting them means:
+- The user can **replace the ISO set** without reflashing the boot chain.
+- The signed boot chain is **immutable in practice** — reduces the surface for accidental corruption.
+- The data partition can be **reformatted** if needed without touching the ESP.
+
+## File size limit on FAT32
+
+FAT32 caps individual files at **4 GB minus 1 byte**. Typical distro ISOs:
+
+| ISO | Size | Fits on FAT32? |
+|---|---|---|
+| Ubuntu LTS desktop | ~5.8 GB | ❌ exceeds |
+| Fedora Workstation | ~2.3 GB | ✅ |
+| Debian netinst / live standard | ~1 GB | ✅ |
+| Arch | ~1.2 GB | ✅ |
+| Alpine standard | ~200 MB | ✅ |
+| NixOS minimal | ~900 MB | ✅ |
+
+If you need to ship the full Ubuntu LTS desktop image: rebuild with `mkusb.sh` using `DATA_FS=ext4`. Trade-off: ext4 isn't natively writable from macOS or Windows, so the "drop files on the host" workflow requires Linux or FUSE drivers.
+
+(The `DATA_FS` override is not yet implemented — issue #40 tracks.)
+
+## Building
+
+```bash
+# Needs: shim-signed, grub-efi-amd64-signed, linux-image-virtual or -generic,
+# mtools, dosfstools, gdisk. All in the standard Ubuntu/Debian repos.
+sudo apt-get install -y \
+    shim-signed grub-efi-amd64-signed linux-image-virtual \
+    mtools dosfstools gdisk
+
+# Kernel reads require root (kernels are mode 0600 by default on modern Ubuntu).
+sudo chmod 0644 /boot/vmlinuz-*-virtual /boot/initrd.img-*-virtual
+
+./scripts/build-initramfs.sh   # produces out/initramfs.cpio.gz
+./scripts/mkusb.sh             # produces out/aegis-boot.img
+```
+
+Default output: 2 GB image. Override with `DISK_SIZE_MB=8192 ./scripts/mkusb.sh` for more ISO capacity.
+
+## Adding ISOs (loop mount)
+
+```bash
+sudo losetup -fP out/aegis-boot.img
+# losetup assigns /dev/loopN; find which one:
+LOOP=$(sudo losetup -j out/aegis-boot.img | cut -d: -f1)
+mkdir -p /mnt/aegis-isos
+sudo mount "${LOOP}p2" /mnt/aegis-isos    # partition 2 is AEGIS_ISOS
+sudo cp ~/Downloads/ubuntu-24.04.iso /mnt/aegis-isos/
+sudo umount /mnt/aegis-isos
+sudo losetup -d "$LOOP"
+```
+
+## Testing under QEMU
+
+Verify your image boots before committing to `dd`-ing to a real stick:
+
+```bash
+./scripts/qemu-try.sh
+# Boots with OVMF SecBoot enforcing — Ctrl-A X to exit.
+```
+
+## Deploying to a real USB stick
+
+```bash
+# WARNING: this destroys all data on /dev/sdX. Verify the device!
+lsblk                                               # find your stick
+sudo dd if=out/aegis-boot.img of=/dev/sdX \
+       bs=4M oflag=direct status=progress conv=fsync
+sync
+```
+
+After `dd` completes, the data partition is still writable. Remount it on your host and drop ISOs onto it at any time:
+
+```bash
+sudo mount /dev/sdX2 /mnt/aegis-isos
+sudo cp *.iso /mnt/aegis-isos/
+sudo umount /mnt/aegis-isos
+```
+
+## Chain of trust recap
+
+See [THREAT_MODEL.md](../THREAT_MODEL.md) for the full model. In short:
+
+- UEFI firmware validates `/EFI/BOOT/BOOTX64.EFI` (shim) against `db`/`dbx`.
+- shim validates `grubx64.efi` via its built-in vendor cert.
+- grub validates `/vmlinuz` via shim's keyring.
+- Kernel unpacks the combined initrd (distro + ours) and runs our `/init`.
+- `rescue-tui` loads, user picks an ISO, `kexec_file_load` validates the target kernel against the platform keyring (enforced by `KEXEC_SIG` when SB is on).
+- Unsigned ISO kernels surface `SignatureRejected` — the TUI tells the user to enroll the key via `mokutil`, never to disable SB.
+
+## Limitations
+
+- **Single-file 4 GB FAT32 cap** on the default data partition (see above).
+- **User responsibility**: ISOs placed on the data partition are trusted by default. The TUI displays hash-verification and signature-verification status but doesn't block boot on a missing sidecar — that's deployment policy, not a mkusb concern.
+- **x86_64 only** — aarch64 / riscv64 variants are a separate epic.

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -86,7 +86,8 @@ install -m 0755 "$BUSYBOX_PATH" "$STAGE_DIR/bin/busybox"
 # rescue-tui doesn't call these directly — they exist for the init script
 # below and for emergency shell fallback.
 for applet in sh mount umount mkdir ls cat dmesg switch_root losetup \
-              mdev blkid lsblk modprobe sleep echo; do
+              mdev blkid lsblk modprobe sleep echo ln readlink rmdir \
+              findfs; do
     ln -sf /bin/busybox "$STAGE_DIR/bin/$applet"
 done
 
@@ -133,17 +134,30 @@ set -e
 # Give the kernel a moment to enumerate USB/NVMe devices before we look.
 /bin/sleep 1
 
-# Auto-mount every block device that looks like it has a filesystem. The TUI
-# will walk /run/media/* looking for .iso files.
+# Prefer the stick's dedicated AEGIS_ISOS data partition if present.
+# findfs resolves LABEL=... to a block device path; mount at a stable
+# location so operators can reason about the layout.
+/bin/mkdir -p /run/media/aegis-isos
+if AEGIS_DEV=$(/bin/findfs LABEL=AEGIS_ISOS 2>/dev/null) && [ -n "$AEGIS_DEV" ]; then
+    if /bin/mount -o ro "$AEGIS_DEV" /run/media/aegis-isos 2>/dev/null; then
+        /bin/echo "init: mounted $AEGIS_DEV (LABEL=AEGIS_ISOS) -> /run/media/aegis-isos"
+    fi
+fi
+
+# Also auto-mount any other block device that looks like it has a
+# filesystem. Covers the case where the user attaches an ISO on a
+# secondary stick or USB drive alongside the boot media.
 for dev in /dev/sd* /dev/nvme*n*p* /dev/vd* /dev/mmcblk*p*; do
     [ -b "$dev" ] || continue
+    # Skip the AEGIS_ISOS partition we already mounted.
+    [ "$dev" = "${AEGIS_DEV:-}" ] && continue
     name=$(/usr/bin/basename "$dev" 2>/dev/null || echo "$dev" | /bin/sed 's|.*/||')
     mp="/run/media/$name"
     /bin/mkdir -p "$mp"
     /bin/mount -o ro "$dev" "$mp" 2>/dev/null || /bin/rmdir "$mp"
 done
 
-export AEGIS_ISO_ROOTS=/run/media
+export AEGIS_ISO_ROOTS=/run/media/aegis-isos:/run/media
 export PATH=/usr/bin:/usr/sbin:/bin:/sbin
 export TERM=linux
 

--- a/scripts/mkusb.sh
+++ b/scripts/mkusb.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Build a bootable aegis-boot USB image.
+#
+# Output: a raw disk image the user can either:
+#   - `dd if=aegis-boot.img of=/dev/sdX bs=4M oflag=direct` onto a real stick
+#   - Boot directly under QEMU with scripts/qemu-try.sh
+#
+# Layout:
+#   GPT disk
+#     Part 1 (ESP, FAT32, ~300 MB)
+#       /EFI/BOOT/BOOTX64.EFI       Microsoft-signed shim
+#       /EFI/BOOT/grubx64.efi       Canonical-signed grub
+#       /EFI/BOOT/grub.cfg          minimal menu, chainloads our kernel
+#       /EFI/ubuntu/grub.cfg        same (Canonical grub looks here)
+#       /vmlinuz                    Canonical-signed kernel
+#       /initrd.img                 our aegis-boot initramfs (concat with
+#                                   distro initrd for driver coverage)
+#     Part 2 (AEGIS_ISOS, FAT32 or ext4, remainder of disk)
+#       User drops .iso files here; rescue-tui discovers them.
+#
+# Requires: the same signed packages we use for OVMF SecBoot E2E CI:
+#   shim-signed, grub-efi-amd64-signed, linux-image-generic or -virtual,
+#   mtools, dosfstools, gdisk, cpio, gzip.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/out}"
+IMG="${IMG:-$OUT_DIR/aegis-boot.img}"
+
+# Sizing. ESP is generous enough to hold shim+grub+kernel+initrd with room
+# to spare. Data partition takes the rest of the disk.
+DISK_SIZE_MB="${DISK_SIZE_MB:-2048}"     # default 2 GB test image
+ESP_SIZE_MB="${ESP_SIZE_MB:-400}"
+DATA_LABEL="${DATA_LABEL:-AEGIS_ISOS}"
+
+# Input binary locations (overridable for cross-builds / packaging).
+SHIM_SRC="${SHIM_SRC:-/usr/lib/shim/shimx64.efi.signed}"
+GRUB_SRC="${GRUB_SRC:-/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed}"
+KERNEL_SRC="${KERNEL_SRC:-}"   # auto-detected below if not set
+INITRD_SRC="${INITRD_SRC:-}"
+
+log() { printf '[mkusb] %s\n' "$*" >&2; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "missing required tool: $1" >&2
+        exit 1
+    }
+}
+
+require mkfs.vfat
+require mcopy
+require mmd
+require sgdisk
+require dd
+require stat
+
+# Locate a readable signed kernel + initrd.
+if [[ -z "$KERNEL_SRC" ]]; then
+    for k in /boot/vmlinuz-*-virtual /boot/vmlinuz-*-generic; do
+        [[ -e "$k" && -r "$k" ]] || continue
+        KERNEL_SRC="$k"
+        ver=$(basename "$k" | sed 's/^vmlinuz-//')
+        candidate="/boot/initrd.img-${ver}"
+        [[ -r "$candidate" ]] && INITRD_SRC="$candidate"
+        break
+    done
+fi
+[[ -n "$KERNEL_SRC" && -r "$KERNEL_SRC" ]] || {
+    echo "no readable signed kernel found; set KERNEL_SRC=/path/to/vmlinuz" >&2
+    echo "(kernels under /boot are often mode 0600 and need sudo to read)" >&2
+    exit 1
+}
+[[ -n "$INITRD_SRC" && -r "$INITRD_SRC" ]] || {
+    echo "no readable distro initrd matching $KERNEL_SRC" >&2
+    exit 1
+}
+
+for f in "$SHIM_SRC" "$GRUB_SRC"; do
+    [[ -r "$f" ]] || {
+        echo "missing signed bootloader: $f" >&2
+        echo "install: sudo apt-get install shim-signed grub-efi-amd64-signed" >&2
+        exit 1
+    }
+done
+
+# Build our initramfs if it doesn't already exist.
+if [[ ! -f "$OUT_DIR/initramfs.cpio.gz" ]]; then
+    log "building aegis-boot initramfs"
+    "$ROOT_DIR/scripts/build-initramfs.sh"
+fi
+AEGIS_INITRD="$OUT_DIR/initramfs.cpio.gz"
+
+# Combined initrd: distro initrd + our initramfs. The kernel unpacks both
+# cpio segments; our /init loads last and wins. This gives us full distro
+# driver coverage + our rescue userland.
+WORK="$(mktemp -d --tmpdir aegis-mkusb-XXXXXX)"
+trap 'rm -rf -- "$WORK"' EXIT
+
+log "concatenating distro initrd + aegis-boot initramfs"
+cat "$INITRD_SRC" "$AEGIS_INITRD" > "$WORK/combined-initrd.img"
+log "  distro : $(stat -c '%s' "$INITRD_SRC") bytes"
+log "  aegis  : $(stat -c '%s' "$AEGIS_INITRD") bytes"
+log "  combined: $(stat -c '%s' "$WORK/combined-initrd.img") bytes"
+
+# grub.cfg — serial console redirect for operator visibility on
+# real hardware with a serial port, plus sane defaults for normal boots.
+cat > "$WORK/grub.cfg" <<'EOF'
+serial --unit=0 --speed=115200
+terminal_input serial console
+terminal_output serial console
+set timeout=1
+menuentry "aegis-boot rescue" {
+    linux /vmlinuz console=ttyS0,115200 panic=5 loglevel=4
+    initrd /initrd.img
+}
+EOF
+
+# ---- Build ESP partition image ---------------------------------------------
+ESP_IMG="$WORK/esp.part"
+dd if=/dev/zero of="$ESP_IMG" bs=1M count="$ESP_SIZE_MB" status=none
+mkfs.vfat -F 32 -n AEGIS_ESP "$ESP_IMG" >/dev/null
+
+mmd -i "$ESP_IMG" ::/EFI ::/EFI/BOOT ::/EFI/ubuntu
+mcopy -i "$ESP_IMG" "$SHIM_SRC"   ::/EFI/BOOT/BOOTX64.EFI
+mcopy -i "$ESP_IMG" "$GRUB_SRC"   ::/EFI/BOOT/grubx64.efi
+mcopy -i "$ESP_IMG" "$WORK/grub.cfg" ::/EFI/ubuntu/grub.cfg
+mcopy -i "$ESP_IMG" "$WORK/grub.cfg" ::/EFI/BOOT/grub.cfg
+mcopy -i "$ESP_IMG" "$KERNEL_SRC" ::/vmlinuz
+mcopy -i "$ESP_IMG" "$WORK/combined-initrd.img" ::/initrd.img
+
+# ---- Build data partition image (empty FAT32 for user ISOs) ----------------
+DATA_SIZE_MB=$((DISK_SIZE_MB - ESP_SIZE_MB - 4))  # -4 MB for GPT + alignment
+if (( DATA_SIZE_MB < 32 )); then
+    echo "DISK_SIZE_MB ($DISK_SIZE_MB) too small; need at least ESP + 32 MB" >&2
+    exit 1
+fi
+DATA_IMG="$WORK/data.part"
+dd if=/dev/zero of="$DATA_IMG" bs=1M count="$DATA_SIZE_MB" status=none
+# FAT32 chosen for cross-OS write-friendliness — users on macOS/Windows
+# will want to drop ISOs onto it without installing drivers. Max single
+# file size 4 GB minus 1 byte is acceptable: DVD-sized ISOs (4.7 GB)
+# need to be split or we ship ext4 as an alternative. Keep FAT32 default;
+# document the limit in USB_LAYOUT.md.
+mkfs.vfat -F 32 -n "$DATA_LABEL" "$DATA_IMG" >/dev/null
+
+# ---- Assemble the GPT disk -------------------------------------------------
+log "assembling GPT disk: $IMG (${DISK_SIZE_MB} MB)"
+mkdir -p "$OUT_DIR"
+dd if=/dev/zero of="$IMG" bs=1M count="$DISK_SIZE_MB" status=none
+
+sgdisk -o "$IMG" >/dev/null
+sgdisk \
+    -n 1:2048:+${ESP_SIZE_MB}M -t 1:ef00 -c 1:"EFI System" \
+    -n 2:0:0                   -t 2:8300 -c 2:"$DATA_LABEL" \
+    "$IMG" >/dev/null
+
+# Splice partitions into the disk image. sgdisk reports offsets; derive
+# them from the partition table we just wrote.
+ESP_START=$(sgdisk -i 1 "$IMG" | awk '/First sector:/ {print $3}')
+DATA_START=$(sgdisk -i 2 "$IMG" | awk '/First sector:/ {print $3}')
+log "  ESP  @ sector $ESP_START"
+log "  data @ sector $DATA_START"
+
+dd if="$ESP_IMG"  of="$IMG" bs=512 seek="$ESP_START"  conv=notrunc status=none
+dd if="$DATA_IMG" of="$IMG" bs=512 seek="$DATA_START" conv=notrunc status=none
+
+sha256sum "$IMG" > "$IMG.sha256"
+
+size=$(stat -c '%s' "$IMG")
+hash=$(awk '{print $1}' "$IMG.sha256")
+log "wrote $IMG ($size bytes)"
+log "sha256: $hash"
+log ""
+log "next steps:"
+log "  1. Drop .iso files onto the AEGIS_ISOS partition:"
+log "       sudo losetup -fP $IMG"
+log "       # find the loop device, then mount the 2nd partition"
+log "       sudo mount /dev/loopXp2 /mnt/aegis-isos"
+log "       sudo cp ubuntu.iso /mnt/aegis-isos/"
+log "       sudo umount /mnt/aegis-isos && sudo losetup -d /dev/loopX"
+log "  2. Boot under QEMU to test: scripts/qemu-try.sh (TODO)"
+log "  3. dd onto a real USB stick:"
+log "       sudo dd if=$IMG of=/dev/sdX bs=4M oflag=direct status=progress"

--- a/scripts/qemu-try.sh
+++ b/scripts/qemu-try.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Boot a mkusb-produced image under QEMU+OVMF SecBoot for developer testing.
+#
+# Usage:
+#   scripts/mkusb.sh               # builds out/aegis-boot.img
+#   scripts/qemu-try.sh            # boots it under QEMU with OVMF SecBoot
+#
+# Optional: drop ISOs into the AEGIS_ISOS data partition before booting so
+# the TUI has something to list. See docs/USB_LAYOUT.md.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/out}"
+IMG="${IMG:-$OUT_DIR/aegis-boot.img}"
+
+OVMF_CODE="${OVMF_CODE:-/usr/share/OVMF/OVMF_CODE_4M.secboot.fd}"
+OVMF_VARS_SRC="${OVMF_VARS_SRC:-/usr/share/OVMF/OVMF_VARS_4M.ms.fd}"
+
+log() { printf '[qemu-try] %s\n' "$*" >&2; }
+
+[[ -f "$IMG" ]] || {
+    echo "image not found: $IMG" >&2
+    echo "build first: scripts/mkusb.sh" >&2
+    exit 1
+}
+
+WORK="$(mktemp -d --tmpdir aegis-qemu-try-XXXXXX)"
+trap 'rm -rf -- "$WORK"' EXIT
+cp "$OVMF_VARS_SRC" "$WORK/vars.fd"
+chmod 0644 "$WORK/vars.fd"
+
+log "booting $IMG under OVMF SecBoot"
+log "  (Ctrl-A X to exit QEMU; timeouts NOT applied — interactive session)"
+
+exec qemu-system-x86_64 \
+    -nographic \
+    -machine q35,smm=on \
+    -global driver=cfi.pflash01,property=secure,value=on \
+    -m 2048M \
+    -drive "if=pflash,format=raw,unit=0,file=$OVMF_CODE,readonly=on" \
+    -drive "if=pflash,format=raw,unit=1,file=$WORK/vars.fd" \
+    -drive "if=ide,format=raw,file=$IMG" \
+    -boot order=c \
+    -serial mon:stdio \
+    "$@"


### PR DESCRIPTION
## Summary

Closes the headline must-have of [v0.5.0 epic #40](https://github.com/williamzujkowski/aegis-boot/issues/40). Turns the aegis-boot engine into **a thing a user can write to a USB stick and boot**.

Matches the maintainer's stated ultimate goal: drop ISOs onto a labelled partition, boot the stick, TUI lists them, select one, kexec under enforcing Secure Boot.

## What's in the PR

### \`scripts/mkusb.sh\`
Builds a GPT-partitioned disk image:
- Part 1: **ESP** (FAT32, ~400 MB) — shim-signed + grub-signed + kernel + combined initrd (distro initrd concatenated with our initramfs for full driver coverage + rescue userland)
- Part 2: **AEGIS_ISOS** data partition (FAT32, remainder) — user drops \`.iso\` files here

Default 2 GB; configurable via \`DISK_SIZE_MB\`. Emits \`out/aegis-boot.img\` + sha256. No root required for image construction itself; kernel reads need \`sudo chmod 0644 /boot/vmlinuz-*\`.

### \`scripts/qemu-try.sh\`
Developer iteration helper — boots \`out/aegis-boot.img\` under OVMF SecBoot enforcing so devs can test without flashing a real stick.

### \`docs/USB_LAYOUT.md\`
ASCII diagram of partition layout, FAT32 4 GB-per-file cap called out, build/test/deploy recipe, chain-of-trust recap mapping to THREAT_MODEL.md.

### \`/init\` upgrade
- Prefers \`LABEL=AEGIS_ISOS\` for stable mount at \`/run/media/aegis-isos\` — operators see the same mount name regardless of which USB port / bus the stick landed on.
- Still auto-mounts other block devices at \`/run/media/<name>\` for multi-stick scenarios.
- \`AEGIS_ISO_ROOTS\` extended to both paths.

### New CI job \`mkusb.yml\` (15th check)
Runs mkusb + boots the output under OVMF SecBoot + asserts \`Secure Boot enabled\` + rescue-tui banner. Uploads the built image as a workflow artifact (14-day retention).

## Test plan

- [x] Local: kernel readable via sudo → mkusb runs clean → QEMU boots with OVMF SB → rescue-tui starts.
- [ ] CI: mkusb job green end-to-end.
- [ ] CI: all 14 other checks still green.

## Known follow-ups (tracked in #40)

- \`DATA_FS=ext4\` option for users who need to ship the Ubuntu LTS desktop ISO (5.8 GB, exceeds FAT32 4 GB limit).
- kexec E2E harness rework (separate v0.5.0 item).
- TPM PCR extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)