### PR TITLE
release: v0.5.0 — the user-shippable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] — 2026-04-14
+
+**The user-shippable release.** Turns aegis-boot from an engine (rescue-tui + crates + reproducible initramfs) into an artifact a user can write to a USB stick and boot. Closes the deployment-story gap that v0.1-v0.4 deliberately left open.
+
+### Headline
+
+**`scripts/mkusb.sh` image builder** (#41). Produces a byte-reproducible bootable disk image:
+- GPT partition table
+- **ESP** (FAT32, 400 MB): MS-signed shim → Canonical-signed grub → signed kernel + combined initrd (distro initrd + our rescue initramfs)
+- **AEGIS_ISOS data partition** (FAT32 by default, remainder of disk): user drops `.iso` files here
+
+`dd if=out/aegis-boot.img of=/dev/sdX` onto a real stick and boot. Local validation via `scripts/qemu-try.sh` (interactive OVMF SecBoot boot) or `scripts/dev-test.sh` (full 7-stage CI-equivalent run).
+
+### Also landed
+
+- **`DATA_FS=ext4` override** (#44) — removes FAT32's 4 GB single-file cap for shipping Ubuntu LTS desktop ISOs and similar.
+- **Label-aware init auto-mount** (#41) — `/init` mounts `LABEL=AEGIS_ISOS` at `/run/media/aegis-isos` before scanning; operators see a stable mount name regardless of which USB port the stick landed on.
+- **MOK enrollment helper** (#42) — when `kexec` returns `SignatureRejected`, the TUI Error screen now embeds the exact `sudo mokutil --import <key>` command with the actual key file path (discovered via `<iso>.pub` / `.key` / `.der` sibling convention). Removes the "which key file do I enroll?" guessing game.
+- **`AEGIS_AUTO_KEXEC` mode** (#38, landed in v0.4) — non-interactive automation mode for CI tests.
+- **Real `kexec_file_load` E2E** (#43) — iso-parser's `mount_iso` gained a losetup fallback for loop-device allocation on kernels with lazy `/dev/loop-control` semantics. Kexec handoff proved end-to-end in local QEMU: rescue-tui discovers ISO → `iso_probe::prepare` loop-mounts via util-linux losetup → `kexec_file_load` fires. Handled kernel compression quirks (decompress `.ko.zst` at initramfs-build time so busybox modprobe can load the modules).
+- **Kernel modules shipped into initramfs** (#43) — `isofs`, `udf`, `loop` (decompressed from `.ko.zst` if the kernel compresses). Without this, `mount -t iso9660` silently fails on distros that compile these as modules.
+- **util-linux losetup shipped into initramfs** — busybox's losetup applet doesn't accept `--show` and doesn't handle modern loop-control semantics consistently; we now carry the real one + its library closure.
+- **`scripts/dev-test.sh` + `docs/LOCAL_TESTING.md`** — full CI-equivalent run locally in ~8 minutes for the billing-paused interim. Remains useful as a pre-push sanity check once CI is back.
+
+### Deferred to v0.6.0
+
+- **TPM PCR extension** — measure ISO hash + cmdline into PCR 12 before kexec. Needs `swtpm` in CI and a concrete trust-chain doc before shipping.
+- **ratatui theming** — `--theme=<name>` flag. Nice-to-have.
+- **ISO metadata preview pane** — volume label, release-notes snippet. Nice-to-have.
+- **`aegis-boot fitness-audit` CLI** — self-check subcommand.
+- **Full target-kernel boot (not partial-pass)** — requires QEMU configuration that preserves serial across `reboot(LINUX_REBOOT_CMD_KEXEC)`; our current CI configuration doesn't. Local kexec fires correctly but serial is lost. Partial-pass accepts matched+mounted+kexec-invoked as proof.
+
+### Test tally
+
+- **v0.4.0:** 84 tests
+- **v0.5.0:** 87 tests (+3)
+
+### CI tally
+
+The full matrix reached 16 jobs across four workflows (`ci.yml`, `mkusb.yml`, `ovmf-secboot.yml`, `kexec-e2e.yml`) before GHA billing suspended runs. All jobs passed locally via `dev-test.sh`. Once billing resolves the CI gate returns.
+
+### Upgrade notes
+
+- `scripts/build-initramfs.sh` now ships kernel modules. Initramfs size went from 3.6 MB (v0.4.0) to ~4.0 MB. Still well under the 20 MB budget.
+- `AEGIS_KMOD_SRC` env var lets operators override the kernel-modules source when the deployment kernel differs from the build host's installed kernel (common in cross-compile / packaging scenarios).
+- `DATA_FS=ext4` is opt-in; default remains FAT32.
+
 ## [0.4.0] — 2026-04-14
 
 The "real Secure Boot" release. Closes the deferred OVMF SecBoot work from v0.2.0/v0.3.0 and lands the matching UX enforcement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -374,7 +374,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kexec-loader"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -598,7 +598,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "crossterm",
  "iso-probe",

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Cuts **v0.5.0** — the headline release of this project. Turns aegis-boot from \"a working engine\" into \"a USB stick you can dd and boot.\"

## Closes

All must-haves of [v0.5.0 epic #40](https://github.com/williamzujkowski/aegis-boot/issues/40):

| PR | Feature |
|---|---|
| #41 | mkusb.sh image builder + USB layout doc + init label-aware mount |
| #42 | MOK enrollment helper (exact \`mokutil --import\` command with key path) |
| #43 | kexec E2E harness — proven in local QEMU end-to-end |
| #44 | \`DATA_FS=ext4\` option for Ubuntu LTS desktop ISOs |

Plus operator infra: \`dev-test.sh\` + \`docs/LOCAL_TESTING.md\` for the billing-paused interim.

## What this enables

```bash
./scripts/mkusb.sh
sudo dd if=out/aegis-boot.img of=/dev/sdX bs=4M oflag=direct status=progress
# Drop ISOs onto the AEGIS_ISOS partition, boot the stick under UEFI SB.
```

## Honest state

**GHA is paused** due to billing. Every change in v0.5.0 is validated locally via \`dev-test.sh\` (7 stages, ~8 min, all green on the Framework host). When billing resolves CI returns as the merge gate.

## Stats

- **Tests:** 84 → 87
- **Initramfs size:** 3.6 MB → ~4.0 MB (kernel modules for iso9660/udf/loop)
- **Reproducibility:** unchanged — both \`rescue-tui\` binary and \`initramfs.cpio.gz\` still byte-identical under \`SOURCE_DATE_EPOCH\`

## Deferred to v0.6.0

All documented in CHANGELOG with rationale: TPM PCR extension (needs swtpm), ratatui theming, ISO metadata preview pane, full target-kernel boot (needs QEMU serial-preserve tweak), fitness-audit CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)