### PR TITLE
feat(rescue-tui): show ISO size in Confirm preview pane

### DIFF
--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -50,6 +50,9 @@ pub struct DiscoveredIso {
     pub hash_verification: HashVerification,
     /// Minisign signature verification status (from sibling .minisig, if any).
     pub signature_verification: SignatureVerification,
+    /// File size in bytes from `stat(2)` on `iso_path`. `None` if stat failed.
+    /// Rendered as a human-readable value in the Confirm preview pane.
+    pub size_bytes: Option<u64>,
 }
 
 /// Compatibility quirks the TUI should surface to the user before invoking
@@ -182,6 +185,7 @@ fn boot_entry_to_discovered(entry: &BootEntry, search_root: &Path) -> Discovered
             "iso-probe: no sibling .minisig"
         ),
     }
+    let size_bytes = std::fs::metadata(&iso_path).ok().map(|m| m.len());
     DiscoveredIso {
         iso_path,
         label: entry.label.clone(),
@@ -192,6 +196,7 @@ fn boot_entry_to_discovered(entry: &BootEntry, search_root: &Path) -> Discovered
         quirks: lookup_quirks(entry.distribution),
         hash_verification,
         signature_verification,
+        size_bytes,
     }
 }
 
@@ -388,6 +393,7 @@ mod tests {
             quirks: vec![],
             hash_verification: HashVerification::NotPresent,
             signature_verification: SignatureVerification::NotPresent,
+            size_bytes: None,
         };
         // Sanity-check the path-joining we'd perform on a real mount.
         let mount = PathBuf::from("/mnt/test");

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -97,6 +97,10 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             Span::raw(iso.iso_path.display().to_string()),
         ]),
         Line::from(vec![
+            Span::styled("Size:     ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(humanize_size(iso.size_bytes)),
+        ]),
+        Line::from(vec![
             Span::styled("Kernel:   ", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(iso.kernel.display().to_string()),
         ]),
@@ -230,6 +234,26 @@ fn signature_span(verification: &iso_probe::SignatureVerification) -> Span<'_> {
     }
 }
 
+const KB: u64 = 1024;
+const MB: u64 = KB * 1024;
+const GB: u64 = MB * 1024;
+
+#[allow(clippy::cast_precision_loss)]
+fn humanize_size(bytes: Option<u64>) -> String {
+    let Some(b) = bytes else {
+        return "(unknown)".to_string();
+    };
+    if b >= GB {
+        format!("{:.2} GiB", b as f64 / GB as f64)
+    } else if b >= MB {
+        format!("{:.1} MiB", b as f64 / MB as f64)
+    } else if b >= KB {
+        format!("{:.0} KiB", b as f64 / KB as f64)
+    } else {
+        format!("{b} B")
+    }
+}
+
 fn draw_error(frame: &mut Frame<'_>, area: Rect, message: &str, remedy: Option<&str>) {
     let mut lines = vec![
         Line::from(vec![Span::styled(
@@ -295,6 +319,7 @@ mod tests {
             quirks: vec![],
             hash_verification: iso_probe::HashVerification::NotPresent,
             signature_verification: iso_probe::SignatureVerification::NotPresent,
+            size_bytes: Some(1_500_000_000),
         }
     }
 
@@ -347,6 +372,26 @@ mod tests {
         assert!(s.contains("casper/vmlinuz"));
         assert!(s.contains("boot=casper"));
         assert!(s.contains("Confirm kexec"));
+    }
+
+    #[test]
+    fn confirm_screen_shows_humanized_size() {
+        let mut state = AppState::new(vec![fake_iso("x")]);
+        state.confirm_selection();
+        let s = render_to_string(&state);
+        // fake_iso uses 1_500_000_000 bytes ≈ 1.40 GiB
+        assert!(s.contains("Size:"), "missing Size: label in {s}");
+        assert!(s.contains("GiB"), "missing GiB unit in {s}");
+    }
+
+    #[test]
+    fn humanize_size_handles_all_units() {
+        assert_eq!(humanize_size(None), "(unknown)");
+        assert_eq!(humanize_size(Some(0)), "0 B");
+        assert_eq!(humanize_size(Some(512)), "512 B");
+        assert_eq!(humanize_size(Some(2048)), "2 KiB");
+        assert_eq!(humanize_size(Some(2 * 1024 * 1024)), "2.0 MiB");
+        assert_eq!(humanize_size(Some(3 * 1024 * 1024 * 1024)), "3.00 GiB");
     }
 
     #[test]

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -388,6 +388,7 @@ mod tests {
             quirks: vec![],
             hash_verification: iso_probe::HashVerification::NotPresent,
             signature_verification: iso_probe::SignatureVerification::NotPresent,
+            size_bytes: Some(1_500_000_000),
         }
     }
 
@@ -467,6 +468,7 @@ mod tests {
             quirks: vec![],
             hash_verification: iso_probe::HashVerification::NotPresent,
             signature_verification: iso_probe::SignatureVerification::NotPresent,
+            size_bytes: Some(1_500_000_000),
         };
         let (_, remedy) = error_diagnostic_with_iso(&KexecError::SignatureRejected, Some(&iso));
         let r = unwrap_remedy(remedy);


### PR DESCRIPTION
## Summary
- Adds `size_bytes: Option<u64>` to `DiscoveredIso`, populated via `std::fs::metadata` at discovery
- Renders humanized size (B/KiB/MiB/GiB) in the kexec Confirm screen
- Helps operators sanity-check what they're about to boot at a glance

Closes part of #40 (v0.5.0 nice-to-have: ISO metadata preview pane).

## Test plan
- [x] 42 workspace tests pass (was 40; +2 new in render::tests)
- [x] cargo fmt clean
- [x] cargo clippy --workspace --all-targets -D warnings clean