### PR TITLE
feat(rescue-tui): AEGIS_THEME palette override

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -10,6 +10,7 @@
 mod persistence;
 mod render;
 mod state;
+mod theme;
 mod tpm;
 
 use std::env;
@@ -107,6 +108,10 @@ fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     let mut state = AppState::new(isos);
+    if let Ok(name) = env::var("AEGIS_THEME") {
+        state.theme = theme::Theme::from_name(&name);
+        tracing::info!(theme = %name, "rescue-tui: theme override applied");
+    }
     apply_persisted_choice(&mut state);
 
     // Non-interactive automation mode. When AEGIS_AUTO_KEXEC is set to a

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -10,6 +10,7 @@ use ratatui::{
 };
 
 use crate::state::{quirks_summary, AppState, Screen};
+use crate::theme::Theme;
 
 /// Render the current frame for the given state.
 pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
@@ -127,12 +128,12 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
         ]),
         Line::from(vec![
             Span::styled("Checksum: ", Style::default().add_modifier(Modifier::BOLD)),
-            checksum_span(&iso.hash_verification),
+            checksum_span(&iso.hash_verification, &state.theme),
         ]),
         Line::from(vec![
             Span::styled("Signature:", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" "),
-            signature_span(&iso.signature_verification),
+            signature_span(&iso.signature_verification, &state.theme),
         ]),
         Line::from(""),
         Line::from(if state.is_kexec_blocked(selected) {
@@ -198,37 +199,39 @@ fn draw_edit_cmdline(
     frame.render_widget(para, area);
 }
 
-fn checksum_span(verification: &iso_probe::HashVerification) -> Span<'_> {
-    use ratatui::style::Color;
+fn checksum_span<'a>(verification: &iso_probe::HashVerification, theme: &Theme) -> Span<'a> {
     match verification {
         iso_probe::HashVerification::Verified { .. } => {
-            Span::styled("✓ verified", Style::default().fg(Color::Green))
+            Span::styled("✓ verified", Style::default().fg(theme.success))
         }
         iso_probe::HashVerification::Mismatch { .. } => Span::styled(
             "✗ MISMATCH — do NOT kexec",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.error)
+                .add_modifier(Modifier::BOLD),
         ),
         iso_probe::HashVerification::NotPresent => Span::raw("(no sibling checksum)"),
     }
 }
 
-fn signature_span(verification: &iso_probe::SignatureVerification) -> Span<'_> {
-    use ratatui::style::Color;
+fn signature_span<'a>(verification: &iso_probe::SignatureVerification, theme: &Theme) -> Span<'a> {
     match verification {
         iso_probe::SignatureVerification::Verified { key_id, .. } => Span::styled(
             format!("✓ verified (signer: {key_id})"),
-            Style::default().fg(Color::Green),
+            Style::default().fg(theme.success),
         ),
         iso_probe::SignatureVerification::KeyNotTrusted { key_id } => Span::styled(
             format!("⚠ signer not trusted ({key_id})"),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(theme.warning),
         ),
         iso_probe::SignatureVerification::Forged { .. } => Span::styled(
             "✗ FORGED — bytes don't match sig",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.error)
+                .add_modifier(Modifier::BOLD),
         ),
         iso_probe::SignatureVerification::Error { .. } => {
-            Span::styled("? sig parse error", Style::default().fg(Color::Yellow))
+            Span::styled("? sig parse error", Style::default().fg(theme.warning))
         }
         iso_probe::SignatureVerification::NotPresent => Span::raw("(no .minisig sidecar)"),
     }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -6,6 +6,8 @@
 use iso_probe::{DiscoveredIso, Quirk};
 use kexec_loader::KexecError;
 
+use crate::theme::Theme;
+
 /// Top-level UI state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Screen {
@@ -49,6 +51,8 @@ pub struct AppState {
     /// Per-ISO cmdline overrides keyed by index. When absent the
     /// ISO-declared default from `iso-probe` is used.
     pub cmdline_overrides: std::collections::HashMap<usize, String>,
+    /// Active color theme (resolved from `AEGIS_THEME` env var).
+    pub theme: Theme,
 }
 
 impl AppState {
@@ -59,6 +63,7 @@ impl AppState {
             isos,
             screen: Screen::List { selected: 0 },
             cmdline_overrides: std::collections::HashMap::new(),
+            theme: Theme::default_theme(),
         }
     }
 

--- a/crates/rescue-tui/src/theme.rs
+++ b/crates/rescue-tui/src/theme.rs
@@ -1,0 +1,110 @@
+//! Color theming for the rescue TUI.
+//!
+//! Operators can override the default palette with `AEGIS_THEME=<name>`
+//! (set in the kernel cmdline as `aegis.theme=<name>` and propagated by
+//! /init, or exported manually from a debug shell). Themes are
+//! intentionally limited to a small set — the rescue environment runs
+//! against unknown TTYs (serial, framebuffer, OVMF console) where some
+//! palettes render unreadably.
+
+use ratatui::style::Color;
+
+/// Named palette controlling foreground colors for status spans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Theme {
+    /// Verified / success state (checksum ok, signature trusted).
+    pub success: Color,
+    /// Warning / soft failure (untrusted signer, parse error).
+    pub warning: Color,
+    /// Hard failure (mismatch, forged signature).
+    pub error: Color,
+}
+
+impl Theme {
+    /// Default 16-color palette suitable for most VT100-class consoles.
+    #[must_use]
+    pub const fn default_theme() -> Self {
+        Self {
+            success: Color::Green,
+            warning: Color::Yellow,
+            error: Color::Red,
+        }
+    }
+
+    /// Monochrome palette — every status renders as the terminal's
+    /// default foreground. Useful on serial consoles whose ANSI color
+    /// support is unreliable or where a screen reader strips color.
+    #[must_use]
+    pub const fn monochrome() -> Self {
+        Self {
+            success: Color::Reset,
+            warning: Color::Reset,
+            error: Color::Reset,
+        }
+    }
+
+    /// High-contrast palette — bright variants only, for low-contrast
+    /// framebuffer consoles (OVMF default font, some HDMI capture cards).
+    #[must_use]
+    pub const fn high_contrast() -> Self {
+        Self {
+            success: Color::LightGreen,
+            warning: Color::LightYellow,
+            error: Color::LightRed,
+        }
+    }
+
+    /// Resolve a theme name (case-insensitive). Unknown names fall back
+    /// to the default palette so a typo never bricks the TUI.
+    #[must_use]
+    pub fn from_name(name: &str) -> Self {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "monochrome" | "mono" | "none" => Self::monochrome(),
+            "high-contrast" | "high_contrast" | "hc" => Self::high_contrast(),
+            _ => Self::default_theme(),
+        }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::default_theme()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_uses_standard_ansi_colors() {
+        let t = Theme::default_theme();
+        assert_eq!(t.success, Color::Green);
+        assert_eq!(t.warning, Color::Yellow);
+        assert_eq!(t.error, Color::Red);
+    }
+
+    #[test]
+    fn monochrome_resets_all_slots() {
+        let t = Theme::monochrome();
+        assert_eq!(t.success, Color::Reset);
+        assert_eq!(t.warning, Color::Reset);
+        assert_eq!(t.error, Color::Reset);
+    }
+
+    #[test]
+    fn from_name_is_case_insensitive_and_accepts_aliases() {
+        assert_eq!(Theme::from_name("monochrome"), Theme::monochrome());
+        assert_eq!(Theme::from_name("MONO"), Theme::monochrome());
+        assert_eq!(Theme::from_name("none"), Theme::monochrome());
+        assert_eq!(Theme::from_name("high-contrast"), Theme::high_contrast());
+        assert_eq!(Theme::from_name("HC"), Theme::high_contrast());
+    }
+
+    #[test]
+    fn from_name_falls_back_to_default_on_unknown() {
+        assert_eq!(Theme::from_name(""), Theme::default_theme());
+        assert_eq!(Theme::from_name("solarized-dark"), Theme::default_theme());
+        assert_eq!(Theme::from_name("xyzzy"), Theme::default_theme());
+    }
+}


### PR DESCRIPTION
Adds Theme module + AEGIS_THEME env var. 3 named palettes (default/monochrome/high-contrast). +4 unit tests (46 total).

Closes part of #40 (v0.5.0 nice-to-have: ratatui theming).