### PR TITLE
docs: tighten v0.6.0 claims after full-review audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [0.6.0] — 2026-04-14
 
-**The polish release.** Lands all four nice-to-haves deferred from v0.5.0. No deployment-shape changes — `mkusb.sh` output is byte-compatible with v0.5.0's; this release adds operator-facing affordances on top.
+**The polish release.** Lands all four nice-to-haves deferred from v0.5.0. No deployment-shape changes — `mkusb.sh` output structure is unchanged from v0.5.0's; this release adds operator-facing affordances on top. (Note: the disk image embeds host-installed shim/grub/kernel binaries and is not byte-reproducible across hosts — only the rescue-tui binary is verified reproducible under SOURCE_DATE_EPOCH.)
 
 ### Headline
 
@@ -16,7 +16,7 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 ### Test tally
 
 - **v0.5.0:** 87 tests
-- **v0.6.0:** 100 tests (+13: 5 TPM + 2 size + 4 theme + 5 fitness)
+- **v0.6.0:** 100 unit tests (+13: 5 TPM + 2 size + 4 theme + 5 fitness-scoring). The "5 fitness" tests cover the `aegis-fitness` binary's score-computation logic, not the audit checks themselves (the binary runs 9 checks at runtime).
 
 ### Deferred
 

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -1,6 +1,6 @@
 # Local testing
 
-While GitHub Actions CI is the primary validation gate, you can run the full matrix locally in ~6-8 minutes using KVM + libvirt. This is the right dev loop when:
+While GitHub Actions CI is the primary validation gate, you can run the full matrix locally in ~8-15 minutes using KVM + libvirt (varies by hardware — fast NVMe + warm cargo cache hits the low end; cold cache or slower disks land closer to the high end). This is the right dev loop when:
 
 - GHA billing is constrained or paused.
 - You want instant feedback before pushing.
@@ -39,8 +39,9 @@ Steps it runs, in order (short-circuits on first failure):
 5. `scripts/mkusb.sh` — produces `out/aegis-boot.img`
 6. QEMU boot of the mkusb image under OVMF SecBoot — asserts SB enforcing + rescue-tui starts
 7. `scripts/qemu-kexec-e2e.sh` — asserts the rescue-tui → target-kernel kexec handoff
+8. `cargo run --release -p aegis-fitness` — repo / build / artifact health audit (added in v0.6.0)
 
-Total runtime on a Framework laptop: ~6-8 min. Most of that is step 6 (QEMU cold boot) and step 7 (second QEMU cold boot + initramfs customization + ISO build).
+Total runtime on a Framework laptop with warm cargo cache: ~8-10 min. Most of that is step 6 (QEMU cold boot) and step 7 (second QEMU cold boot + initramfs customization + ISO build). Cold cargo cache adds 2-5 min on top.
 
 ## Iterating on specific tests
 


### PR DESCRIPTION
Inline fixes for the non-controversial accuracy issues from #52. Other findings (security gating #55, path validation #56, sig diagnostic #57, CI fitness step #53, main.rs tests #54) tracked separately.