### PR TITLE
chore: gitignore .security-discoveries.jsonl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ out/
 crates/*/fuzz/corpus/
 crates/*/fuzz/artifacts/
 *.cdx.json
+.security-discoveries.jsonl


### PR DESCRIPTION
Local-only security findings file should not be committed.