### PR TITLE
docs(78): post-v0.7.0 accuracy audit — README rewrite + CHANGELOG/LOCAL_TESTING/USB_LAYOUT updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,16 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [0.7.0] — 2026-04-15
 
-**Real-hardware-ready release.** Foundation for actually using aegis-boot on a physical USB stick plugged into a real machine (the goal the project has been building toward). v0.6.x fixed the QEMU+virtio path; v0.7.0 adds the storage-controller modules real hardware needs.
+**Storage-module-complete release.** Adds the kernel modules real hardware needs (AHCI, NVMe, USB-storage, UAS) so rescue-tui can in principle see a USB stick or internal disk on a physical machine. **Real-hardware boot has not yet been validated** — that's gated on a Framework / ThinkPad / Dell shakedown ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)) and gates v1.0.0. v0.6.x fixed the QEMU+virtio path; v0.7.0 is the foundation for the next step.
 
 ### Headline
 
 - **Storage controller modules shipped in the initramfs** (#72). `build-initramfs.sh` now copies (or skips-as-built-in) AHCI (SATA), NVMe, USB core + xHCI/EHCI + usb-storage + UAS, plus SCSI core. On modern Ubuntu kernels (6.8+) these are modules; without shipping them, rescue-tui on real hardware had no visibility into the storage bus and the user's USB stick + internal disks were all invisible. `/init` now modprobes the set early with a longer (3s) settle sleep for USB hub/bus enumeration.
 - **`qemu-loaded-stick.sh --attach {virtio,sata,usb}`** (#72). Lets developers exercise each storage-driver path without real hardware. `virtio` is the fast paravirtual default; `sata` drives the AHCI module path real desktops use; `usb` hangs the stick off `qemu-xhci` with `usb-storage`, matching a real USB plug.
 
-### Verified end-to-end
+### Verified end-to-end (in QEMU only)
 
-With `alpine-3.20.3-x86_64.iso` on the AEGIS_ISOS partition:
+With `alpine-3.20.3-x86_64.iso` on the AEGIS_ISOS partition (real-hardware behavior may differ — drivers behave differently on actual PCI/USB buses):
 
 | Attach mode | Result |
 |---|---|
@@ -111,7 +111,7 @@ None of the v0.5.0-deferred items remain. v0.7.0 epic (TBD) will likely focus on
 
 ### Headline
 
-**`scripts/mkusb.sh` image builder** (#41). Produces a byte-reproducible bootable disk image:
+**`scripts/mkusb.sh` image builder** (#41). Produces a bootable disk image (only the `rescue-tui` binary is byte-reproducible under SOURCE_DATE_EPOCH; the disk image embeds host-installed shim/grub/kernel binaries and is not hash-stable across hosts):
 - GPT partition table
 - **ESP** (FAT32, 400 MB): MS-signed shim → Canonical-signed grub → signed kernel + combined initrd (distro initrd + our rescue initramfs)
 - **AEGIS_ISOS data partition** (FAT32 by default, remainder of disk): user drops `.iso` files here

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -1,34 +1,63 @@
-# Aegis-Boot
+# aegis-boot
 
-Reproducible UEFI Secure Boot orchestration infrastructure.
+A signed UEFI Secure Boot rescue environment that lets operators pick any ISO from a USB stick's data partition and `kexec` into it — without leaving the chain of trust.
 
-## Architecture
+**Status:** v0.7.0 — feature-complete under QEMU simulation; real-hardware shakedown gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
-The runtime is a **signed Linux rescue environment + ratatui TUI + kexec** (Option B). See [ADR 0001](./docs/adr/0001-runtime-architecture.md) for the full decision record and the vote that produced it.
+## What it does
 
-Boot chain: `UEFI firmware → shim → signed rescue kernel → initramfs → rescue-tui → kexec_file_load → selected ISO's kernel`.
+1. Flash `out/aegis-boot.img` (produced by `scripts/mkusb.sh`) to a USB stick.
+2. Drop `.iso` files onto the `AEGIS_ISOS` partition.
+3. Boot the stick on any UEFI machine with Secure Boot enabled.
+4. A minimal ratatui TUI lists the ISOs; the operator selects one.
+5. `kexec_file_load(2)` hands off to the selected ISO's kernel.
+
+Boot chain: `UEFI firmware → shim (MS-signed) → grub (Canonical-signed) → rescue kernel → our initramfs → rescue-tui → kexec_file_load → selected ISO's kernel`. Full rationale: [ADR 0001](./docs/adr/0001-runtime-architecture.md).
+
+## Quickstart (simulation)
+
+```bash
+# 1. build
+cargo build --release -p rescue-tui
+./scripts/build-initramfs.sh
+./scripts/mkusb.sh
+
+# 2. drop some ISOs into a dir
+mkdir -p test-isos && cp ~/Downloads/*.iso test-isos/
+
+# 3. boot the simulated stick under QEMU+OVMF SecBoot
+./scripts/qemu-loaded-stick.sh -d ./test-isos -a usb -i
+```
+
+See [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) for the full developer loop.
 
 ## Components
 
-- **[BUILDING.md](./BUILDING.md)** — Reproducible build setup (Docker + Nix)
-- **[THREAT_MODEL.md](./THREAT_MODEL.md)** — UEFI Secure Boot threat model (PK/KEK/MOK/SBAT)
-- **[docs/adr/](./docs/adr/)** — Architecture Decision Records
-- **[docs/compatibility/iso-matrix.md](./docs/compatibility/iso-matrix.md)** — Per-distro ISO + kexec compatibility matrix
-- **[Dockerfile.locked](./Dockerfile.locked)** — Pinned base image (Ubuntu 22.04, Rust 1.75.0, EDK II stable202311)
-- **[flake.nix](./flake.nix)** — Nix flake for declarative dev environments
-- **[crates/iso-parser](./crates/iso-parser)** — ISO media parser (on-media analysis, `std`-compatible)
-- **[crates/iso-probe](./crates/iso-probe)** — Runtime ISO discovery on the live rescue environment
-- **[crates/rescue-tui](./crates/rescue-tui)** — ratatui application the user sees
-- **[crates/kexec-loader](./crates/kexec-loader)** — Safe wrapper over `kexec_file_load(2)`
+| Crate | Role |
+|---|---|
+| [`iso-parser`](./crates/iso-parser) | ISO media analysis — finds kernel/initrd/cmdline in distro boot configs |
+| [`iso-probe`](./crates/iso-probe) | Runtime discovery + sibling `.sha256` / `.minisig` verification |
+| [`kexec-loader`](./crates/kexec-loader) | Safe wrapper over `kexec_file_load(2)` with error classification |
+| [`rescue-tui`](./crates/rescue-tui) | ratatui application the operator sees; hard-blocks kexec on hash/sig failure |
+| [`aegis-fitness`](./crates/aegis-fitness) | Repo / build / artifact health audit (9 checks) |
 
-## Status
+## Documentation
 
-Work in progress. Architecture decided (ADR 0001); `iso-parser` is the only crate with real functionality. `iso-probe`, `rescue-tui`, and `kexec-loader` are skeleton-only — implementation tracked from [#4](https://github.com/williamzujkowski/aegis-boot/issues/4).
+- [BUILDING.md](./BUILDING.md) — reproducible build setup (Docker + Nix)
+- [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) — 8-stage local CI equivalent
+- [docs/USB_LAYOUT.md](./docs/USB_LAYOUT.md) — GPT + ESP + `AEGIS_ISOS` partition scheme
+- [docs/adr/](./docs/adr/) — Architecture Decision Records
+- [docs/compatibility/iso-matrix.md](./docs/compatibility/iso-matrix.md) — per-distro kexec compatibility
+- [SECURITY.md](./SECURITY.md) — vulnerability reporting
+- [THREAT_MODEL.md](./THREAT_MODEL.md) — UEFI Secure Boot threat model (PK/KEK/MOK/SBAT)
+- [CHANGELOG.md](./CHANGELOG.md)
+
+## Build environment
+
+- Rust 1.85.0 (pinned in `Dockerfile.locked`, enforced via `rust-version` in every `Cargo.toml`)
+- Ubuntu 22.04 base (Docker) or a Nix flake
+- No EDK II / UEFI toolchain — we use shim + signed distro kernels instead
 
 ## License
 
-Dual-licensed under [Apache-2.0](./LICENSE-APACHE) or [MIT](./LICENSE-MIT) at your option.
-
-## Security
-
-Report vulnerabilities privately — see [SECURITY.md](./SECURITY.md).
+Dual-licensed: [Apache-2.0](./LICENSE-APACHE) OR [MIT](./LICENSE-MIT), at your option.

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iso-parser"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.85"
+version = "0.7.0"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/williamzujkowski/aegis-boot"
 description = "ISO installation media parser for aegis-boot"

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -87,15 +87,27 @@ virt-install --name aegis-boot-dev \
 ```bash
 mkdir -p test-isos
 cp ~/Downloads/ubuntu-24.04.iso test-isos/
-./scripts/qemu-loaded-stick.sh                    # serial
-./scripts/qemu-loaded-stick.sh -i                 # GTK
-./scripts/qemu-loaded-stick.sh -d ~/iso-stash -k  # custom dir, keep image
+./scripts/qemu-loaded-stick.sh                       # default: virtio, serial
+./scripts/qemu-loaded-stick.sh -i                    # GTK display
+./scripts/qemu-loaded-stick.sh -a sata -i            # AHCI path (real desktops)
+./scripts/qemu-loaded-stick.sh -a usb                # usb-storage on xHCI (real USB)
+./scripts/qemu-loaded-stick.sh -d ~/iso-stash -k     # custom dir, keep image
 ```
 
 The script builds a fresh `out/aegis-boot.img`, loop-mounts AEGIS_ISOS,
 copies every `.iso` (plus any sibling `.sha256` / `.minisig`) from the
 source dir, and boots under OVMF SecBoot. Image size auto-scales to
 1.5× the total ISO bytes (min 2 GiB).
+
+`--attach` chooses how the stick image is presented to the VM:
+
+| Mode | What it exercises | Use when |
+|---|---|---|
+| `virtio` (default) | paravirtual `virtio-blk` | fastest dev loop; only proves the boot chain |
+| `sata` | AHCI module path (`ahci.ko`) | matches most desktops + older laptops |
+| `usb` | `qemu-xhci` + `usb-storage` | closest to a real USB stick plugged into a host |
+
+All three modes were verified end-to-end in v0.7.0 with Alpine 3.20 (4 ISO entries discovered).
 
 ### Manual, if you want to inspect the partition
 

--- a/docs/USB_LAYOUT.md
+++ b/docs/USB_LAYOUT.md
@@ -115,6 +115,19 @@ sudo cp *.iso /mnt/aegis-isos/
 sudo umount /mnt/aegis-isos
 ```
 
+## Storage modules shipped in the initramfs
+
+For rescue-tui to see the AEGIS_ISOS partition (or any internal disk the operator might want to scan), the initramfs has to include the kernel modules for the storage controller. Most modern Ubuntu generic kernels (6.8+) compile these as modules, not built-in. As of v0.7.0 (#72), `build-initramfs.sh` ships:
+
+- `libahci`, `ahci` — SATA AHCI controllers (most desktops + older laptops)
+- `nvme-core`, `nvme` — NVMe SSDs (most modern laptops)
+- `usb-storage`, `uas` — USB mass storage (the deployment path)
+- `nls_utf8` — vfat fallback charset (the default `iocharset=utf8` is otherwise a missing module)
+
+`scsi_mod`, `sd_mod`, `usbcore`, `xhci-hcd/pci`, `ehci-hcd/pci`, and `loop`/`isofs`/`udf` are typically built-in on Ubuntu kernels and skipped at build time with an INFO log. `/init` modprobes the full set early; built-in modules return successfully without doing anything.
+
+Real-hardware boot has been validated only in QEMU simulation as of v0.7.0 (`scripts/qemu-loaded-stick.sh --attach {virtio,sata,usb}`). A Framework / ThinkPad / Dell shakedown is tracked in [#51](https://github.com/williamzujkowski/aegis-boot/issues/51).
+
 ## Chain of trust recap
 
 See [THREAT_MODEL.md](../THREAT_MODEL.md) for the full model. In short:

--- a/docs/content-audit.md
+++ b/docs/content-audit.md
@@ -1,0 +1,20 @@
+# Content audit log
+
+Per [#78](https://github.com/williamzujkowski/aegis-boot/issues/78), this file records each documentation accuracy audit so we can re-audit on a cadence.
+
+| Date       | Reviewing | Files audited | Findings filed | PRs |
+|------------|-----------|---------------|----------------|-----|
+| 2026-04-15 | v0.7.0    | README, BUILDING, SECURITY, THREAT_MODEL, CHANGELOG, USB_LAYOUT, LOCAL_TESTING, all ADRs, all compatibility/, all crate Cargo.toml + top-level rustdoc | #76, #77, #78 (epics); inline fixes in this PR | #79 (this) |
+| 2026-04-15 | v0.6.0    | CHANGELOG (partial) | #52 | #58 |
+
+## Process
+
+1. Spawn 4 parallel review agents (top-level docs, CHANGELOG, docs/ subtree, crate rustdoc + Cargo metadata).
+2. Each agent categorizes findings as CRITICAL / OVERSTATED / STALE / VAGUE with file:line refs.
+3. Verify each CRITICAL claim manually before fixing (agents can be wrong).
+4. Fix in place; reference epic #78 in the PR.
+5. Update this log.
+
+## Cadence
+
+Re-run before each minor release (0.x → 0.(x+1)) and before every 1.x release.


### PR DESCRIPTION
Closes part of #78. 4-agent parallel doc audit findings: README was severely stale (skeleton-only claims + wrong Rust version + wrong EDK II claim); CHANGELOG v0.5.0 still had the byte-reproducible-image claim; CHANGELOG v0.7.0 overstated as real-hardware-ready; LOCAL_TESTING/USB_LAYOUT missed v0.7.0 --attach + storage modules; iso-parser Cargo.toml stuck at 0.1.0. Adds docs/content-audit.md to track future audits.