### PR TITLE
chore(77): expand CODEOWNERS + document lints intent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,31 @@
 # Default owner for everything
-*                       @williamzujkowski
+*                                       @williamzujkowski
 
-# Security-critical: require explicit review
-/THREAT_MODEL.md        @williamzujkowski
-/SECURITY.md            @williamzujkowski
-/Dockerfile.locked      @williamzujkowski
-/flake.nix              @williamzujkowski
-/.github/workflows/     @williamzujkowski
-/crates/iso-parser/     @williamzujkowski
+# Security-critical: explicit review gate
+/THREAT_MODEL.md                        @williamzujkowski
+/SECURITY.md                            @williamzujkowski
+/Dockerfile.locked                      @williamzujkowski
+/flake.nix                              @williamzujkowski
+/.github/workflows/                     @williamzujkowski
+
+# Crates — workspace + each crate
+/Cargo.toml                             @williamzujkowski
+/Cargo.lock                             @williamzujkowski
+/crates/iso-parser/                     @williamzujkowski
+/crates/iso-probe/                      @williamzujkowski
+/crates/kexec-loader/                   @williamzujkowski
+/crates/rescue-tui/                     @williamzujkowski
+/crates/aegis-fitness/                  @williamzujkowski
+
+# Scripts that produce the bootable artifact or run as PID 1
+/scripts/build-initramfs.sh             @williamzujkowski
+/scripts/mkusb.sh                       @williamzujkowski
+/scripts/qemu-kexec-e2e.sh              @williamzujkowski
+/scripts/ovmf-secboot-e2e.sh            @williamzujkowski
+
+# Governance docs
+/CONTRIBUTING.md                        @williamzujkowski
+/CODE_OF_CONDUCT.md                     @williamzujkowski
+/ROADMAP.md                             @williamzujkowski
+/CHANGELOG.md                           @williamzujkowski
+/docs/adr/                              @williamzujkowski

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,13 @@ tracing = "0.1"
 libc = "0.2"
 
 [workspace.lints.rust]
-# `deny`, not `forbid`, so individual crates can narrowly opt into `unsafe`
-# for syscall FFI (kexec-loader). Every such crate must justify it per
-# module with `#[allow(unsafe_code)]` and document the invariant.
+# `deny`, not `forbid`, so kexec-loader can narrowly opt into `unsafe`
+# for syscall FFI via `#[allow(unsafe_code)]` with documented invariants.
+# Library crates that don't need any unsafe (iso-probe, rescue-tui,
+# aegis-fitness) override this in their own [lints.rust] to `forbid` —
+# stricter, and `forbid` cannot be opted out of even with #[allow(...)].
+# That per-crate duplication is intentional; cargo lints can't merge
+# partial overrides with workspace inheritance.
 unsafe_code = "deny"
 missing_docs = "warn"
 

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -21,3 +21,10 @@ tempfile = "3.14"
 similar-asserts = "1.5"
 tokio = { version = "1", features = ["rt", "macros"] }
 serde_json = "1.0"
+
+# NOTE: no [lints] section — this crate predates the workspace lint
+# discipline and uses unwrap()/expect() liberally in tests. Tracked
+# separately under #77 follow-up; do not add `workspace = true` here
+# without first auditing the test-suite warnings (38 clippy errors at
+# last attempt). Adding `[lints]` is a non-trivial cleanup, not a
+# CODEOWNERS-style fix.


### PR DESCRIPTION
Closes more of #77. CODEOWNERS now covers all 5 crates, security-sensitive scripts, governance docs. Workspace Cargo.toml gains an explanatory comment about per-crate [lints] duplication. iso-parser lint-cleanup deferred to a follow-up issue.