### PR TITLE
feat(rescue-tui): UX Tier 1 — chrome, vim keys, help overlay, status glyphs, quit confirm, SB/TPM banner (#85)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -163,27 +163,67 @@ fn event_loop<B: ratatui::backend::Backend>(
             continue;
         }
 
-        // In the cmdline editor, typing characters (including 'q') should
-        // insert, not quit. Keep 'q' as global quit only outside the editor.
-        let in_editor = matches!(state.screen, Screen::EditCmdline { .. });
-        if !in_editor && key.code == KeyCode::Char('q') {
-            state.quit();
+        // ConfirmQuit modal swallows everything: y/Enter confirms exit,
+        // n/Esc cancels back to prior screen.
+        if matches!(state.screen, Screen::ConfirmQuit { .. }) {
+            match key.code {
+                KeyCode::Char('y' | 'Y') | KeyCode::Enter => state.confirm_quit(),
+                KeyCode::Char('n' | 'N' | 'q') | KeyCode::Esc => {
+                    state.cancel_quit();
+                }
+                _ => {}
+            }
             continue;
         }
 
-        match (&state.screen, key.code) {
-            (Screen::List { .. }, KeyCode::Up) => state.move_selection(-1),
-            (Screen::List { .. }, KeyCode::Down) => state.move_selection(1),
-            (Screen::List { .. }, KeyCode::Enter) => state.confirm_selection(),
+        // Help overlay swallows everything: ?/Esc/q dismisses.
+        if matches!(state.screen, Screen::Help { .. }) {
+            match key.code {
+                KeyCode::Char('?' | 'q') | KeyCode::Esc => state.close_help(),
+                _ => {}
+            }
+            continue;
+        }
 
-            (Screen::Confirm { .. }, KeyCode::Esc) => state.cancel_confirmation(),
+        let in_editor = matches!(state.screen, Screen::EditCmdline { .. });
+
+        // Global keys (not in cmdline editor):
+        //   q  → quit confirmation prompt (was instant exit before #85)
+        //   ?  → help overlay
+        if !in_editor {
+            match key.code {
+                KeyCode::Char('q') => {
+                    state.request_quit();
+                    continue;
+                }
+                KeyCode::Char('?') => {
+                    state.open_help();
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        match (&state.screen, key.code) {
+            // Vim navigation aliases for arrow keys (#85).
+            (Screen::List { .. }, KeyCode::Up | KeyCode::Char('k')) => state.move_selection(-1),
+            (Screen::List { .. }, KeyCode::Down | KeyCode::Char('j')) => state.move_selection(1),
+            (Screen::List { .. }, KeyCode::Char('g')) => state.move_to_first(),
+            (Screen::List { .. }, KeyCode::Char('G')) => state.move_to_last(),
+            (Screen::List { .. }, KeyCode::Enter | KeyCode::Char('l')) => {
+                state.confirm_selection();
+            }
+
+            (Screen::Confirm { .. }, KeyCode::Esc | KeyCode::Char('h')) => {
+                state.cancel_confirmation();
+            }
             (Screen::Confirm { .. }, KeyCode::Char('e')) => state.enter_cmdline_editor(),
             (Screen::Confirm { selected }, KeyCode::Enter) => {
                 let idx = *selected;
                 if state.is_kexec_blocked(idx) {
                     tracing::warn!(
                         idx,
-                        "rescue-tui: refused kexec — ISO carries NotKexecBootable quirk"
+                        "rescue-tui: refused kexec — ISO is kexec-blocked (quirk or verification failure)"
                     );
                     state.record_kexec_error(&kexec_loader::KexecError::UnsupportedImage);
                 } else {
@@ -198,8 +238,11 @@ fn event_loop<B: ratatui::backend::Backend>(
             (Screen::EditCmdline { .. }, KeyCode::Backspace) => state.cmdline_backspace(),
             (Screen::EditCmdline { .. }, KeyCode::Char(c)) => state.cmdline_insert(c),
 
-            (Screen::Error { .. }, _) => {
-                state.screen = Screen::List { selected: 0 };
+            // Error → return to List, preserving the ISO that failed
+            // so the operator doesn't have to re-navigate. (#85)
+            (Screen::Error { return_to, .. }, _) => {
+                let idx = *return_to;
+                state.screen = Screen::List { selected: idx };
             }
             _ => {}
         }

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -9,13 +9,57 @@ use ratatui::{
     Frame,
 };
 
-use crate::state::{quirks_summary, AppState, Screen};
+use crate::state::{quirks_summary, AppState, Screen, SecureBootStatus};
 use crate::theme::Theme;
 
 /// Render the current frame for the given state.
+///
+/// Layout (#85):
+///
+/// ```text
+/// ┌──────────────────────────────────────────────────────┐
+/// │  aegis-boot v0.7.1     SB:enforcing  TPM:available   │ <- header
+/// ├──────────────────────────────────────────────────────┤
+/// │                                                      │
+/// │              (current screen body)                   │ <- body
+/// │                                                      │
+/// ├──────────────────────────────────────────────────────┤
+/// │  [↑↓/jk] Move  [Enter] Boot  [/] Filter  [?] Help    │ <- footer
+/// └──────────────────────────────────────────────────────┘
+/// ```
 pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
     let area = frame.area();
-    match &state.screen {
+    let chrome = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // header banner
+            Constraint::Min(3),    // body
+            Constraint::Length(1), // footer
+        ])
+        .split(area);
+    let (header_area, body_area, footer_area) = (chrome[0], chrome[1], chrome[2]);
+
+    draw_header(frame, header_area, state);
+    draw_body(frame, body_area, state);
+    draw_footer(frame, footer_area, state);
+
+    // Overlays draw on top of everything.
+    if let Screen::Help { .. } = &state.screen {
+        draw_help_overlay(frame, area, state);
+    }
+    if let Screen::ConfirmQuit { .. } = &state.screen {
+        draw_confirm_quit_overlay(frame, area, state);
+    }
+}
+
+fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    // Help and ConfirmQuit overlays draw the prior screen underneath
+    // for context, then layer on top.
+    let effective = match &state.screen {
+        Screen::Help { prior } | Screen::ConfirmQuit { prior } => prior.as_ref(),
+        other => other,
+    };
+    match effective {
         Screen::List { selected } => draw_list(frame, area, state, *selected),
         Screen::Confirm { selected } => draw_confirm(frame, area, state, *selected),
         Screen::EditCmdline {
@@ -23,21 +67,157 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
             buffer,
             cursor,
         } => draw_edit_cmdline(frame, area, state, *selected, buffer, *cursor),
-        Screen::Error { message, remedy } => draw_error(frame, area, message, remedy.as_deref()),
-        Screen::Quitting => {}
+        Screen::Error {
+            message, remedy, ..
+        } => draw_error(frame, area, message, remedy.as_deref()),
+        Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => {}
     }
 }
 
-fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(2)])
-        .split(area);
+fn draw_header(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let version = env!("CARGO_PKG_VERSION");
+    let sb_color = match state.secure_boot {
+        SecureBootStatus::Enforcing => state.theme.success,
+        SecureBootStatus::Disabled => state.theme.error,
+        SecureBootStatus::Unknown => state.theme.warning,
+    };
+    let header = Line::from(vec![
+        Span::styled(
+            format!(" aegis-boot v{version} "),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(state.secure_boot.summary(), Style::default().fg(sb_color)),
+        Span::raw("  "),
+        Span::styled(
+            state.tpm.summary(),
+            Style::default().fg(state.theme.success),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(header), area);
+}
 
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    // Footer hints depend on the underlying screen, not the overlay.
+    let effective = match &state.screen {
+        Screen::Help { prior } | Screen::ConfirmQuit { prior } => prior.as_ref(),
+        other => other,
+    };
+    let hint = match effective {
+        Screen::List { .. } => " [↑↓/jk] Move  [g/G] First/Last  [Enter] Boot  [?] Help  [q] Quit",
+        Screen::Confirm { .. } => {
+            " [Enter] kexec  [e] Edit cmdline  [Esc/h] Back  [?] Help  [q] Quit"
+        }
+        Screen::EditCmdline { .. } => " [Enter] Save  [Esc] Cancel  [←/→] Move  [Backspace] Delete",
+        Screen::Error { .. } => " Press any key to return to the list  ·  [q] Quit",
+        Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => "",
+    };
+    frame.render_widget(Paragraph::new(hint), area);
+}
+
+/// Single-character status glyph for a list row, encoding the worst
+/// security state. Visible in monochrome themes (no color reliance).
+/// (#85, k9s/dialog pattern.)
+fn status_glyph(iso: &iso_probe::DiscoveredIso) -> &'static str {
+    use iso_probe::{HashVerification as H, Quirk, SignatureVerification as S};
+    if iso.quirks.contains(&Quirk::NotKexecBootable) {
+        return "[X]"; // can't kexec at all
+    }
+    if matches!(iso.hash_verification, H::Mismatch { .. }) {
+        return "[!]"; // tampered
+    }
+    if matches!(iso.signature_verification, S::Forged { .. }) {
+        return "[!]"; // crypto fail
+    }
+    if matches!(iso.signature_verification, S::Verified { .. }) {
+        return "[+]"; // signed + trusted
+    }
+    if matches!(iso.hash_verification, H::Verified { .. }) {
+        return "[~]"; // hash ok, sig absent
+    }
+    "[ ]"
+}
+
+fn draw_help_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    // Center a 60x18 panel.
+    let w = area.width.min(70);
+    let h = area.height.min(20);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let panel = Rect::new(x, y, w, h);
+    let lines = vec![
+        Line::from(Span::styled(
+            "Keybindings",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(" Global"),
+        Line::from("   ?         this help"),
+        Line::from("   q         quit (with confirmation)"),
+        Line::from(""),
+        Line::from(" List screen"),
+        Line::from("   ↑ ↓ / j k     move selection"),
+        Line::from("   g / G         first / last entry"),
+        Line::from("   Enter / l     confirm selection"),
+        Line::from(""),
+        Line::from(" Confirm screen"),
+        Line::from("   Enter         kexec into the ISO"),
+        Line::from("   e             edit kernel cmdline"),
+        Line::from("   Esc / h       back to list"),
+        Line::from(""),
+        Line::from(" Status glyphs on list rows"),
+        Line::from("   [+] verified  [~] hash-only  [ ] unknown"),
+        Line::from("   [!] tampered/forged  [X] not kexec-bootable"),
+        Line::from(""),
+        Line::from(Span::styled(
+            " Esc or ? to dismiss",
+            Style::default().fg(state.theme.warning),
+        )),
+    ];
+    let block = Block::default().borders(Borders::ALL).title(" Help (#85) ");
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        panel,
+    );
+}
+
+fn draw_confirm_quit_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let w = area.width.min(50);
+    let h = 7;
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let panel = Rect::new(x, y, w, h);
+    let lines = vec![
+        Line::from(Span::styled(
+            "Quit aegis-boot?",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("This will reboot the machine."),
+        Line::from(""),
+        Line::from(Span::styled(
+            " [y/Enter] yes    [n/Esc/q] cancel",
+            Style::default().fg(state.theme.warning),
+        )),
+    ];
+    let block = Block::default().borders(Borders::ALL).title(" Confirm ");
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        panel,
+    );
+}
+
+fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
     if state.isos.is_empty() {
-        let empty = Paragraph::new("No bootable ISOs found.\nPress q to quit.")
-            .block(Block::default().borders(Borders::ALL).title("aegis-boot"));
-        frame.render_widget(empty, chunks[0]);
+        let empty = Paragraph::new(
+            "No bootable ISOs found.\n\nPress q to quit, or check that AEGIS_ISO_ROOTS\npoints at a directory containing .iso files.",
+        )
+        .block(Block::default().borders(Borders::ALL).title("aegis-boot"));
+        frame.render_widget(empty, area);
         return;
     }
 
@@ -45,31 +225,26 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
         .isos
         .iter()
         .map(|iso| {
+            let glyph = status_glyph(iso);
             let qs = quirks_summary(iso);
             let line = if qs.is_empty() {
-                format!("{}  ({})", iso.label, iso.distribution_name())
+                format!("{glyph} {}  ({})", iso.label, iso.distribution_name())
             } else {
-                format!("{}  ({})  {}", iso.label, iso.distribution_name(), qs)
+                format!("{glyph} {}  ({})  {qs}", iso.label, iso.distribution_name())
             };
             ListItem::new(line)
         })
         .collect();
 
+    let title = format!(" aegis-boot — pick an ISO ({} found) ", state.isos.len());
     let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title("aegis-boot — pick an ISO"),
-        )
+        .block(Block::default().borders(Borders::ALL).title(title))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();
     list_state.select(Some(selected));
-    frame.render_stateful_widget(list, chunks[0], &mut list_state);
-
-    let help = Paragraph::new("↑/↓: navigate · Enter: select · q: quit");
-    frame.render_widget(help, chunks[1]);
+    frame.render_stateful_widget(list, area, &mut list_state);
 }
 
 fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
@@ -136,10 +311,15 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             signature_span(&iso.signature_verification, &state.theme),
         ]),
         Line::from(""),
+        // Per-screen action hint kept inline to make BLOCKED state
+        // unmissable; full keybind list is in the persistent footer.
         Line::from(if state.is_kexec_blocked(selected) {
-            "Enter: BLOCKED (not kexec-bootable) · e: edit cmdline · Esc: cancel"
+            Span::styled(
+                "Enter: BLOCKED — verification or quirk failure",
+                Style::default().fg(state.theme.error),
+            )
         } else {
-            "Enter: kexec · e: edit cmdline · Esc: cancel"
+            Span::raw("Enter: kexec   ·   e: edit kernel cmdline   ·   Esc: back to list")
         }),
     ];
     let title = if state.is_kexec_blocked(selected) {

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -30,12 +30,29 @@ pub enum Screen {
         /// Byte-offset cursor position within the buffer.
         cursor: usize,
     },
-    /// Showing a fatal-or-classified error after attempted kexec.
+    /// Showing a fatal-or-classified error after attempted kexec. The
+    /// `return_to` index lets the operator return to the failed ISO row
+    /// rather than the top of the list. (#85)
     Error {
         /// User-facing diagnostic copied from [`error_diagnostic`].
         message: String,
         /// User-facing remedy hint, if any.
         remedy: Option<String>,
+        /// Index of the ISO whose kexec attempt produced this error, so
+        /// returning to the List preserves the operator's place.
+        return_to: usize,
+    },
+    /// Help overlay (`?` from any non-edit screen). Stores the screen
+    /// to return to so dismissal restores prior state. (#85)
+    Help {
+        /// Boxed screen to restore on dismiss; boxed to keep the
+        /// `Help` variant the same size as the others.
+        prior: Box<Screen>,
+    },
+    /// Quit confirmation prompt. (#85 — was instant exit before.)
+    ConfirmQuit {
+        /// Boxed screen to restore on cancel.
+        prior: Box<Screen>,
     },
     /// User asked to quit; main loop should exit cleanly.
     Quitting,
@@ -53,6 +70,90 @@ pub struct AppState {
     pub cmdline_overrides: std::collections::HashMap<usize, String>,
     /// Active color theme (resolved from `AEGIS_THEME` env var).
     pub theme: Theme,
+    /// Secure Boot enforcement status, detected once at startup.
+    /// Rendered in the persistent header banner. (#85)
+    pub secure_boot: SecureBootStatus,
+    /// TPM availability, detected once at startup. Rendered in the
+    /// persistent header banner. (#85)
+    pub tpm: TpmStatus,
+}
+
+/// Coarse Secure Boot enforcement state, detected once at startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecureBootStatus {
+    /// EFI variable says SB is enforcing.
+    Enforcing,
+    /// EFI variable present but SB disabled / setup mode.
+    Disabled,
+    /// Couldn't read EFI vars (not booted via UEFI, or efivars not mounted).
+    Unknown,
+}
+
+/// TPM availability for pre-kexec PCR measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TpmStatus {
+    /// `/dev/tpm0` or `/dev/tpmrm0` present.
+    Available,
+    /// No TPM device exposed.
+    Absent,
+}
+
+impl SecureBootStatus {
+    /// Detect SB status from /sys/firmware/efi/efivars. Best-effort —
+    /// returns Unknown on any read error so the TUI can boot anywhere.
+    #[must_use]
+    pub fn detect() -> Self {
+        // EFI var format: 4 bytes attributes, 1 byte data (0/1).
+        let candidates = [
+            "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c",
+            "/sys/firmware/efi/efivars/SecureBoot",
+        ];
+        for path in candidates {
+            if let Ok(bytes) = std::fs::read(path) {
+                if let Some(&value) = bytes.get(4) {
+                    return if value == 1 {
+                        Self::Enforcing
+                    } else {
+                        Self::Disabled
+                    };
+                }
+            }
+        }
+        Self::Unknown
+    }
+
+    /// Short user-facing label for the TUI header banner.
+    #[must_use]
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::Enforcing => "SB:enforcing",
+            Self::Disabled => "SB:disabled",
+            Self::Unknown => "SB:unknown",
+        }
+    }
+}
+
+impl TpmStatus {
+    /// Detect TPM presence by checking for `/dev/tpm*` device nodes.
+    #[must_use]
+    pub fn detect() -> Self {
+        if std::path::Path::new("/dev/tpm0").exists()
+            || std::path::Path::new("/dev/tpmrm0").exists()
+        {
+            Self::Available
+        } else {
+            Self::Absent
+        }
+    }
+
+    /// Short user-facing label for the TUI header banner.
+    #[must_use]
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::Available => "TPM:available",
+            Self::Absent => "TPM:none",
+        }
+    }
 }
 
 impl AppState {
@@ -64,6 +165,8 @@ impl AppState {
             screen: Screen::List { selected: 0 },
             cmdline_overrides: std::collections::HashMap::new(),
             theme: Theme::default_theme(),
+            secure_boot: SecureBootStatus::detect(),
+            tpm: TpmStatus::detect(),
         }
     }
 
@@ -188,6 +291,26 @@ impl AppState {
         *cursor = new_cursor;
     }
 
+    /// Jump to the first row (vim `g`). No-op outside the List screen
+    /// or on an empty list. (#85)
+    pub fn move_to_first(&mut self) {
+        if let Screen::List { selected } = &mut self.screen {
+            if !self.isos.is_empty() {
+                *selected = 0;
+            }
+        }
+    }
+
+    /// Jump to the last row (vim `G`). No-op outside the List screen
+    /// or on an empty list. (#85)
+    pub fn move_to_last(&mut self) {
+        if let Screen::List { selected } = &mut self.screen {
+            if !self.isos.is_empty() {
+                *selected = self.isos.len() - 1;
+            }
+        }
+    }
+
     /// Advance the highlighted row up (negative) or down (positive), saturating
     /// at list bounds.
     pub fn move_selection(&mut self, delta: i32) {
@@ -228,17 +351,68 @@ impl AppState {
         // If the error occurred during a Confirm flow, enrich with
         // ISO-specific context (sibling key discovery for
         // SignatureRejected).
-        let iso = match &self.screen {
+        let (iso, return_to) = match &self.screen {
             Screen::Confirm { selected } | Screen::EditCmdline { selected, .. } => {
-                self.isos.get(*selected)
+                (self.isos.get(*selected), *selected)
             }
-            _ => None,
+            _ => (None, 0),
         };
         let (message, remedy) = error_diagnostic_with_iso(err, iso);
-        self.screen = Screen::Error { message, remedy };
+        self.screen = Screen::Error {
+            message,
+            remedy,
+            return_to,
+        };
     }
 
-    /// Request a clean exit.
+    /// Open the help overlay over the current screen. (#85)
+    pub fn open_help(&mut self) {
+        // Don't stack — if already in Help, do nothing.
+        if matches!(self.screen, Screen::Help { .. }) {
+            return;
+        }
+        let prior = std::mem::replace(&mut self.screen, Screen::Quitting);
+        self.screen = Screen::Help {
+            prior: Box::new(prior),
+        };
+    }
+
+    /// Dismiss the help overlay and restore the prior screen.
+    pub fn close_help(&mut self) {
+        if let Screen::Help { prior } = std::mem::replace(&mut self.screen, Screen::Quitting) {
+            self.screen = *prior;
+        }
+    }
+
+    /// Open the quit-confirmation prompt over the current screen.
+    /// Idempotent — re-pressing `q` in the prompt does nothing. (#85)
+    pub fn request_quit(&mut self) {
+        if matches!(self.screen, Screen::ConfirmQuit { .. } | Screen::Quitting) {
+            return;
+        }
+        let prior = std::mem::replace(&mut self.screen, Screen::Quitting);
+        self.screen = Screen::ConfirmQuit {
+            prior: Box::new(prior),
+        };
+    }
+
+    /// Dismiss the quit prompt without exiting.
+    pub fn cancel_quit(&mut self) {
+        if let Screen::ConfirmQuit { prior } = std::mem::replace(&mut self.screen, Screen::Quitting)
+        {
+            self.screen = *prior;
+        }
+    }
+
+    /// Confirm exit — only call from `ConfirmQuit` screen. Direct exit.
+    pub fn confirm_quit(&mut self) {
+        self.screen = Screen::Quitting;
+    }
+
+    /// Legacy direct quit — kept for tests that exercise the terminal
+    /// state but no longer wired to a key. New code should call
+    /// [`Self::request_quit`] instead so the operator gets a confirmation.
+    #[cfg(test)]
     pub fn quit(&mut self) {
         self.screen = Screen::Quitting;
     }
@@ -555,6 +729,70 @@ mod tests {
         let mut s = AppState::new(vec![fake_iso("a")]);
         s.quit();
         assert_eq!(s.screen, Screen::Quitting);
+    }
+
+    // --- Tier 1 UX (#85) -----------------------------------------------
+
+    #[test]
+    fn request_quit_opens_confirm_overlay() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.request_quit();
+        assert!(matches!(s.screen, Screen::ConfirmQuit { .. }));
+    }
+
+    #[test]
+    fn cancel_quit_restores_prior_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.request_quit();
+        s.cancel_quit();
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+    }
+
+    #[test]
+    fn confirm_quit_exits() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.request_quit();
+        s.confirm_quit();
+        assert_eq!(s.screen, Screen::Quitting);
+    }
+
+    #[test]
+    fn open_help_overlays_prior_screen() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        s.move_selection(1);
+        s.open_help();
+        assert!(matches!(s.screen, Screen::Help { .. }));
+        s.close_help();
+        assert!(matches!(s.screen, Screen::List { selected: 1 }));
+    }
+
+    #[test]
+    fn move_to_first_jumps_to_zero() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
+        s.move_selection(2);
+        assert_eq!(s.screen, Screen::List { selected: 2 });
+        s.move_to_first();
+        assert_eq!(s.screen, Screen::List { selected: 0 });
+    }
+
+    #[test]
+    fn move_to_last_jumps_to_max() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
+        s.move_to_last();
+        assert_eq!(s.screen, Screen::List { selected: 2 });
+    }
+
+    #[test]
+    fn record_kexec_error_preserves_failed_selection() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
+        s.move_selection(1);
+        s.confirm_selection();
+        s.record_kexec_error(&KexecError::SignatureRejected);
+        match s.screen {
+            Screen::Error { return_to, .. } => assert_eq!(return_to, 1),
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
First tranche of the rescue-tui UX overhaul (#85). Synthesis of parallel-agent research on best-in-class boot pickers + TUIs. 7 new tests, 115 workspace tests total.