### PR TITLE
feat(rescue-tui): verify-now action with progress bar (#89)

### DIFF
--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 pub use iso_parser::{BootEntry, Distribution, IsoError};
 pub use minisign::{verify_iso_signature, SignatureVerification};
-pub use signature::{verify_iso_hash, HashVerification};
+pub use signature::{verify_iso_hash, verify_iso_hash_with_progress, HashVerification};
 
 /// Metadata for a single discovered ISO. Paths are relative to the (now
 /// unmounted) ISO root and become absolute once handed to [`prepare`].

--- a/crates/iso-probe/src/signature.rs
+++ b/crates/iso-probe/src/signature.rs
@@ -73,10 +73,30 @@ impl HashVerification {
 /// Returns [`std::io::Error`] on failure to read the ISO itself. Missing or
 /// unreadable sibling files are handled as `NotPresent`, not errors.
 pub fn verify_iso_hash(iso_path: &Path) -> std::io::Result<HashVerification> {
+    verify_iso_hash_with_progress(iso_path, |_, _| {})
+}
+
+/// Progress-reporting variant of [`verify_iso_hash`] for interactive
+/// operator-initiated re-verification (#89). Calls `on_progress(bytes_read,
+/// total_bytes)` periodically during the hash computation so the caller can
+/// render a progress bar. No guarantees on tick frequency — fast enough for
+/// a human-perceivable bar (~10 Hz on modern `NVMe`).
+///
+/// # Errors
+///
+/// Same as [`verify_iso_hash`].
+pub fn verify_iso_hash_with_progress<F>(
+    iso_path: &Path,
+    mut on_progress: F,
+) -> std::io::Result<HashVerification>
+where
+    F: FnMut(u64, u64),
+{
     let Some(expected) = find_expected_hash(iso_path) else {
         return Ok(HashVerification::NotPresent);
     };
-    let actual = sha256_of_file(iso_path)?;
+    let total = std::fs::metadata(iso_path).map(|m| m.len()).unwrap_or(0);
+    let actual = sha256_of_file_with_progress(iso_path, total, &mut on_progress)?;
     if actual == expected.hash.to_ascii_lowercase() {
         Ok(HashVerification::Verified {
             digest: actual,
@@ -163,18 +183,40 @@ fn is_sha256_hex(s: &str) -> bool {
     s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-fn sha256_of_file(path: &Path) -> std::io::Result<String> {
+/// Streaming SHA-256 with periodic callback into `on_progress(bytes_read,
+/// total)`. Tick rate capped at ~10 Hz so the callback doesn't dominate
+/// CPU on fast storage. (#89)
+fn sha256_of_file_with_progress(
+    path: &Path,
+    total: u64,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> std::io::Result<String> {
+    use std::time::{Duration, Instant};
     let file = File::open(path)?;
     let mut reader = BufReader::with_capacity(1 << 20, file);
     let mut hasher = Sha256::new();
-    let mut buf = [0u8; 8192];
+    // Heap-allocated 64 KiB buffer — too large to sit on the stack per
+    // clippy::large_stack_arrays.
+    let mut buf = vec![0u8; 65_536];
+    let mut bytes = 0u64;
+    let mut last_tick = Instant::now();
+    let tick_interval = Duration::from_millis(100);
+    // Emit an initial "starting" tick so the progress bar renders
+    // immediately on slow storage.
+    on_progress(0, total);
     loop {
         let n = reader.read(&mut buf)?;
         if n == 0 {
             break;
         }
         hasher.update(&buf[..n]);
+        bytes += n as u64;
+        if last_tick.elapsed() >= tick_interval {
+            on_progress(bytes, total);
+            last_tick = Instant::now();
+        }
     }
+    on_progress(bytes, total);
     Ok(hex::encode(hasher.finalize()))
 }
 

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -17,6 +17,8 @@ use std::env;
 use std::io;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread;
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -142,10 +144,18 @@ fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
     result
 }
 
+// Event loop is intentionally over the 100-line clippy threshold: the
+// screen-specific key handling lives here in one place, and splitting
+// it hurts readability more than the length.
+#[allow(clippy::too_many_lines)]
 fn event_loop<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     state: &mut AppState,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Active verify-now worker (#89). None when no verification is in
+    // flight; Some(rx) while the worker thread is streaming progress.
+    let mut active_verify: Option<Receiver<VerifyMsg>> = None;
+
     loop {
         terminal.draw(|f| render::draw(f, state))?;
 
@@ -153,13 +163,56 @@ fn event_loop<B: ratatui::backend::Backend>(
             return Ok(());
         }
 
-        if !event::poll(Duration::from_millis(250))? {
+        // Drain any pending verify-now progress / completion.
+        if let Some(rx) = active_verify.as_ref() {
+            loop {
+                match rx.try_recv() {
+                    Ok(VerifyMsg::Progress { bytes, total }) => {
+                        state.verify_tick(bytes, total);
+                    }
+                    Ok(VerifyMsg::Done(Ok(outcome))) => {
+                        state.verify_finish(outcome);
+                        active_verify = None;
+                        break;
+                    }
+                    Ok(VerifyMsg::Done(Err(e))) => {
+                        tracing::warn!(error = %e, "verify-now: worker failed");
+                        state.cancel_verify();
+                        active_verify = None;
+                        break;
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        active_verify = None;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Shorter poll timeout while verifying so the progress bar
+        // animates smoothly; 250ms is fine otherwise.
+        let poll = if active_verify.is_some() {
+            Duration::from_millis(50)
+        } else {
+            Duration::from_millis(250)
+        };
+        if !event::poll(poll)? {
             continue;
         }
         let Event::Key(key) = event::read()? else {
             continue;
         };
         if key.kind != KeyEventKind::Press {
+            continue;
+        }
+
+        // Verifying screen swallows all keys: Esc cancels, others no-op.
+        if matches!(state.screen, Screen::Verifying { .. }) {
+            if key.code == KeyCode::Esc {
+                state.cancel_verify();
+                active_verify = None;
+            }
             continue;
         }
 
@@ -228,6 +281,23 @@ fn event_loop<B: ratatui::backend::Backend>(
             }
             (Screen::List { .. }, KeyCode::Char('/')) => state.open_filter(),
             (Screen::List { .. }, KeyCode::Char('s')) => state.cycle_sort(),
+            (Screen::List { selected }, KeyCode::Char('v')) => {
+                if let Some(real_idx) = state.real_index(*selected) {
+                    if let Some(iso) = state.isos.get(real_idx) {
+                        let rx = spawn_verify_worker(iso.iso_path.clone());
+                        state.begin_verify(real_idx);
+                        active_verify = Some(rx);
+                    }
+                }
+            }
+            (Screen::Confirm { selected }, KeyCode::Char('v')) => {
+                let real_idx = *selected;
+                if let Some(iso) = state.isos.get(real_idx) {
+                    let rx = spawn_verify_worker(iso.iso_path.clone());
+                    state.begin_verify(real_idx);
+                    active_verify = Some(rx);
+                }
+            }
 
             (Screen::Confirm { .. }, KeyCode::Esc | KeyCode::Char('h')) => {
                 state.cancel_confirmation();
@@ -267,6 +337,37 @@ fn event_loop<B: ratatui::backend::Backend>(
 /// Find the first ISO whose path contains `needle` (substring match on the
 /// absolute path). Pure helper for `AEGIS_AUTO_KEXEC`; extracted for unit
 /// testing without spinning up QEMU. (#54)
+/// Message from the verify-now worker thread back to the event loop.
+/// The worker is fire-and-forget after cancel — the channel is dropped
+/// on the UI side and the thread exits when sends fail. (#89)
+#[derive(Debug)]
+enum VerifyMsg {
+    /// Incremental progress update.
+    Progress { bytes: u64, total: u64 },
+    /// Worker finished. Contains either the [`iso_probe::HashVerification`]
+    /// outcome (success path) or an I/O error.
+    Done(Result<iso_probe::HashVerification, String>),
+}
+
+/// Kick off a verify-now worker thread for the ISO at the given path.
+/// Returns the receiver end; caller installs it into `active_verify` so
+/// the event loop can poll. The thread runs sha256 with periodic
+/// progress ticks. (#89)
+fn spawn_verify_worker(iso_path: PathBuf) -> Receiver<VerifyMsg> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let tx_progress = tx.clone();
+        let result = iso_probe::verify_iso_hash_with_progress(&iso_path, |bytes, total| {
+            // Send is best-effort; drop errors when the UI side
+            // has cancelled and released its Receiver.
+            let _ = tx_progress.send(VerifyMsg::Progress { bytes, total });
+        });
+        let payload = result.map_err(|e| e.to_string());
+        let _ = tx.send(VerifyMsg::Done(payload));
+    });
+    rx
+}
+
 fn find_auto_kexec_target(isos: &[iso_probe::DiscoveredIso], needle: &str) -> Option<usize> {
     if needle.is_empty() {
         return None;

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
 
@@ -70,8 +70,97 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Screen::Error {
             message, remedy, ..
         } => draw_error(frame, area, message, remedy.as_deref()),
+        Screen::Verifying {
+            selected,
+            bytes,
+            total,
+            ..
+        } => draw_verifying(frame, area, state, *selected, *bytes, *total),
         Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => {}
     }
+}
+
+fn draw_verifying(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    selected: usize,
+    bytes: u64,
+    total: u64,
+) {
+    let Some(iso) = state.isos.get(selected) else {
+        return;
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(1),
+        ])
+        .split(area);
+    let (label_area, path_area, gauge_area, note_area) =
+        (chunks[0], chunks[1], chunks[2], chunks[3]);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                "Verifying:  ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(&iso.label),
+        ])),
+        label_area,
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                "ISO path:   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(iso.iso_path.display().to_string()),
+        ])),
+        path_area,
+    );
+
+    // Cast u64 → f64 for the ratio. Precision loss on the high bits is
+    // meaningless for a progress bar — we just need a 0..=1 value.
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = if total > 0 {
+        (bytes as f64 / total as f64).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    // Cast f64 → u16 for percent. Ratio is pre-clamped to [0, 1],
+    // so 100.0 * ratio ∈ [0, 100] — u16 cannot truncate or sign-flip.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let pct = (ratio * 100.0) as u16;
+    let label = if total > 0 {
+        format!(
+            "{pct}%   ({} / {})",
+            humanize_size(Some(bytes)),
+            humanize_size(Some(total))
+        )
+    } else {
+        "preparing…".to_string()
+    };
+    frame.render_widget(
+        Gauge::default()
+            .block(Block::default().borders(Borders::ALL).title(" SHA-256 "))
+            .gauge_style(Style::default().fg(state.theme.success))
+            .ratio(ratio)
+            .label(label),
+        gauge_area,
+    );
+
+    frame.render_widget(
+        Paragraph::new(
+            "Re-running hash verification against the ISO bytes on the\ndata partition. This is the same computation iso-probe ran at\ndiscovery time. Esc to cancel; the worker will finish in the\nbackground and the result will be discarded.",
+        )
+        .wrap(Wrap { trim: false }),
+        note_area,
+    );
 }
 
 fn draw_header(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -108,15 +197,16 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     } else {
         match effective {
             Screen::List { .. } => {
-                " [↑↓/jk] Move  [Enter] Boot  [/] Filter  [s] Sort  [?] Help  [q] Quit"
+                " [↑↓/jk] Move  [Enter] Boot  [/] Filter  [s] Sort  [v] Verify  [?] Help  [q] Quit"
             }
             Screen::Confirm { .. } => {
-                " [Enter] kexec  [e] Edit cmdline  [Esc/h] Back  [?] Help  [q] Quit"
+                " [Enter] kexec  [e] cmdline  [v] Verify  [Esc/h] Back  [?] Help  [q] Quit"
             }
             Screen::EditCmdline { .. } => {
                 " [Enter] Save  [Esc] Cancel  [←/→] Move  [Backspace] Delete"
             }
             Screen::Error { .. } => " Press any key to return to the list  ·  [q] Quit",
+            Screen::Verifying { .. } => " Verifying in background  ·  [Esc] Cancel",
             Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => "",
         }
     };
@@ -232,6 +322,7 @@ fn draw_help_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Line::from("   Enter / l     confirm selection"),
         Line::from("   /             open filter (substring match)"),
         Line::from("   s             cycle sort: name → size → distro"),
+        Line::from("   v             verify now (re-run SHA-256 with progress)"),
         Line::from(""),
         Line::from(" Confirm screen"),
         Line::from("   Enter         kexec into the ISO"),

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -54,6 +54,20 @@ pub enum Screen {
         /// Boxed screen to restore on cancel.
         prior: Box<Screen>,
     },
+    /// Verify-now action (#89) — a worker thread streams progress
+    /// while re-running hash verification against the selected ISO.
+    Verifying {
+        /// Real ISO index (not visible-view index) being verified.
+        selected: usize,
+        /// Bytes hashed so far.
+        bytes: u64,
+        /// Total bytes to hash (0 if unknown).
+        total: u64,
+        /// Populated when the worker finishes — caller then updates
+        /// the ISO's verification fields in place and dismisses the
+        /// screen.
+        result: Option<HashVerification>,
+    },
     /// User asked to quit; main loop should exit cleanly.
     Quitting,
 }
@@ -565,6 +579,50 @@ impl AppState {
         }
     }
 
+    /// Open the Verifying screen for the ISO at real index `idx`.
+    /// Caller (main.rs) spawns the worker thread that will feed
+    /// progress ticks via [`Self::verify_tick`] and completion via
+    /// [`Self::verify_finish`]. (#89)
+    pub fn begin_verify(&mut self, idx: usize) {
+        if self.isos.get(idx).is_some() {
+            self.screen = Screen::Verifying {
+                selected: idx,
+                bytes: 0,
+                total: 0,
+                result: None,
+            };
+        }
+    }
+
+    /// Progress update from the verify worker.
+    pub fn verify_tick(&mut self, new_bytes: u64, new_total: u64) {
+        if let Screen::Verifying { bytes, total, .. } = &mut self.screen {
+            *bytes = new_bytes;
+            *total = new_total;
+        }
+    }
+
+    /// Worker finished. Update the ISO's `hash_verification` in place
+    /// and transition back to the Confirm screen on the same ISO so
+    /// the operator sees the refreshed verdict. (#89)
+    pub fn verify_finish(&mut self, outcome: HashVerification) {
+        if let Screen::Verifying { selected, .. } = self.screen {
+            if let Some(iso) = self.isos.get_mut(selected) {
+                iso.hash_verification = outcome;
+            }
+            self.screen = Screen::Confirm { selected };
+        }
+    }
+
+    /// Cancel an in-progress verification (Esc). Dismisses the
+    /// Verifying screen without updating the iso. The worker thread
+    /// continues in the background; its result is discarded.
+    pub fn cancel_verify(&mut self) {
+        if let Screen::Verifying { selected, .. } = self.screen {
+            self.screen = Screen::Confirm { selected };
+        }
+    }
+
     /// Confirm exit — only call from `ConfirmQuit` screen. Direct exit.
     pub fn confirm_quit(&mut self) {
         self.screen = Screen::Quitting;
@@ -1029,6 +1087,59 @@ mod tests {
         s.filter = "debian".to_string();
         s.confirm_selection();
         assert_eq!(s.screen, Screen::Confirm { selected: 1 });
+    }
+
+    // --- verify-now (#89) ---------------------------------------------
+
+    #[test]
+    fn begin_verify_opens_verifying_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.begin_verify(0);
+        assert!(matches!(
+            s.screen,
+            Screen::Verifying {
+                selected: 0,
+                bytes: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn verify_tick_updates_progress() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.begin_verify(0);
+        s.verify_tick(1024, 4096);
+        match s.screen {
+            Screen::Verifying { bytes, total, .. } => {
+                assert_eq!(bytes, 1024);
+                assert_eq!(total, 4096);
+            }
+            _ => panic!("expected Verifying"),
+        }
+    }
+
+    #[test]
+    fn verify_finish_updates_iso_and_returns_to_confirm() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.begin_verify(0);
+        let outcome = HashVerification::Verified {
+            digest: "abc123".to_string(),
+            source: "fake".to_string(),
+        };
+        s.verify_finish(outcome.clone());
+        assert_eq!(s.isos[0].hash_verification, outcome);
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+    }
+
+    #[test]
+    fn cancel_verify_returns_to_confirm_without_updating_iso() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        let original = s.isos[0].hash_verification.clone();
+        s.begin_verify(0);
+        s.cancel_verify();
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+        assert_eq!(s.isos[0].hash_verification, original);
     }
 
     #[test]


### PR DESCRIPTION
Closes #89. Operator presses `v` to re-run SHA-256 with a Gauge progress bar, cancellable via Esc. Worker thread + mpsc. 126 tests (was 123).