### PR TITLE
feat(rescue-tui): rescue-shell entry + typed trust confirmation (#90, #93)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> ExitCode {
     tracing_subscriber_init();
     let roots = parse_roots(env::var("AEGIS_ISO_ROOTS").ok().as_deref());
     match run(&roots) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(code) => ExitCode::from(code),
         Err(e) => {
             eprintln!("rescue-tui: {e}");
             ExitCode::from(1)
@@ -75,7 +75,7 @@ fn parse_roots(env_var: Option<&str>) -> Vec<PathBuf> {
     }
 }
 
-fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
+fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         roots = ?roots,
@@ -126,7 +126,7 @@ fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
     // support CI end-to-end testing without a TTY. Real operator automation
     // should live outside the TUI binary.
     if let Ok(needle) = env::var("AEGIS_AUTO_KEXEC") {
-        return run_auto_kexec(&state, &needle);
+        return run_auto_kexec(&state, &needle).map(|()| 0u8);
     }
 
     enable_raw_mode()?;
@@ -135,13 +135,22 @@ fn run(roots: &[PathBuf]) -> Result<(), Box<dyn std::error::Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = event_loop(&mut terminal, &mut state);
+    let loop_result = event_loop(&mut terminal, &mut state);
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
 
-    result
+    loop_result?;
+
+    // #90: if the operator selected the rescue-shell entry, signal
+    // that to /init via the exit code. Otherwise ordinary quit.
+    if state.shell_requested {
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        Ok(crate::state::RESCUE_SHELL_EXIT_CODE as u8)
+    } else {
+        Ok(0)
+    }
 }
 
 // Event loop is intentionally over the 100-line clippy threshold: the
@@ -277,7 +286,22 @@ fn event_loop<B: ratatui::backend::Backend>(
             (Screen::List { .. }, KeyCode::Char('g')) => state.move_to_first(),
             (Screen::List { .. }, KeyCode::Char('G')) => state.move_to_last(),
             (Screen::List { .. }, KeyCode::Enter | KeyCode::Char('l')) => {
-                state.confirm_selection();
+                if state.is_shell_selected() {
+                    // #90: rescue shell picked. Signal the shell-drop
+                    // exit path; run() will propagate the sentinel
+                    // code so /init can exec /bin/sh.
+                    tracing::info!(
+                        "operator selected rescue shell — exiting with code {}",
+                        crate::state::RESCUE_SHELL_EXIT_CODE
+                    );
+                    state.shell_requested = true;
+                    // Direct exit — no confirmation prompt needed;
+                    // the operator already picked the shell
+                    // explicitly.
+                    state.confirm_quit();
+                } else {
+                    state.confirm_selection();
+                }
             }
             (Screen::List { .. }, KeyCode::Char('/')) => state.open_filter(),
             (Screen::List { .. }, KeyCode::Char('s')) => state.cycle_sort(),
@@ -311,9 +335,29 @@ fn event_loop<B: ratatui::backend::Backend>(
                         "rescue-tui: refused kexec — ISO is kexec-blocked (quirk or verification failure)"
                     );
                     state.record_kexec_error(&kexec_loader::KexecError::UnsupportedImage);
+                } else if state.is_degraded_trust(idx) {
+                    // #93: YELLOW/GRAY verdict → require typing "boot".
+                    state.enter_trust_challenge(idx);
                 } else {
                     attempt_kexec(state, idx);
                 }
+            }
+
+            // Trust challenge (#93): Enter only fires kexec if the
+            // buffer equals "boot" — otherwise ignored. Backspace /
+            // characters edit the buffer; Esc cancels.
+            (Screen::TrustChallenge { selected, buffer }, KeyCode::Enter) => {
+                let idx = *selected;
+                if buffer == "boot" {
+                    attempt_kexec(state, idx);
+                }
+            }
+            (Screen::TrustChallenge { .. }, KeyCode::Esc) => state.trust_challenge_cancel(),
+            (Screen::TrustChallenge { .. }, KeyCode::Backspace) => {
+                state.trust_challenge_backspace();
+            }
+            (Screen::TrustChallenge { .. }, KeyCode::Char(c)) => {
+                state.trust_challenge_push(c);
             }
 
             (Screen::EditCmdline { .. }, KeyCode::Enter) => state.commit_cmdline_edit(),

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -76,8 +76,75 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
             total,
             ..
         } => draw_verifying(frame, area, state, *selected, *bytes, *total),
+        Screen::TrustChallenge { selected, buffer } => {
+            draw_trust_challenge(frame, area, state, *selected, buffer);
+        }
         Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => {}
     }
+}
+
+fn draw_trust_challenge(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    selected: usize,
+    buffer: &str,
+) {
+    let Some(iso) = state.isos.get(selected) else {
+        return;
+    };
+    let verdict = trust_verdict(iso);
+    let lines = vec![
+        Line::from(Span::styled(
+            "Degraded trust — typed confirmation required",
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .fg(state.theme.warning),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Verdict: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                verdict.label(),
+                Style::default().fg(verdict.color(&state.theme)),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("ISO:     ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(iso.iso_path.display().to_string()),
+        ]),
+        Line::from(""),
+        Line::from("This ISO lacks a verified signature in AEGIS_TRUSTED_KEYS, or has no"),
+        Line::from("sidecar checksum/.minisig. Booting it is a trust decision."),
+        Line::from(""),
+        Line::from("To proceed, type the word below exactly then press Enter."),
+        Line::from("Esc cancels."),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Type: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "boot",
+                Style::default()
+                    .fg(state.theme.error)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("You:  ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(buffer),
+            Span::styled("│", Style::default().add_modifier(Modifier::SLOW_BLINK)),
+        ]),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Trust challenge (#93) "),
+            )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
 }
 
 fn draw_verifying(
@@ -207,6 +274,7 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
             }
             Screen::Error { .. } => " Press any key to return to the list  ·  [q] Quit",
             Screen::Verifying { .. } => " Verifying in background  ·  [Esc] Cancel",
+            Screen::TrustChallenge { .. } => " Type `boot` + Enter to proceed  ·  [Esc] Cancel",
             Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => "",
         }
     };
@@ -384,6 +452,7 @@ fn draw_confirm_quit_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState
 }
 
 fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
+    use crate::state::ViewEntry;
     if state.isos.is_empty() {
         let empty = Paragraph::new(
             "No bootable ISOs found.\n\nPress q to quit, or check that AEGIS_ISO_ROOTS\npoints at a directory containing .iso files.",
@@ -420,48 +489,58 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
     };
     frame.render_widget(Paragraph::new(info_line), info_area);
 
-    let view = state.visible_indices();
-    if view.is_empty() {
-        let msg = format!(
-            "No ISOs match filter \"{}\".\nPress / to edit or Esc to clear.",
-            state.filter
-        );
-        let p = Paragraph::new(msg).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" aegis-boot — no matches "),
-        );
-        frame.render_widget(p, list_area);
-        return;
-    }
-
-    let items: Vec<ListItem> = view
+    // Full entries view includes the rescue-shell synthetic row at
+    // the end, even when the ISO list is empty (#90).
+    let entries = state.visible_entries();
+    let iso_entries: Vec<usize> = entries
         .iter()
-        .map(|&i| {
-            let iso = &state.isos[i];
-            let glyph = status_glyph(iso);
-            let qs = quirks_summary(iso);
-            let line = if qs.is_empty() {
-                format!("{glyph} {}  ({})", iso.label, iso.distribution_name())
+        .filter_map(|e| {
+            if let ViewEntry::Iso(i) = e {
+                Some(*i)
             } else {
-                format!("{glyph} {}  ({})  {qs}", iso.label, iso.distribution_name())
-            };
-            ListItem::new(line)
+                None
+            }
         })
         .collect();
 
-    let title = format!(
-        " aegis-boot — pick an ISO ({}/{} shown) ",
-        view.len(),
-        state.isos.len()
-    );
+    let items: Vec<ListItem> = entries
+        .iter()
+        .map(|e| match e {
+            ViewEntry::Iso(i) => {
+                let iso = &state.isos[*i];
+                let glyph = status_glyph(iso);
+                let qs = quirks_summary(iso);
+                let line = if qs.is_empty() {
+                    format!("{glyph} {}  ({})", iso.label, iso.distribution_name())
+                } else {
+                    format!("{glyph} {}  ({})  {qs}", iso.label, iso.distribution_name())
+                };
+                ListItem::new(line)
+            }
+            ViewEntry::RescueShell => {
+                ListItem::new("[#] rescue shell (busybox)  — dropped from rescue-tui")
+            }
+        })
+        .collect();
+
+    let title = if iso_entries.is_empty() && state.filter.is_empty() {
+        " aegis-boot — no ISOs; shell available ".to_string()
+    } else if iso_entries.is_empty() {
+        format!(" aegis-boot — no matches for \"{}\" ", state.filter)
+    } else {
+        format!(
+            " aegis-boot — pick an ISO ({}/{} shown, +shell) ",
+            iso_entries.len(),
+            state.isos.len()
+        )
+    };
     let list = List::new(items)
         .block(Block::default().borders(Borders::ALL).title(title))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();
-    let cursor = selected.min(view.len().saturating_sub(1));
+    let cursor = selected.min(entries.len().saturating_sub(1));
     list_state.select(Some(cursor));
     frame.render_stateful_widget(list, list_area, &mut list_state);
 }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -54,6 +54,18 @@ pub enum Screen {
         /// Boxed screen to restore on cancel.
         prior: Box<Screen>,
     },
+    /// Typed-confirmation challenge before kexec'ing an ISO whose
+    /// trust state is degraded (YELLOW untrusted signer, GRAY no
+    /// verification material). Operator must type `boot` exactly to
+    /// continue — prevents muscle-memory Enter on a warned state.
+    /// SSH first-connect / HSTS / Gatekeeper "type the app name"
+    /// pattern. (#93)
+    TrustChallenge {
+        /// Real ISO index being kexec'd.
+        selected: usize,
+        /// Current input buffer (characters typed so far).
+        buffer: String,
+    },
     /// Verify-now action (#89) — a worker thread streams progress
     /// while re-running hash verification against the selected ISO.
     Verifying {
@@ -90,6 +102,10 @@ pub struct AppState {
     /// TPM availability, detected once at startup. Rendered in the
     /// persistent header banner. (#85)
     pub tpm: TpmStatus,
+    /// Set when the operator picked the rescue-shell entry (#90).
+    /// Causes `main.rs::run()` to exit with [`RESCUE_SHELL_EXIT_CODE`]
+    /// so the initramfs `/init` script can drop to busybox.
+    pub shell_requested: bool,
     /// Active substring filter on the List screen (#85 Tier 2).
     /// Empty means show all ISOs. Matches against label + path,
     /// case-insensitive.
@@ -113,6 +129,25 @@ pub enum SortOrder {
     /// Group by distribution family.
     Distro,
 }
+
+/// An entry displayed on the List screen. Includes discovered ISOs
+/// (by real index) and synthetic entries like the always-present
+/// rescue shell (#90).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewEntry {
+    /// Real ISO at this index into [`AppState::isos`].
+    Iso(usize),
+    /// Synthetic "drop to rescue shell" entry (#90). Selecting it
+    /// exits rescue-tui with [`RESCUE_SHELL_EXIT_CODE`] so the
+    /// initramfs `/init` can recognize the operator request and
+    /// `exec /bin/sh`.
+    RescueShell,
+}
+
+/// Exit code rescue-tui returns when the operator picks the synthetic
+/// "rescue shell" entry. `/init` switches on this value and drops to
+/// busybox instead of treating the exit as an error. (#90)
+pub const RESCUE_SHELL_EXIT_CODE: i32 = 42;
 
 impl SortOrder {
     /// Cycle to the next sort order.
@@ -225,16 +260,40 @@ impl AppState {
             theme: Theme::default_theme(),
             secure_boot: SecureBootStatus::detect(),
             tpm: TpmStatus::detect(),
+            shell_requested: false,
             filter: String::new(),
             filter_editing: false,
             sort_order: SortOrder::Name,
         }
     }
 
+    /// Ordered list of entries displayed on the List screen (#90).
+    /// Mix of [`ViewEntry::Iso`] (one per filter-matching ISO in sort
+    /// order) followed by the synthetic [`ViewEntry::RescueShell`] at
+    /// the end. The rescue-shell entry is always present — even when
+    /// no ISOs are discovered — so operators always have an escape
+    /// hatch to a signed busybox shell.
+    #[must_use]
+    pub fn visible_entries(&self) -> Vec<ViewEntry> {
+        let mut entries: Vec<ViewEntry> = self
+            .visible_indices()
+            .into_iter()
+            .map(ViewEntry::Iso)
+            .collect();
+        entries.push(ViewEntry::RescueShell);
+        entries
+    }
+
+    /// Translate a List-cursor position to the selected [`ViewEntry`].
+    #[must_use]
+    pub fn view_entry(&self, cursor: usize) -> Option<ViewEntry> {
+        self.visible_entries().into_iter().nth(cursor)
+    }
+
     /// Indices into [`Self::isos`] in display order — applies both the
-    /// substring filter and the active sort. Selection cursor on the
-    /// List screen indexes INTO this view, not directly into `isos`.
-    /// (#85 Tier 2)
+    /// substring filter and the active sort. This is the ISO-only view
+    /// (no rescue-shell entry). Use [`Self::visible_entries`] when
+    /// rendering or navigating. (#85 Tier 2)
     #[must_use]
     pub fn visible_indices(&self) -> Vec<usize> {
         let needle = self.filter.to_ascii_lowercase();
@@ -455,9 +514,12 @@ impl AppState {
         *cursor = new_cursor;
     }
 
-    /// Jump to the first visible row (vim `g`). (#85)
+    /// Jump to the first visible row (vim `g`). (#85). The visible
+    /// view always has at least one row (the rescue-shell entry
+    /// since #90), so the `has_view` check is trivially true — kept
+    /// for defence in depth in case that invariant ever changes.
     pub fn move_to_first(&mut self) {
-        let has_view = !self.visible_indices().is_empty();
+        let has_view = !self.visible_entries().is_empty();
         if let Screen::List { selected } = &mut self.screen {
             if has_view {
                 *selected = 0;
@@ -465,9 +527,10 @@ impl AppState {
         }
     }
 
-    /// Jump to the last visible row (vim `G`). (#85)
+    /// Jump to the last visible row (vim `G`). With #90 the last row
+    /// is always the rescue-shell entry.
     pub fn move_to_last(&mut self) {
-        let view_len = self.visible_indices().len();
+        let view_len = self.visible_entries().len();
         if let Screen::List { selected } = &mut self.screen {
             if view_len > 0 {
                 *selected = view_len - 1;
@@ -476,10 +539,10 @@ impl AppState {
     }
 
     /// Advance the visible cursor up (negative) or down (positive),
-    /// saturating at the visible-list bounds. With Tier 2 filter+sort,
-    /// `selected` indexes the visible view (#85), not raw `isos`.
+    /// saturating at the visible-list bounds. Cursor indexes the full
+    /// entries list (ISOs + rescue shell), not just ISOs (#85, #90).
     pub fn move_selection(&mut self, delta: i32) {
-        let view_len = self.visible_indices().len();
+        let view_len = self.visible_entries().len();
         let Screen::List { selected } = &mut self.screen else {
             return;
         };
@@ -496,26 +559,40 @@ impl AppState {
         }
     }
 
-    /// Transition list → confirm for the highlighted ISO. The cursor on
-    /// List indexes the visible view; we translate to the real iso
-    /// index here so downstream screens see the canonical id.
+    /// Transition list → confirm for the highlighted ISO. The cursor
+    /// on List indexes the full entries view (ISOs + rescue shell);
+    /// ISO selections route to Confirm, shell selections are handled
+    /// by [`Self::is_shell_selected`] (main.rs exits with
+    /// [`RESCUE_SHELL_EXIT_CODE`] in that case).
     pub fn confirm_selection(&mut self) {
         if let Screen::List { selected } = self.screen {
-            if let Some(real) = self.real_index(selected) {
+            if let Some(ViewEntry::Iso(real)) = self.view_entry(selected) {
                 self.screen = Screen::Confirm { selected: real };
             }
         }
     }
 
+    /// Whether the List cursor currently highlights the synthetic
+    /// rescue-shell entry. main.rs uses this to branch on Enter. (#90)
+    #[must_use]
+    pub fn is_shell_selected(&self) -> bool {
+        if let Screen::List { selected } = self.screen {
+            matches!(self.view_entry(selected), Some(ViewEntry::RescueShell))
+        } else {
+            false
+        }
+    }
+
     /// Transition confirm → list (cancel). Maps the real ISO index
-    /// back to its position in the current visible view (or 0 if it's
-    /// no longer visible — e.g. filter changed).
+    /// back to its cursor position in the current entries view (ISO
+    /// entries + rescue shell, #90). Falls back to 0 if the ISO is
+    /// no longer visible (e.g. filter changed).
     pub fn cancel_confirmation(&mut self) {
         if let Screen::Confirm { selected } = self.screen {
             let cursor = self
-                .visible_indices()
+                .visible_entries()
                 .iter()
-                .position(|&i| i == selected)
+                .position(|e| matches!(e, ViewEntry::Iso(i) if *i == selected))
                 .unwrap_or(0);
             self.screen = Screen::List { selected: cursor };
         }
@@ -576,6 +653,58 @@ impl AppState {
         if let Screen::ConfirmQuit { prior } = std::mem::replace(&mut self.screen, Screen::Quitting)
         {
             self.screen = *prior;
+        }
+    }
+
+    /// Coarse trust classification for the Confirm screen's verdict
+    /// line AND for deciding whether [`Self::enter_trust_challenge`]
+    /// fires before a kexec. Mirrors the `TrustVerdict` enum in
+    /// render.rs but kept here so state-machine tests don't need to
+    /// depend on the UI layer. (#93)
+    #[must_use]
+    pub fn is_degraded_trust(&self, idx: usize) -> bool {
+        let Some(iso) = self.isos.get(idx) else {
+            return false;
+        };
+        // GREEN if hash OR signature is verified.
+        let verified = matches!(
+            iso.signature_verification,
+            SignatureVerification::Verified { .. }
+        ) || matches!(iso.hash_verification, HashVerification::Verified { .. });
+        !verified
+    }
+
+    /// Enter the typed-confirmation challenge screen for a degraded
+    /// trust state. (#93)
+    pub fn enter_trust_challenge(&mut self, idx: usize) {
+        self.screen = Screen::TrustChallenge {
+            selected: idx,
+            buffer: String::new(),
+        };
+    }
+
+    /// Character entry for the trust challenge. Returns true iff the
+    /// buffer now equals the expected token "boot" — caller then
+    /// proceeds to kexec.
+    pub fn trust_challenge_push(&mut self, c: char) -> bool {
+        if let Screen::TrustChallenge { buffer, .. } = &mut self.screen {
+            buffer.push(c);
+            return buffer == "boot";
+        }
+        false
+    }
+
+    /// Backspace in the trust challenge buffer.
+    pub fn trust_challenge_backspace(&mut self) {
+        if let Screen::TrustChallenge { buffer, .. } = &mut self.screen {
+            buffer.pop();
+        }
+    }
+
+    /// Cancel the trust challenge and return to Confirm.
+    pub fn trust_challenge_cancel(&mut self) {
+        if let Screen::TrustChallenge { selected, .. } = self.screen {
+            self.screen = Screen::Confirm { selected };
         }
     }
 
@@ -821,11 +950,12 @@ mod tests {
 
     #[test]
     fn movement_clamps_at_bounds() {
+        // 3 ISOs + 1 rescue-shell row = 4 entries; max cursor = 3.
         let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
         s.move_selection(-5);
         assert_eq!(s.screen, Screen::List { selected: 0 });
         s.move_selection(99);
-        assert_eq!(s.screen, Screen::List { selected: 2 });
+        assert_eq!(s.screen, Screen::List { selected: 3 });
     }
 
     #[test]
@@ -997,9 +1127,10 @@ mod tests {
 
     #[test]
     fn move_to_last_jumps_to_max() {
+        // 3 ISOs + 1 rescue-shell row = last cursor is 3.
         let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
         s.move_to_last();
-        assert_eq!(s.screen, Screen::List { selected: 2 });
+        assert_eq!(s.screen, Screen::List { selected: 3 });
     }
 
     #[test]
@@ -1087,6 +1218,109 @@ mod tests {
         s.filter = "debian".to_string();
         s.confirm_selection();
         assert_eq!(s.screen, Screen::Confirm { selected: 1 });
+    }
+
+    // --- rescue-shell entry (#90) -------------------------------------
+
+    #[test]
+    fn rescue_shell_entry_always_last_even_with_no_isos() {
+        let s = AppState::new(vec![]);
+        let entries = s.visible_entries();
+        assert_eq!(entries, vec![ViewEntry::RescueShell]);
+    }
+
+    #[test]
+    fn rescue_shell_entry_appended_after_isos() {
+        let s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        let entries = s.visible_entries();
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(entries[2], ViewEntry::RescueShell));
+    }
+
+    #[test]
+    fn rescue_shell_entry_survives_filter_with_no_iso_matches() {
+        let mut s = AppState::new(vec![fake_iso("ubuntu")]);
+        s.filter = "nope".to_string();
+        assert_eq!(s.visible_entries(), vec![ViewEntry::RescueShell]);
+    }
+
+    #[test]
+    fn is_shell_selected_true_when_cursor_on_shell_row() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.move_to_last();
+        assert!(s.is_shell_selected());
+    }
+
+    #[test]
+    fn is_shell_selected_false_when_cursor_on_iso_row() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.move_to_first();
+        assert!(!s.is_shell_selected());
+    }
+
+    // --- typed trust challenge (#93) ----------------------------------
+
+    #[test]
+    fn enter_trust_challenge_opens_screen_with_empty_buffer() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_trust_challenge(0);
+        assert!(matches!(
+            s.screen,
+            Screen::TrustChallenge {
+                selected: 0,
+                ref buffer,
+            } if buffer.is_empty()
+        ));
+    }
+
+    #[test]
+    fn trust_challenge_push_returns_true_at_boot_string() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_trust_challenge(0);
+        assert!(!s.trust_challenge_push('b'));
+        assert!(!s.trust_challenge_push('o'));
+        assert!(!s.trust_challenge_push('o'));
+        assert!(s.trust_challenge_push('t'));
+    }
+
+    #[test]
+    fn trust_challenge_backspace_rolls_back() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_trust_challenge(0);
+        s.trust_challenge_push('b');
+        s.trust_challenge_push('x');
+        s.trust_challenge_backspace();
+        // 'b' alone is not "boot" yet.
+        assert!(!matches!(
+            &s.screen,
+            Screen::TrustChallenge { buffer, .. } if buffer == "boot"
+        ));
+    }
+
+    #[test]
+    fn trust_challenge_cancel_returns_to_confirm() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_trust_challenge(0);
+        s.trust_challenge_cancel();
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+    }
+
+    #[test]
+    fn is_degraded_trust_true_when_no_verification() {
+        let s = AppState::new(vec![fake_iso("a")]);
+        // fake_iso() has NotPresent for both hash and sig → degraded.
+        assert!(s.is_degraded_trust(0));
+    }
+
+    #[test]
+    fn is_degraded_trust_false_when_hash_verified() {
+        let mut iso = fake_iso("a");
+        iso.hash_verification = HashVerification::Verified {
+            digest: "abc".to_string(),
+            source: "/x".to_string(),
+        };
+        let s = AppState::new(vec![iso]);
+        assert!(!s.is_degraded_trust(0));
     }
 
     // --- verify-now (#89) ---------------------------------------------

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -471,14 +471,19 @@ fi
 
 export TERM=linux
 
-# Hand off. On clean quit, drop to a shell so the user isn't staring at
-# a kernel panic.
-/usr/bin/rescue-tui || {
-    /bin/echo "rescue-tui exited; dropping to emergency shell"
-    exec /bin/sh
-}
-
-# rescue-tui returned without error (unusual — kexec would have replaced us).
+# Hand off. Exit code semantics (#90):
+#   0        — operator chose Quit → drop to emergency shell (old default)
+#   42       — operator chose the rescue-shell entry explicitly
+#   anything — crash / unclean exit → emergency shell
+# All paths land in /bin/sh; the different branches only differ in the
+# banner so an operator reading the serial log can tell which happened.
+/usr/bin/rescue-tui
+rc=$?
+case "$rc" in
+    0)   /bin/echo "init: rescue-tui quit cleanly; dropping to emergency shell" ;;
+    42)  /bin/echo "init: rescue shell requested by operator (#90)" ;;
+    *)   /bin/echo "init: rescue-tui exited unexpectedly (rc=$rc); dropping to emergency shell" ;;
+esac
 exec /bin/sh
 INIT_SH
 chmod 0755 "$STAGE_DIR/init"


### PR DESCRIPTION
Closes #90 and part of #93. Always-present [#] rescue-shell row on List (exit code 42 sentinel → /init drops to /bin/sh). Typed 'boot' challenge before kexec on YELLOW/GRAY trust verdicts. 141 tests (was 126).