### PR TITLE
feat(rescue-tui): one-frame error + F10 save-log (#92)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -367,6 +367,25 @@ fn event_loop<B: ratatui::backend::Backend>(
             (Screen::EditCmdline { .. }, KeyCode::Backspace) => state.cmdline_backspace(),
             (Screen::EditCmdline { .. }, KeyCode::Char(c)) => state.cmdline_insert(c),
 
+            // F10 on Error → tee the one-frame evidence to
+            // /run/media/aegis-isos/aegis-log-<ts>.txt so the
+            // operator can pull it off the stick from any machine
+            // after reboot. rEFInd log-on-ESP pattern. (#92)
+            (Screen::Error { .. }, KeyCode::F(10)) => {
+                if let Some(text) = state.error_evidence_text() {
+                    match save_error_log(&text) {
+                        Ok(path) => tracing::info!(
+                            path = %path.display(),
+                            "operator saved error evidence via F10"
+                        ),
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "F10 save-log failed (continuing)"
+                        ),
+                    }
+                }
+            }
+
             // Error → return to List, preserving the ISO that failed
             // so the operator doesn't have to re-navigate. (#85)
             (Screen::Error { return_to, .. }, _) => {
@@ -378,9 +397,36 @@ fn event_loop<B: ratatui::backend::Backend>(
     }
 }
 
-/// Find the first ISO whose path contains `needle` (substring match on the
-/// absolute path). Pure helper for `AEGIS_AUTO_KEXEC`; extracted for unit
-/// testing without spinning up QEMU. (#54)
+/// Write an error-screen evidence snapshot to the `AEGIS_ISOS` data
+/// partition so the operator can retrieve it after reboot. Best-effort
+/// — returns the path on success, an error message on failure.
+/// Location: first writable directory in `[/run/media/aegis-isos,
+/// /tmp]` with a timestamped filename. (#92)
+fn save_error_log(text: &str) -> Result<PathBuf, String> {
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_secs();
+    let filename = format!("aegis-log-{ts}.txt");
+    for dir in ["/run/media/aegis-isos", "/tmp"] {
+        let dir_path = std::path::Path::new(dir);
+        if !dir_path.is_dir() {
+            continue;
+        }
+        let out = dir_path.join(&filename);
+        let Ok(mut f) = std::fs::File::create(&out) else {
+            continue;
+        };
+        if f.write_all(text.as_bytes()).is_err() {
+            continue;
+        }
+        return Ok(out);
+    }
+    Err("no writable target (tried /run/media/aegis-isos, /tmp)".into())
+}
+
 /// Message from the verify-now worker thread back to the event loop.
 /// The worker is fire-and-forget after cancel — the channel is dropped
 /// on the UI side and the thread exits when sends fail. (#89)

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -68,8 +68,10 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
             cursor,
         } => draw_edit_cmdline(frame, area, state, *selected, buffer, *cursor),
         Screen::Error {
-            message, remedy, ..
-        } => draw_error(frame, area, message, remedy.as_deref()),
+            message,
+            remedy,
+            return_to,
+        } => draw_error(frame, area, state, *return_to, message, remedy.as_deref()),
         Screen::Verifying {
             selected,
             bytes,
@@ -272,7 +274,9 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
             Screen::EditCmdline { .. } => {
                 " [Enter] Save  [Esc] Cancel  [←/→] Move  [Backspace] Delete"
             }
-            Screen::Error { .. } => " Press any key to return to the list  ·  [q] Quit",
+            Screen::Error { .. } => {
+                " [F10] Save evidence to AEGIS_ISOS  ·  any key = back  ·  [q] Quit"
+            }
             Screen::Verifying { .. } => " Verifying in background  ·  [Esc] Cancel",
             Screen::TrustChallenge { .. } => " Type `boot` + Enter to proceed  ·  [Esc] Cancel",
             Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => "",
@@ -771,29 +775,140 @@ fn humanize_size(bytes: Option<u64>) -> String {
     }
 }
 
-fn draw_error(frame: &mut Frame<'_>, area: Rect, message: &str, remedy: Option<&str>) {
+// memtest86+ single-frame evidence: a screenshot of this panel should
+// be a complete bug report — no external context needed. (#92)
+#[allow(clippy::too_many_lines)]
+fn draw_error(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    return_to: usize,
+    message: &str,
+    remedy: Option<&str>,
+) {
+    let iso = state.isos.get(return_to);
+    let cmdline = state.effective_cmdline(return_to);
+    let measurement_hex = iso
+        .map(|i| hex::encode(crate::tpm::compute_measurement(&i.iso_path, &cmdline)))
+        .unwrap_or_default();
+
     let mut lines = vec![
-        Line::from(vec![Span::styled(
-            "kexec failed",
-            Style::default().add_modifier(Modifier::BOLD),
-        )]),
+        Line::from(Span::styled(
+            "kexec failed — capture this screen for bug reports",
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .fg(state.theme.error),
+        )),
         Line::from(""),
-        Line::from(message.to_string()),
+        Line::from(vec![
+            Span::styled(
+                "Diagnostic: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(message.to_string()),
+        ]),
     ];
     if let Some(r) = remedy {
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![Span::styled(
-            "Remedy:",
-            Style::default().add_modifier(Modifier::BOLD),
-        )]));
-        lines.push(Line::from(r.to_string()));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Remedy:     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(r.to_string()),
+        ]));
     }
+
+    // Evidence block — only if we have an ISO context.
+    if let Some(iso) = iso {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "── Evidence (memtest-style; one frame = one bug report) ──",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Version:    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!("aegis-boot v{}", env!("CARGO_PKG_VERSION"))),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "SB / TPM:   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(
+                "{}  ·  {}",
+                state.secure_boot.summary(),
+                state.tpm.summary()
+            )),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "ISO label:  ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(iso.label.clone()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "ISO path:   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(iso.iso_path.display().to_string()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Size:       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(humanize_size(iso.size_bytes)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Distro:     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(iso.distribution_name().to_string()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Verdict:    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(trust_verdict(iso).label().to_string()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Cmdline:    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(if cmdline.is_empty() {
+                "(none)".to_string()
+            } else {
+                cmdline
+            }),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "Measured:   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!("sha256:{measurement_hex}")),
+        ]));
+    }
+
     lines.push(Line::from(""));
-    lines.push(Line::from(
-        "Press q to quit, any other key to return to the list.",
-    ));
+    lines.push(Line::from(Span::styled(
+        "F10 = save log to AEGIS_ISOS  ·  any key = back to list  ·  q = quit",
+        Style::default().fg(state.theme.warning),
+    )));
     let para = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL).title("Error"))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" kexec error "),
+        )
         .wrap(Wrap { trim: false });
     frame.render_widget(para, area);
 }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -743,6 +743,54 @@ impl AppState {
         }
     }
 
+    /// Produce a plain-text evidence snapshot of the current Error
+    /// screen suitable for writing to the `AEGIS_ISOS` data partition.
+    /// memtest86+-style "one frame = one bug report," serialized.
+    /// (#92)
+    #[must_use]
+    pub fn error_evidence_text(&self) -> Option<String> {
+        use std::fmt::Write as _;
+        let (msg, remedy, return_to) = match &self.screen {
+            Screen::Error {
+                message,
+                remedy,
+                return_to,
+            } => (message.clone(), remedy.clone(), *return_to),
+            _ => return None,
+        };
+        let iso = self.isos.get(return_to)?;
+        let cmdline = self.effective_cmdline(return_to);
+        let mut body = String::new();
+        body.push_str("aegis-boot kexec-failure evidence\n");
+        body.push_str("=================================\n\n");
+        let _ = writeln!(body, "Diagnostic: {msg}");
+        if let Some(r) = remedy {
+            let _ = writeln!(body, "Remedy:     {r}");
+        }
+        body.push('\n');
+        let _ = writeln!(body, "Version:    aegis-boot v{}", env!("CARGO_PKG_VERSION"));
+        let _ = writeln!(
+            body,
+            "SB / TPM:   {}  ·  {}",
+            self.secure_boot.summary(),
+            self.tpm.summary()
+        );
+        let _ = writeln!(body, "ISO label:  {}", iso.label);
+        let _ = writeln!(body, "ISO path:   {}", iso.iso_path.display());
+        let _ = writeln!(body, "Size:       {:?}", iso.size_bytes);
+        let _ = writeln!(body, "Distribution: {:?}", iso.distribution);
+        let _ = writeln!(body, "Quirks:     {:?}", iso.quirks);
+        let _ = writeln!(body, "Hash state: {:?}", iso.hash_verification);
+        let _ = writeln!(body, "Sig state:  {:?}", iso.signature_verification);
+        let cmdline_display = if cmdline.is_empty() {
+            "(none)"
+        } else {
+            &cmdline
+        };
+        let _ = writeln!(body, "Cmdline:    {cmdline_display}");
+        Some(body)
+    }
+
     /// Cancel an in-progress verification (Esc). Dismisses the
     /// Verifying screen without updating the iso. The worker thread
     /// continues in the background; its result is discarded.
@@ -1321,6 +1369,27 @@ mod tests {
         };
         let s = AppState::new(vec![iso]);
         assert!(!s.is_degraded_trust(0));
+    }
+
+    // --- one-frame error evidence (#92) -------------------------------
+
+    #[test]
+    fn error_evidence_text_populated_after_kexec_error() {
+        let mut s = AppState::new(vec![fake_iso("ubuntu-24.04")]);
+        s.confirm_selection();
+        s.record_kexec_error(&KexecError::SignatureRejected);
+        let Some(text) = s.error_evidence_text() else {
+            panic!("evidence populated on Error");
+        };
+        assert!(text.contains("aegis-boot kexec-failure evidence"));
+        assert!(text.contains("ubuntu-24.04"));
+        assert!(text.contains("Diagnostic:"));
+    }
+
+    #[test]
+    fn error_evidence_text_none_when_not_error_screen() {
+        let s = AppState::new(vec![fake_iso("a")]);
+        assert!(s.error_evidence_text().is_none());
     }
 
     // --- verify-now (#89) ---------------------------------------------


### PR DESCRIPTION
Closes the one-frame error + dual-sink log items from #92. memtest-style evidence block on Error; F10 saves snapshot to /run/media/aegis-isos/. 139 tests.