### PR TITLE
chore(release): v0.10.1 — brand + design-review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.1] — 2026-04-15
+
+**Brand identity + design-review fixes.** Delivers [#76](https://github.com/williamzujkowski/aegis-boot/issues/76) (brand identity spec produced by the nexus-agents `ux_expert`) and the three concrete fixes from the expert's subsequent self-critique.
+
+### Brand identity (#76)
+
+- **`assets/brand/`** — master SVG + monochrome variant of the shield-with-keyhole logo; ASCII renders (full 10-line README hero + compact 3-line TUI); `palette.css` with oklch + hex; `BRAND.md` usage guidelines.
+- **README hero block** — shield ASCII + tagline + license/release/CI badges.
+- **Tagline:** *Signed boot. Any ISO. Your keys.*
+- **`aegis` theme** — fifth named palette alongside default / monochrome / high-contrast / okabe-ito. Steel-blue primary (`#3B82F6`), emerald success, amber warning, vermillion error. Verified under deuteranopia/protanopia; distinct from Ubuntu/Fedora/Arch distro palettes.
+- **TUI header** gains the `◆` shield mark in brand primary plus the tagline in dim italic.
+
+### Design-review fixes (#76 self-critique)
+
+- **Header degrades gracefully on narrow terminals.** Previously truncated mid-word ("Signed boot. Any ISO. Yo"). Now span-chain is gated on `area.width`: ≥90 = full; ≥70 drops tagline; ≥50 drops TPM; <50 keeps only mark + name + version. Shield mark always survives.
+- **TrustChallenge mismatch feedback.** Typed characters `≥4` that don't equal `boot` render in error colour + bold. Silent-fail on a security gate was trainable toward muscle-memory mashing.
+- **TPM status colour reflects TPM state.** Previously hardcoded to green regardless; `TPM:none` now renders amber (warning). A green "none" was a lie.
+
+### Deferred to follow-up issues
+
+- [#101](https://github.com/williamzujkowski/aegis-boot/issues/101) Confirm info density — verdict can scroll off 24-row terminals
+- [#102](https://github.com/williamzujkowski/aegis-boot/issues/102) Filter-mode entry visual subtlety
+- [#103](https://github.com/williamzujkowski/aegis-boot/issues/103) `q` on Confirm opens ConfirmQuit (should be Esc-back equivalent)
+- [#104](https://github.com/williamzujkowski/aegis-boot/issues/104) `AEGIS_A11Y=text` screen-reader / braille mode
+
+### Tests
+
+Workspace tests 140 (+1 for the aegis theme; no test-count change from design-review fixes since they're render-only).
+
 ## [0.10.0] — 2026-04-15
 
 **Rescue + trust challenge + evidence release.** Implements the three biggest deferred items from the UX epic parent ([#85](https://github.com/williamzujkowski/aegis-boot/issues/85)) and its trust/a11y children ([#92](https://github.com/williamzujkowski/aegis-boot/issues/92), [#93](https://github.com/williamzujkowski/aegis-boot/issues/93)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-fitness"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "hex",
  "iso-parser",
@@ -382,7 +382,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kexec-loader"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "libc",
  "thiserror",
@@ -606,7 +606,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "crossterm",
  "hex",

--- a/crates/aegis-fitness/Cargo.toml
+++ b/crates/aegis-fitness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-fitness"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-parser"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Ships #76 brand identity + three design-review fixes. 140 tests.