### PR TITLE
fix(boot): console order + secondary mount — shakedown findings (#112, #113)

### DIFF
--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -454,15 +454,27 @@ done
 # Also auto-mount any other block device that looks like it has a
 # filesystem. Covers the case where the user attaches an ISO on a
 # secondary stick or USB drive alongside the boot media.
-for dev in /dev/sd* /dev/nvme*n*p* /dev/vd* /dev/mmcblk*p*; do
+# (#113) Iterate PARTITIONS, not whole disks — /dev/sda doesn't have
+# a filesystem and mount attempts print noisy "Can't open blockdev"
+# errors. The name pattern requires a trailing digit (partition
+# suffix): sd*[0-9] matches sda1/sdb2/... but not sda/sdb.
+for dev in /dev/sd*[0-9] /dev/nvme*n*p* /dev/vd*[0-9] /dev/mmcblk*p*; do
     [ -b "$dev" ] || continue
     # Skip the AEGIS_ISOS partition we already mounted.
     [ "$dev" = "${AEGIS_DEV:-}" ] && continue
     name=$(echo "$dev" | /bin/sed 's|.*/||')
     mp="/run/media/$name"
     /bin/mkdir -p "$mp"
+    # (#113) Explicit vfat options when auto-mount without a type
+    # fails — Linux vfat defaults to iocharset=iso8859-1 which is a
+    # module we don't ship. cp437 is built-in on Ubuntu generic
+    # kernels. Try auto first (ext4/ntfs/etc work fine), fall back
+    # to explicit vfat on failure.
     if /bin/mount -o ro "$dev" "$mp" 2>/dev/null; then
         /bin/echo "init: secondary-mount $dev -> $mp"
+    elif /bin/mount -t vfat -o ro,codepage=437,iocharset=cp437 \
+            "$dev" "$mp" 2>/dev/null; then
+        /bin/echo "init: secondary-mount $dev -> $mp (fs=vfat)"
     else
         /bin/rmdir "$mp" 2>/dev/null
     fi

--- a/scripts/mkusb.sh
+++ b/scripts/mkusb.sh
@@ -114,7 +114,20 @@ terminal_output serial console
 set timeout=3
 
 # Normal boot — concise kernel logs.
+# console= order MATTERS: last one wins as /dev/console for userspace.
+# We want tty0 (local monitor) as the default rescue-tui target on
+# real-hardware boots; kernel still echoes to all console= targets
+# so a serial operator gets dmesg + can edit grub to flip the order.
+# (#112)
 menuentry "aegis-boot rescue" {
+    linux /vmlinuz console=ttyS0,115200 console=tty0 panic=5 loglevel=4
+    initrd /initrd.img
+}
+
+# Serial-primary variant — for operators using a serial console or a
+# KVM IP console with no local monitor. rescue-tui's alt-screen
+# renders on ttyS0.
+menuentry "aegis-boot rescue (serial-primary)" {
     linux /vmlinuz console=tty0 console=ttyS0,115200 panic=5 loglevel=4
     initrd /initrd.img
 }
@@ -124,7 +137,7 @@ menuentry "aegis-boot rescue" {
 # the operator can read the pre-rescue-tui state on screen. Also tees
 # the /init log to /run/media/aegis-isos/aegis-boot-<ts>.log.
 menuentry "aegis-boot rescue (verbose — first-boot debug)" {
-    linux /vmlinuz console=tty0 console=ttyS0,115200 panic=30 loglevel=7 earlyprintk=efi ignore_loglevel aegis.verbose=1
+    linux /vmlinuz console=ttyS0,115200 console=tty0 panic=30 loglevel=7 earlyprintk=efi ignore_loglevel aegis.verbose=1
     initrd /initrd.img
 }
 EOF


### PR DESCRIPTION
Closes #112 (critical — rescue-tui was invisible on GTK) and #113 (secondary-mount noise). Found during first real-USB shakedown on SanDisk Cruzer.