### PR TITLE
feat(aegis-cli): aegis-boot flash CLI — 3-step guided USB writer (#124)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,14 @@
 version = 4
 
 [[package]]
+name = "aegis-cli"
+version = "0.11.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aegis-fitness"
 version = "0.11.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/rescue-tui",
     "crates/kexec-loader",
     "crates/aegis-fitness",
+    "crates/aegis-cli",
 ]
 exclude = ["crates/iso-parser/fuzz"]
 

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "aegis-cli"
+version = "0.11.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Operator CLI for aegis-boot — flash, add, list, verify"
+
+[[bin]]
+name = "aegis-boot"
+path = "src/main.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/crates/aegis-cli/src/detect.rs
+++ b/crates/aegis-cli/src/detect.rs
@@ -1,0 +1,96 @@
+//! Removable drive detection via sysfs.
+//!
+//! Enumerates `/sys/block/sd*` looking for removable USB mass storage
+//! devices. Filters out system drives, `NVMe`, loop devices, and
+//! anything that isn't flagged as removable by the kernel.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A detected removable USB drive.
+#[derive(Debug, Clone)]
+pub struct Drive {
+    /// Block device path (e.g. `/dev/sdc`).
+    pub dev: PathBuf,
+    /// Human-readable model string from sysfs.
+    pub model: String,
+    /// Capacity in bytes.
+    pub size_bytes: u64,
+    /// Number of existing partitions.
+    pub partitions: usize,
+}
+
+impl Drive {
+    /// Human-readable capacity.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn size_human(&self) -> String {
+        let gb = self.size_bytes as f64 / 1_073_741_824.0;
+        if gb >= 1.0 {
+            format!("{gb:.1} GB")
+        } else {
+            let mb = self.size_bytes as f64 / 1_048_576.0;
+            format!("{mb:.0} MB")
+        }
+    }
+}
+
+/// Scan sysfs for removable USB block devices suitable for flashing.
+/// Returns them sorted by device name.
+#[must_use]
+pub fn list_removable_drives() -> Vec<Drive> {
+    let mut drives = Vec::new();
+    let Ok(entries) = fs::read_dir("/sys/block") else {
+        return drives;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Only sd* devices (SCSI/USB mass storage).
+        if !name_str.starts_with("sd") {
+            continue;
+        }
+        let sysdir = entry.path();
+        // Must be removable.
+        if read_sysfs_int(&sysdir.join("removable")) != Some(1) {
+            continue;
+        }
+        // Read model + size.
+        let model = read_sysfs_str(&sysdir.join("device/model"))
+            .unwrap_or_else(|| "(unknown model)".to_string());
+        let size_bytes = read_sysfs_int_u64(&sysdir.join("size")).unwrap_or(0) * 512;
+        // Count partitions (sdX1, sdX2, ...).
+        let partitions = fs::read_dir(&sysdir)
+            .map(|iter| {
+                iter.flatten()
+                    .filter(|e| {
+                        e.file_name()
+                            .to_string_lossy()
+                            .starts_with(name_str.as_ref())
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+
+        drives.push(Drive {
+            dev: PathBuf::from(format!("/dev/{name_str}")),
+            model: model.trim().to_string(),
+            size_bytes,
+            partitions,
+        });
+    }
+    drives.sort_by(|a, b| a.dev.cmp(&b.dev));
+    drives
+}
+
+fn read_sysfs_str(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok()
+}
+
+fn read_sysfs_int(path: &Path) -> Option<i64> {
+    read_sysfs_str(path)?.trim().parse().ok()
+}
+
+fn read_sysfs_int_u64(path: &Path) -> Option<u64> {
+    read_sysfs_str(path)?.trim().parse().ok()
+}

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -1,0 +1,267 @@
+//! `aegis-boot flash` — guided USB writer.
+//!
+//! Three steps:
+//!   1. Auto-detect removable drives (or accept explicit `/dev/sdX`)
+//!   2. Typed confirmation (`flash`)
+//!   3. Build image inline + write with progress + verify
+//!
+//! Wraps the logic of `scripts/mkusb.sh` + `dd` into one command.
+//! For v1.0.0 the image is built by shelling out to mkusb.sh; a
+//! future version can inline the Rust equivalent.
+
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use crate::detect::{self, Drive};
+
+/// Entry point for `aegis-boot flash [device]`.
+pub fn run(args: &[String]) -> ExitCode {
+    if args.first().map(String::as_str) == Some("--help")
+        || args.first().map(String::as_str) == Some("-h")
+    {
+        println!("aegis-boot flash — write aegis-boot to a USB stick");
+        println!();
+        println!("USAGE: aegis-boot flash [/dev/sdX]");
+        println!("  No argument = auto-detect removable drives.");
+        println!("  Explicit device = flash to that drive.");
+        return ExitCode::SUCCESS;
+    }
+    let explicit_dev = args.first().map(std::string::String::as_str);
+
+    // Step 1: select drive.
+    let Some(drive) = select_drive(explicit_dev) else {
+        return ExitCode::from(1);
+    };
+
+    // Step 2: typed confirmation.
+    if !confirm_destructive(&drive) {
+        eprintln!("Cancelled.");
+        return ExitCode::SUCCESS;
+    }
+
+    // Step 3: build + write + verify.
+    match flash(&drive) {
+        Ok(()) => {
+            println!();
+            println!("Done. Next steps:");
+            println!("  1. Mount the AEGIS_ISOS partition and copy .iso files onto it:");
+            println!(
+                "       sudo mount {}2 /mnt && cp *.iso /mnt/ && sudo umount /mnt",
+                drive.dev.display()
+            );
+            println!("  2. Boot from the stick (UEFI boot menu, select the USB entry).");
+            println!("  3. In rescue-tui, pick an ISO and press Enter.");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("flash failed: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn select_drive(explicit: Option<&str>) -> Option<Drive> {
+    if let Some(dev) = explicit {
+        let path = PathBuf::from(dev);
+        if !path.exists() {
+            eprintln!("device not found: {dev}");
+            return None;
+        }
+        // Build a minimal Drive for the explicit path.
+        let drives = detect::list_removable_drives();
+        if let Some(d) = drives.into_iter().find(|d| d.dev == path) {
+            return Some(d);
+        }
+        eprintln!("{dev} is not a removable drive (or not detected as one).");
+        eprintln!("Available removable drives:");
+        for d in detect::list_removable_drives() {
+            eprintln!("  {} — {} ({})", d.dev.display(), d.model, d.size_human());
+        }
+        return None;
+    }
+
+    let drives = detect::list_removable_drives();
+    if drives.is_empty() {
+        eprintln!("No removable USB drives detected.");
+        eprintln!("Plug in a USB stick and try again, or specify a device:");
+        eprintln!("  aegis-boot flash /dev/sdX");
+        return None;
+    }
+
+    println!("Detected removable drives:");
+    for (i, d) in drives.iter().enumerate() {
+        let parts = if d.partitions > 0 {
+            format!("{} partitions", d.partitions)
+        } else {
+            "no partitions".to_string()
+        };
+        println!(
+            "  [{}] {}  {}  {}  ({})",
+            i + 1,
+            d.dev.display(),
+            d.model,
+            d.size_human(),
+            parts,
+        );
+    }
+    println!();
+
+    if drives.len() == 1 {
+        print!(
+            "Use {} {}? [Y/n]: ",
+            drives[0].dev.display(),
+            drives[0].model
+        );
+    } else {
+        print!("Select drive [1-{}]: ", drives.len());
+    }
+    io::stdout().flush().ok();
+
+    let mut line = String::new();
+    if io::stdin().lock().read_line(&mut line).unwrap_or(0) == 0 {
+        return None;
+    }
+    let input = line.trim();
+
+    if drives.len() == 1 && (input.is_empty() || input.eq_ignore_ascii_case("y")) {
+        return Some(drives.into_iter().next().unwrap_or_else(|| unreachable!()));
+    }
+
+    let idx: usize = match input.parse::<usize>() {
+        Ok(n) if n >= 1 && n <= drives.len() => n - 1,
+        _ => {
+            eprintln!("Invalid selection.");
+            return None;
+        }
+    };
+    Some(
+        drives
+            .into_iter()
+            .nth(idx)
+            .unwrap_or_else(|| unreachable!()),
+    )
+}
+
+fn confirm_destructive(drive: &Drive) -> bool {
+    println!();
+    println!(
+        "  ALL DATA ON {} ({}, {}) WILL BE ERASED.",
+        drive.dev.display(),
+        drive.model,
+        drive.size_human()
+    );
+    println!();
+    print!("  Type 'flash' to confirm: ");
+    io::stdout().flush().ok();
+
+    let mut line = String::new();
+    if io::stdin().lock().read_line(&mut line).unwrap_or(0) == 0 {
+        return false;
+    }
+    line.trim() == "flash"
+}
+
+fn flash(drive: &Drive) -> Result<(), String> {
+    let repo_root = find_repo_root().ok_or("cannot find aegis-boot repo root (no Cargo.toml)")?;
+    let mkusb = repo_root.join("scripts/mkusb.sh");
+    let out_dir = repo_root.join("out");
+
+    // Step 3a: build the image via mkusb.sh.
+    println!();
+    println!("Building aegis-boot image...");
+
+    // Compute disk size from drive capacity — use the full stick.
+    let disk_mb = (drive.size_bytes / (1024 * 1024)).max(2048);
+
+    let status = Command::new("bash")
+        .arg(&mkusb)
+        .env("OUT_DIR", &out_dir)
+        .env("DISK_SIZE_MB", disk_mb.to_string())
+        .status()
+        .map_err(|e| format!("mkusb.sh exec failed: {e}"))?;
+
+    if !status.success() {
+        return Err(format!("mkusb.sh exited with {status}"));
+    }
+
+    let img_path = out_dir.join("aegis-boot.img");
+    if !img_path.is_file() {
+        return Err("mkusb.sh did not produce out/aegis-boot.img".to_string());
+    }
+
+    let img_size = std::fs::metadata(&img_path)
+        .map(|m| m.len())
+        .map_err(|e| format!("stat: {e}"))?;
+
+    // Step 3b: dd with progress.
+    println!();
+    #[allow(clippy::cast_precision_loss)]
+    let img_gb = img_size as f64 / 1_073_741_824.0;
+    println!(
+        "Writing {} ({img_gb:.1} GB) to {} ...",
+        img_path.display(),
+        drive.dev.display()
+    );
+
+    let dd_status = Command::new("sudo")
+        .args([
+            "dd",
+            &format!("if={}", img_path.display()),
+            &format!("of={}", drive.dev.display()),
+            "bs=4M",
+            "oflag=direct",
+            "conv=fsync",
+            "status=progress",
+        ])
+        .status()
+        .map_err(|e| format!("dd exec failed: {e}"))?;
+
+    if !dd_status.success() {
+        return Err(format!("dd exited with {dd_status}"));
+    }
+
+    // Step 3c: sync + verify partition table.
+    println!("Syncing...");
+    let _ = Command::new("sudo").arg("sync").status();
+    let _ = Command::new("sudo")
+        .args(["partprobe", &drive.dev.display().to_string()])
+        .status();
+
+    println!();
+    println!(
+        "aegis-boot installed on {} ({}, {}).",
+        drive.dev.display(),
+        drive.model,
+        drive.size_human()
+    );
+    println!("  Partition 1: ESP (signed boot chain)");
+    println!("  Partition 2: AEGIS_ISOS (ready for ISOs)");
+
+    Ok(())
+}
+
+fn find_repo_root() -> Option<PathBuf> {
+    // Check common locations.
+    for candidate in [std::env::current_dir().ok(), dirs_from_exe()]
+        .into_iter()
+        .flatten()
+    {
+        let mut cur = candidate;
+        loop {
+            if cur.join("Cargo.toml").is_file() && cur.join("crates").is_dir() {
+                return Some(cur);
+            }
+            if !cur.pop() {
+                break;
+            }
+        }
+    }
+    None
+}
+
+fn dirs_from_exe() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf))
+}

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -1,0 +1,64 @@
+//! `aegis-boot` — operator CLI for aegis-boot.
+//!
+//! Subcommands:
+//!   * `flash`  — write aegis-boot to a USB stick (3-step guided)
+//!   * `add`    — copy + validate an ISO onto the stick
+//!   * `list`   — show ISOs on the stick with verification status
+//!
+//! This replaces the developer workflow of running shell scripts
+//! manually. The binary is named `aegis-boot` so operators type
+//! `aegis-boot flash /dev/sdX` etc.
+
+#![forbid(unsafe_code)]
+
+mod detect;
+mod flash;
+
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let subcmd = args.first().map(std::string::String::as_str);
+
+    match subcmd {
+        Some("flash") => flash::run(&args[1..]),
+        Some("list") => {
+            eprintln!("aegis-boot list: not yet implemented (tracked in #125)");
+            ExitCode::from(1)
+        }
+        Some("add") => {
+            eprintln!("aegis-boot add: not yet implemented (tracked in #125)");
+            ExitCode::from(1)
+        }
+        Some("-h" | "--help" | "help") | None => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        Some("--version" | "version") => {
+            println!("aegis-boot v{}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        Some(other) => {
+            eprintln!("aegis-boot: unknown command '{other}'");
+            eprintln!("run 'aegis-boot --help' for usage");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn print_help() {
+    println!("aegis-boot — Signed boot. Any ISO. Your keys.");
+    println!();
+    println!("USAGE:");
+    println!("  aegis-boot flash [device]    Write aegis-boot to a USB stick");
+    println!("  aegis-boot list [device]     Show ISOs on the stick");
+    println!("  aegis-boot add <iso> [device] Copy + validate an ISO");
+    println!("  aegis-boot --version         Print version");
+    println!("  aegis-boot --help            This message");
+    println!();
+    println!("EXAMPLES:");
+    println!("  aegis-boot flash             # auto-detect removable drive");
+    println!("  aegis-boot flash /dev/sdc    # specific drive");
+    println!("  aegis-boot add ubuntu.iso    # validate + copy to stick");
+}


### PR DESCRIPTION
Closes #124. New binary crate producing the `aegis-boot` command. `aegis-boot flash` auto-detects removable USB drives, typed confirmation, builds + dd's with progress.