### PR TITLE
docs: full public-readiness audit — accuracy fixes + new operator docs + .github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: aegis-boot did something wrong, refused something it should have accepted, or crashed.
+title: "bug: <one-line description>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The more we can reproduce, the faster we can fix.
+
+        **Security-sensitive findings (key handling, signature bypass, supply-chain) → DO NOT file here.**
+        Use the private path in [SECURITY.md](../blob/main/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: aegis-boot version
+      description: Output of `aegis-boot --version` (or commit SHA if built from source).
+      placeholder: "v0.12.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: where
+    attributes:
+      label: Where did it happen?
+      options:
+        - Workstation (writing the stick — `aegis-boot flash` / `add` / `list`)
+        - Firmware boot (stick won't appear, Secure Boot violation, etc.)
+        - rescue-tui (TUI shows wrong info, won't navigate, no ISOs found)
+        - kexec hand-off (errno from kexec_file_load, target kernel won't start)
+        - Build (cargo build, mkusb.sh, build-initramfs.sh)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you see, and what did you expect to see?
+      placeholder: |
+        I ran `sudo aegis-boot flash /dev/sdc` on Ubuntu 24.04. The build step
+        succeeded but `dd` exited with status 1. I expected it to write
+        cleanly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Exact commands and inputs. If a specific ISO triggers it, link to the ISO.
+      placeholder: |
+        1. `git clone ... && cd aegis-boot`
+        2. `cargo build --release`
+        3. `sudo aegis-boot flash /dev/sdc`
+        4. <see error>
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Workstation distro + kernel; target firmware + SB state if relevant.
+      placeholder: |
+        Workstation: Ubuntu 24.04, kernel 6.8.0-31-generic
+        Target: Framework Laptop 13, firmware 3.05, Secure Boot enforcing
+        ISO: ubuntu-24.04.2-live-server-amd64.iso (Canonical)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste relevant output (rescue-tui stderr, journalctl, dmesg, dd error, etc.). Use a code fence.
+      render: shell
+      placeholder: |
+        $ sudo aegis-boot flash /dev/sdc
+        ...
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else?
+      description: Optional. Workarounds tried, hypotheses, related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/williamzujkowski/aegis-boot/security/advisories/new
+    about: Report security findings privately. Acknowledgement within 7 days. See SECURITY.md.
+  - name: Question or discussion
+    url: https://github.com/williamzujkowski/aegis-boot/discussions
+    about: For open-ended questions or design discussions, use Discussions instead of Issues.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Propose a new capability, behavior, or change in scope.
+title: "feat: <one-line description>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for thinking about this. Concrete proposals beat abstract ones — say what you'd do, not just what's wrong with today.
+
+        Before filing: skim [ROADMAP.md](../blob/main/ROADMAP.md) and the [Non-goals](../blob/main/ROADMAP.md#non-goals-probably-forever) section. If your idea is in non-goals, the answer is probably no, but the reasoning is worth reading.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Who hits this, when, and what's the cost today?
+      placeholder: |
+        Operators flashing aegis-boot from macOS can't use `aegis-boot flash`
+        because the CLI is Linux-only. They have to fall back to `dd` by hand
+        (which loses the safety prompts) or boot a Linux VM just to flash.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should happen instead? Be specific — names, commands, screens.
+      placeholder: |
+        `aegis-boot flash` detects the host OS. On macOS it uses `diskutil
+        list -plist` for drive enumeration and `sudo dd` with the macOS-style
+        bs= argument. The typed-confirmation step stays the same.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is your proposal better?
+      placeholder: |
+        - Document the manual `dd` path on macOS (rejected: loses safety
+          prompts).
+        - Ship a separate `aegis-boot-mac` binary (rejected: split surface,
+          versioning drift).
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and trade-offs
+      description: What's the cost? What new things would maintainers have to test forever?
+      placeholder: |
+        - New CI job: macOS runner running `aegis-boot flash --dry-run`.
+        - Vendoring `diskutil` parsing logic; adds ~150 LOC.
+        - Doesn't add a new attack surface (we already shell to `dd`).
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How urgent is this for you?
+      options:
+        - Blocker — I can't use aegis-boot without it
+        - High — I have a workaround but it's painful
+        - Medium — Would be nice
+        - Low — Filing for visibility
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for the PR! A few asks before you submit.
+
+* Title: conventional commit format. Examples:
+    feat(rescue-tui): add high-contrast theme
+    fix(kexec-loader): classify ENODATA as SignatureRejected
+    docs(install): clarify MOK enrollment flow
+  Types: feat, fix, refactor, docs, test, chore, perf, build, ci.
+
+* Branch: feat/<issue>-..., fix/<issue>-..., docs/<topic>, chore/<topic>.
+
+* One concern per PR. Don't bundle a security fix with a refactor.
+
+* See CONTRIBUTING.md for the full bar.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What changes, and why? -->
+
+## Linked issue
+
+<!-- "closes #N" / "refs #N" / "part of #N" -->
+
+## What changed
+
+<!-- Bulleted list of the actual diff. Reviewers can read the diff;
+     this list says where to focus their attention. -->
+
+-
+
+## How was this tested?
+
+<!-- Tests added, scripts run, hardware exercised. Required for
+     anything beyond a typo / pure-doc change. -->
+
+- [ ] `cargo test --workspace` passes locally
+- [ ] `./scripts/dev-test.sh` passes locally (or noted exceptions below)
+- [ ] CHANGELOG entry under "Unreleased" if user-visible
+- [ ] Docs updated if behavior or interface changed
+
+<!-- Specific test runs / scenarios: -->
+
+## Risk
+
+<!-- Anything reviewers should pay extra attention to:
+     - boot-chain, signing, or kexec-touching code
+     - changes to mkusb.sh / build-initramfs.sh
+     - dependency bumps
+     - platform-specific behavior
+
+     If purely additive / docs / tests-only, write "low / additive". -->
+
+## Out of scope
+
+<!-- What this PR explicitly does NOT do (so reviewers don't ask).
+     Optional. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,17 +7,19 @@ Thanks for your interest. This is a small project with a sharp focus — a signe
 ```bash
 git clone git@github.com:williamzujkowski/aegis-boot.git
 cd aegis-boot
-cargo test --workspace               # 108 tests as of v0.7.1
+cargo test --workspace               # 140 tests as of v0.12.0
 ./scripts/dev-test.sh                # full 8-stage local CI
 ```
 
 Prereqs are listed at the top of [`scripts/dev-test.sh`](./scripts/dev-test.sh) and in [`docs/LOCAL_TESTING.md`](./docs/LOCAL_TESTING.md).
 
+The operator-facing CLI lives in [`crates/aegis-cli`](./crates/aegis-cli) (binary `aegis-boot`). When working on the operator surface, exercise it directly: `cargo run -p aegis-cli -- flash --help`. Don't add operator-facing flags without updating [`docs/CLI.md`](./docs/CLI.md).
+
 ## Workflow
 
 1. **Open an issue first** for anything bigger than a typo — alignment beats rework.
 2. **Branch off `main`**: `feat/<issue>-short-description`, `fix/<issue>-...`, `docs/<topic>`, `chore/<topic>`.
-3. **Conventional commits** (enforced manually, no commitlint hook yet):
+3. **Conventional commits** (validated in PR review; no commitlint hook yet):
    ```
    feat(rescue-tui): add high-contrast theme
    fix(security): block kexec on hash mismatch (#55)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.10.0 — feature-complete under QEMU simulation; real-hardware shakedown gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.12.0 — operator CLI shipped; real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 
-1. Flash `out/aegis-boot.img` (produced by `scripts/mkusb.sh`) to a USB stick.
+1. Flash an aegis-boot image to a USB stick (`aegis-boot flash` or `dd`).
 2. Drop `.iso` files onto the `AEGIS_ISOS` partition.
 3. Boot the stick on any UEFI machine with Secure Boot enabled.
 4. A minimal ratatui TUI lists the ISOs; the operator selects one.
@@ -37,43 +37,102 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 Boot chain: `UEFI firmware → shim (MS-signed) → grub (Canonical-signed) → rescue kernel → our initramfs → rescue-tui → kexec_file_load → selected ISO's kernel`. Full rationale: [ADR 0001](./docs/adr/0001-runtime-architecture.md).
 
-## Quickstart (simulation)
+## How it differs from Ventoy / Rufus / balenaEtcher
+
+| Tool | Boots arbitrary ISOs | Preserves Secure Boot chain | Per-ISO trust decision |
+|---|---|---|---|
+| **aegis-boot** | yes | **yes** — kernel-level signature check via `KEXEC_SIG` | yes — operator enrolls keys per distro |
+| Ventoy | yes | weakened — one shared MOK key trusts every Ventoy-booted kernel | no |
+| Rufus | one ISO at a time | depends on ISO; no orchestration | n/a |
+| balenaEtcher | one ISO at a time | depends on ISO; no orchestration | n/a |
+
+aegis-boot is the right pick when you need to boot operator-supplied ISOs **without disabling Secure Boot or trusting a global third-party MOK**. Unsigned ISO kernels are refused with a clear error and a `mokutil --import` command for the specific signing key — see [docs/UNSIGNED_KERNEL.md](./docs/UNSIGNED_KERNEL.md).
+
+## Quickstart — operators
+
+Pre-built binaries are published per release; build from source per [BUILDING.md](./BUILDING.md) if needed.
 
 ```bash
-# 1. build
-cargo build --release -p rescue-tui
+# 1. write aegis-boot to a USB stick (3-step guided; auto-detects removable drives)
+sudo aegis-boot flash             # or: sudo aegis-boot flash /dev/sdc
+
+# 2. add ISOs to the stick (auto-detects mount; copies sidecars too)
+aegis-boot add ~/Downloads/ubuntu-24.04.2-live-server-amd64.iso
+aegis-boot list                   # show what's on the stick
+
+# 3. plug the stick into a target machine, boot from it (UEFI + SB enabled)
+#    The TUI discovers ISOs, shows verification status, and kexecs on Enter.
+```
+
+Operator end-to-end walkthrough: [docs/INSTALL.md](./docs/INSTALL.md). Common errors and their fixes: [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md).
+
+## Quickstart — developers
+
+```bash
+cargo build --release
 ./scripts/build-initramfs.sh
-./scripts/mkusb.sh
+./scripts/mkusb.sh                # produces out/aegis-boot.img
 
-# 2. drop some ISOs into a dir
+# Boot the simulated stick under QEMU + OVMF SecBoot
 mkdir -p test-isos && cp ~/Downloads/*.iso test-isos/
-
-# 3. boot the simulated stick under QEMU+OVMF SecBoot
 ./scripts/qemu-loaded-stick.sh -d ./test-isos -a usb -i
 ```
 
-See [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) for the full developer loop.
+Full developer loop: [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md).
 
 ## Components
 
 | Crate | Role |
 |---|---|
+| [`aegis-cli`](./crates/aegis-cli) | Operator CLI — `aegis-boot flash`, `add`, `list` |
 | [`iso-parser`](./crates/iso-parser) | ISO media analysis — finds kernel/initrd/cmdline in distro boot configs |
-| [`iso-probe`](./crates/iso-probe) | Runtime discovery + sibling `.sha256` / `.minisig` verification |
+| [`iso-probe`](./crates/iso-probe) | Runtime discovery + sibling `.sha256` / `.minisig` verification + installer-vs-live heuristics |
 | [`kexec-loader`](./crates/kexec-loader) | Safe wrapper over `kexec_file_load(2)` with error classification |
 | [`rescue-tui`](./crates/rescue-tui) | ratatui application the operator sees; hard-blocks kexec on hash/sig failure |
 | [`aegis-fitness`](./crates/aegis-fitness) | Repo / build / artifact health audit (9 checks) |
 
 ## Documentation
 
+**For operators**
+
+- [docs/INSTALL.md](./docs/INSTALL.md) — flash → add ISOs → boot → select, end-to-end
+- [docs/CLI.md](./docs/CLI.md) — `aegis-boot` CLI reference
+- [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) — common errors and fixes (errno 61, won't-boot, etc.)
+- [docs/UNSIGNED_KERNEL.md](./docs/UNSIGNED_KERNEL.md) — what to do when an ISO's kernel isn't signed
+- [docs/USB_LAYOUT.md](./docs/USB_LAYOUT.md) — what's on the stick (ESP + `AEGIS_ISOS`)
+
+**For contributors**
+
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — patch workflow, conventions, PR bar
+- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — one-page mental model
 - [BUILDING.md](./BUILDING.md) — reproducible build setup (Docker + Nix)
 - [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) — 8-stage local CI equivalent
-- [docs/USB_LAYOUT.md](./docs/USB_LAYOUT.md) — GPT + ESP + `AEGIS_ISOS` partition scheme
 - [docs/adr/](./docs/adr/) — Architecture Decision Records
 - [docs/compatibility/iso-matrix.md](./docs/compatibility/iso-matrix.md) — per-distro kexec compatibility
-- [SECURITY.md](./SECURITY.md) — vulnerability reporting
+
+**Security**
+
+- [SECURITY.md](./SECURITY.md) — vulnerability reporting (use private advisory; 7-day ack SLA)
 - [THREAT_MODEL.md](./THREAT_MODEL.md) — UEFI Secure Boot threat model (PK/KEK/MOK/SBAT)
-- [CHANGELOG.md](./CHANGELOG.md)
+
+**Project**
+
+- [CHANGELOG.md](./CHANGELOG.md) | [ROADMAP.md](./ROADMAP.md) | [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+
+## Runtime configuration
+
+`rescue-tui` reads these environment variables (set on the kernel cmdline or in the `/init` script):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AEGIS_ISO_ROOTS` | `/run/media:/mnt` | Colon-separated dirs to scan for `.iso` files |
+| `AEGIS_THEME` | (built-in) | Override theme name (e.g. `high-contrast`) |
+| `AEGIS_AUTO_KEXEC` | unset | Substring; first matching ISO is kexec'd without operator confirmation |
+| `AEGIS_A11Y` | unset | `1` enables text-only mode (also auto-enabled when `TERM=dumb`) |
+| `AEGIS_LOG_JSON` | unset | `1` switches `tracing` output to JSON for `journalctl --output=json` |
+| `AEGIS_STATE_DIR` | `/var/lib/aegis-boot` | Where last-booted state is persisted |
+
+`scripts/mkusb.sh` reads: `OUT_DIR`, `IMG`, `DISK_SIZE_MB` (default 2048), `ESP_SIZE_MB` (400), `DATA_LABEL` (`AEGIS_ISOS`), `DATA_FS` (`fat32` or `ext4`), `SHIM_SRC`, `GRUB_SRC`, `KERNEL_SRC`, `INITRD_SRC`.
 
 ## Build environment
 
@@ -83,4 +142,9 @@ See [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) for the full developer loop
 
 ## License
 
-Dual-licensed: [Apache-2.0](./LICENSE-APACHE) OR [MIT](./LICENSE-MIT), at your option.
+Dual-licensed under either of:
+
+- [Apache License 2.0](./LICENSE-APACHE) (`LICENSE-APACHE`)
+- [MIT License](./LICENSE-MIT) (`LICENSE-MIT`)
+
+at your option. Contributions are accepted under the same dual license; see [CONTRIBUTING.md](./CONTRIBUTING.md#license).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,18 +2,18 @@
 
 A forward-looking sketch. The CHANGELOG tells what already shipped; this file says where we're going. Everything here is subject to change — file an issue if you think the priorities are wrong.
 
-## Now (active)
+## Now (toward v1.0.0)
 
-- **#77** Repo cleanup — CONTRIBUTING, ROADMAP, scripts/README, docs/README *(this PR)*
-- **#76** Project branding — logo, tagline, social preview, README hero
-- **#78** Docs/content accuracy audit cadence (recurring; ran at v0.7.0)
-
-## Next (toward v1.0.0)
-
-- **#51** Real-hardware shakedown on Framework / ThinkPad / Dell. Required for v1.0.0. Needs physical access — can't run from CI.
-- **crates.io publishing** ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51) gate) — `iso-parser`, `iso-probe`, `kexec-loader` go up at v1.0.0-rc1. `rescue-tui` and `aegis-fitness` stay repo-local.
+- **#51** Multi-vendor real-hardware shakedown — Framework / ThinkPad / Dell direct boot. Required for v1.0.0; QEMU USB-passthrough is not enough. Needs physical access; can't run from CI.
+- **#132** Last-booted real-hardware E2E test — automate the manual shakedown that closed [#109](https://github.com/williamzujkowski/aegis-boot/issues/109).
+- **#123** `aegis-boot flash` on macOS / Windows — currently Linux-only; cross-platform support is a v1.0 expectation.
 - **`scripts/release.sh`** — manual asset upload is fine for v0.x; for v1.0.0 we want one command.
 - **Reproducibility extension** — currently only `rescue-tui` is verified reproducible under SOURCE_DATE_EPOCH. Stretch: include `initramfs.cpio.gz` once we can pin the busybox version.
+
+## Recently shipped
+
+- **v0.12.0** — `aegis-boot` operator CLI (flash/list/add) ([#124](https://github.com/williamzujkowski/aegis-boot/issues/124), [#125](https://github.com/williamzujkowski/aegis-boot/issues/125)); installer-vs-live warning on Confirm screen ([#131](https://github.com/williamzujkowski/aegis-boot/issues/131)); post-kexec handoff banner ([#127](https://github.com/williamzujkowski/aegis-boot/issues/127)); unsigned-kernel operator guidance ([#126](https://github.com/williamzujkowski/aegis-boot/issues/126)); real-hardware shakedown closing the v1.0 boot-chain gate ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)).
+- **v0.10.1** — repo cleanup ([#77](https://github.com/williamzujkowski/aegis-boot/issues/77)), branding ([#76](https://github.com/williamzujkowski/aegis-boot/issues/76)), docs accuracy audit cadence ([#78](https://github.com/williamzujkowski/aegis-boot/issues/78)).
 
 ## Later (post-1.0)
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -2,7 +2,7 @@
 
 **Version:** 2.0
 **Scope:** Option B runtime (signed Linux rescue + ratatui TUI + kexec) per [ADR 0001](./docs/adr/0001-runtime-architecture.md)
-**Last reviewed:** 2026-04-14
+**Last reviewed:** 2026-04-16 (re-confirmed for v0.12.0 release; no model changes — the operator CLI sits below the trust boundary and cannot influence kernel verification)
 
 This document replaces the v1.0 threat model, which assumed a systemd-boot + custom-signed-orchestrator chain. That assumption no longer matches the chosen runtime and has been removed rather than patched.
 

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -18,7 +18,7 @@ use crate::theme::Theme;
 ///
 /// ```text
 /// ┌──────────────────────────────────────────────────────┐
-/// │  aegis-boot v0.7.1     SB:enforcing  TPM:available   │ <- header
+/// │  aegis-boot v0.12.0    SB:enforcing  TPM:available   │ <- header
 /// ├──────────────────────────────────────────────────────┤
 /// │                                                      │
 /// │              (current screen body)                   │ <- body

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# Architecture overview
+
+One-page mental model for contributors. For decision rationale see [ADR 0001](./adr/0001-runtime-architecture.md). For threat boundaries see [THREAT_MODEL.md](../THREAT_MODEL.md).
+
+## Boot chain
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ UEFI firmware                                                   │
+│   verifies /EFI/BOOT/BOOTX64.EFI (shim) against db/dbx          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ shim (Microsoft-signed)                                         │
+│   verifies grubx64.efi via vendor cert                          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ grub (Canonical-signed)                                         │
+│   verifies /vmlinuz via shim's keyring                          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Linux rescue kernel (Canonical-signed)                          │
+│   loads concatenated initramfs (distro + ours)                  │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ /init (PID 1, busybox sh)                                       │
+│   mounts /proc /sys /dev, modprobes storage modules,            │
+│   auto-mounts AEGIS_ISOS under /run/media, exec's rescue-tui    │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ rescue-tui (ratatui)                                            │
+│   discovers .iso files via iso-probe                            │
+│   shows verification status (sha256 / minisig sidecars)         │
+│   warns on installer images                                     │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ kexec_file_load(2)  ← KERNEL ENFORCES KEXEC_SIG SIGNATURE       │
+│   selected ISO's kernel takes over                              │
+│   ENODATA (errno 61) if unsigned and SB enforcing               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+The trust boundary is the dashed line between "what the firmware verified" and "what the operator picked." The kernel enforces signature checks on the selected kernel via `KEXEC_SIG`; aegis-boot does **not** bypass that enforcement. Unsigned kernels surface as `errno 61` and require explicit MOK enrollment by the operator (not a global trust decision).
+
+## Crate dependencies
+
+```
+aegis-cli ────┐                              (operator workstation)
+              │                              binary: aegis-boot
+              ▼
+         (shells out to mkusb.sh + dd; reads /sys/block/sd*)
+
+
+rescue-tui ──┬──► iso-probe ──► iso-parser   (on the stick, in initramfs)
+             │                                binary: rescue-tui
+             ├──► kexec-loader
+             │
+             └──► (TPM PCR 12 measurement via tpm2_pcrextend shell-out)
+```
+
+| Crate | Lives | Used at | Role |
+|---|---|---|---|
+| `aegis-cli` | workstation | flash time | Operator CLI: `flash`, `list`, `add` |
+| `rescue-tui` | initramfs | boot time | TUI loop, screens, key bindings, kexec dispatch |
+| `iso-probe` | initramfs | boot time | Filesystem walk, sidecar verification, installer heuristic |
+| `iso-parser` | initramfs | boot time | Parses isolinux/grub/EFI configs out of an ISO to find kernel + initrd + cmdline |
+| `kexec-loader` | initramfs | boot time | Safe wrapper over `kexec_file_load(2)` syscall with error classification |
+| `aegis-fitness` | dev | CI / pre-release | Repo / build / artifact health audit (9 checks) |
+
+`unsafe` is forbidden workspace-wide except in `kexec-loader`, where the syscall lives behind a tightly scoped function.
+
+## What's on the stick
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  GPT partition table                                    │
+├─────────────────────────────────────────────────────────┤
+│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~400 MB)         │  ← signed boot chain
+│    /EFI/BOOT/BOOTX64.EFI   (MS-signed shim)             │     immutable in normal use
+│    /EFI/BOOT/grubx64.efi   (Canonical-signed grub)      │
+│    /EFI/BOOT/grub.cfg                                   │
+│    /vmlinuz                (Canonical-signed kernel)    │
+│    /initrd.img             (distro initrd + our /init)  │
+├─────────────────────────────────────────────────────────┤
+│  Part 2 — Data (FAT32 or ext4, label AEGIS_ISOS)        │  ← operator content
+│    ubuntu-24.04.2-live-server-amd64.iso                 │     replaceable without
+│    ubuntu-24.04.2-live-server-amd64.iso.sha256          │     reflashing
+│    fedora-workstation-41-x86_64.iso                     │
+│    alpine-3.20.3-x86_64.iso                             │
+│    alpine-3.20.3-x86_64.iso.pub  ← MOK key, optional    │
+└─────────────────────────────────────────────────────────┘
+```
+
+Splitting the two means: the operator can swap ISO sets without touching the signed boot chain, and the boot chain's immutability simplifies the threat model.
+
+## Build pipeline
+
+```
+   source ──► cargo build (Rust 1.85, pinned)
+            └─► rescue-tui binary
+
+   rescue-tui + busybox + /init script + ldd-resolved libs
+            └─► scripts/build-initramfs.sh
+                  └─► out/initramfs.cpio.gz (deterministic, SOURCE_DATE_EPOCH)
+
+   shim-signed + grub-efi-amd64-signed + linux-image + our initramfs
+            └─► scripts/mkusb.sh
+                  └─► out/aegis-boot.img (GPT + ESP + AEGIS_ISOS)
+
+   out/aegis-boot.img
+            └─► dd to /dev/sdX  (via aegis-boot flash, or by hand)
+```
+
+CI verifies:
+- Reproducibility: two `docker build` passes produce byte-identical `docker save` SHAs
+- Initramfs determinism: two `build-initramfs.sh` runs produce byte-identical `initramfs.cpio.gz`
+- OVMF SecBoot E2E: simulated SB-enforcing boot reaches rescue-tui
+- kexec E2E: rescue-tui successfully kexecs into a target kernel
+
+## Where to look in the code
+
+| You're working on | Start here |
+|---|---|
+| The TUI | [`crates/rescue-tui/src/main.rs`](../crates/rescue-tui/src/main.rs) (event loop), [`state.rs`](../crates/rescue-tui/src/state.rs) (state machine), [`render.rs`](../crates/rescue-tui/src/render.rs) (screens) |
+| The CLI | [`crates/aegis-cli/src/main.rs`](../crates/aegis-cli/src/main.rs) (dispatch), [`flash.rs`](../crates/aegis-cli/src/flash.rs), [`inventory.rs`](../crates/aegis-cli/src/inventory.rs) |
+| ISO discovery | [`crates/iso-probe/src/lib.rs`](../crates/iso-probe/src/lib.rs) |
+| ISO content parsing | [`crates/iso-parser/src/lib.rs`](../crates/iso-parser/src/lib.rs) |
+| The kexec syscall | [`crates/kexec-loader/src/lib.rs`](../crates/kexec-loader/src/lib.rs) (the only `unsafe` in the workspace) |
+| Stick assembly | [`scripts/mkusb.sh`](../scripts/mkusb.sh) |
+| Initramfs | [`scripts/build-initramfs.sh`](../scripts/build-initramfs.sh), `/init` is appended inline |
+
+## Glossary
+
+- **PK / KEK / db / dbx** — UEFI Secure Boot key hierarchy. Platform Key signs Key Exchange Keys, which sign the `db` allowlist and `dbx` blocklist of allowed/revoked binaries.
+- **MOK** — Machine Owner Key. Operator-controlled trust anchor enrolled via shim + `mokutil`. Lets you authorize binaries the platform CA didn't sign.
+- **SBAT** — Secure Boot Advanced Targeting. Component-level revocation carried inside shim and grub.
+- **shim** — Microsoft-signed bootloader shim that bridges the firmware → distro bootloader. Carries the distro CA and the MOK keyring.
+- **`kexec_file_load(2)`** — The signature-aware kexec syscall. Required when SB is enforcing; the older `kexec_load(2)` is blocked by kernel lockdown.
+- **`KEXEC_SIG`** — Kernel config that requires the loaded kernel to be signed by a key the platform trusts.
+- **GREEN / YELLOW / GRAY verdict** — rescue-tui's verification verdict on an ISO: GREEN = sha256 + minisig both verify; YELLOW = one verifies; GRAY = no sidecars present (boot allowed but with friction).
+
+---
+
+For deeper context:
+- Why this architecture and not EDK II or dracut? → [ADR 0001](./adr/0001-runtime-architecture.md)
+- Threat model (PK / KEK / MOK / SBAT details, attacker capabilities, non-goals) → [THREAT_MODEL.md](../THREAT_MODEL.md)
+- The full boot-chain narrative with verification at each step → [USB_LAYOUT.md § Chain of trust recap](./USB_LAYOUT.md#chain-of-trust-recap)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,149 @@
+# `aegis-boot` CLI reference
+
+The `aegis-boot` binary is the operator-facing front end. It wraps the build/flash/inventory operations that previously required running shell scripts and `dd` by hand.
+
+```
+aegis-boot — Signed boot. Any ISO. Your keys.
+
+USAGE:
+  aegis-boot flash [device]    Write aegis-boot to a USB stick
+  aegis-boot list [device]     Show ISOs on the stick
+  aegis-boot add <iso> [device] Copy + validate an ISO
+  aegis-boot --version         Print version
+  aegis-boot --help            This message
+```
+
+All three subcommands accept `--help` / `-h` for per-command usage.
+
+The implementation lives in [`crates/aegis-cli`](../crates/aegis-cli) (binary name `aegis-boot`).
+
+---
+
+## `aegis-boot flash`
+
+Writes a freshly built `aegis-boot.img` to a USB stick.
+
+### Usage
+
+```bash
+sudo aegis-boot flash             # auto-detect removable drives
+sudo aegis-boot flash /dev/sdc    # explicit device
+sudo aegis-boot flash --help
+```
+
+### What it does
+
+1. **Drive detection** — scans `/sys/block/sd*` for devices with `removable=1`. Skips NVMe, loop, and any system drive that isn't flagged removable. Reads model + size from sysfs.
+2. **Selection prompt** — shows numbered list, asks `[Y/n]` if exactly one drive, `[1-N]` otherwise. Pressing Enter on the single-drive prompt accepts.
+3. **Typed confirmation** — requires you to type the literal string `flash`. `y`, `yes`, `Y` are *not* accepted. This is intentional friction because `dd` to the wrong device destroys it.
+4. **Build** — invokes `scripts/mkusb.sh` with `OUT_DIR=<repo>/out` and `DISK_SIZE_MB=<full stick capacity>`.
+5. **Write** — invokes `sudo dd if=out/aegis-boot.img of=/dev/sdX bs=4M oflag=direct conv=fsync status=progress`.
+6. **Sync + partprobe** — flushes caches, asks the kernel to re-read the partition table.
+
+### Exit codes
+
+- `0` — success
+- `1` — drive not found, build failed, or `dd` failed
+- `2` — usage error (unknown subcommand)
+
+### Requirements
+
+- Repo root present (the binary `find_repo_root()`s for `Cargo.toml + crates/`). For now the CLI assumes the repo is on disk; standalone packaging is tracked separately.
+- `bash`, `sudo`, `dd`, `partprobe`, plus all the build prereqs in [BUILDING.md](../BUILDING.md).
+
+---
+
+## `aegis-boot list`
+
+Inventories ISOs on the stick.
+
+### Usage
+
+```bash
+aegis-boot list                       # auto-find mounted AEGIS_ISOS
+aegis-boot list /dev/sdc              # mount partition 2 of device, list, unmount
+aegis-boot list /mnt/aegis-isos       # use existing mount path
+aegis-boot list --help
+```
+
+### What it does
+
+1. **Mount resolution** — see [Mount resolution rules](#mount-resolution-rules) below.
+2. **Scan** — reads the mount directory, separates `.iso` files (case-insensitive on the extension) from sidecars.
+3. **Pair** — for each ISO, checks for sibling `<iso>.sha256` / `<iso>.SHA256SUMS` (either counts) and `<iso>.minisig`.
+4. **Print** — table with `[✓ sha256] [✓ minisig]  size  name` rows, sorted by name.
+
+If the CLI mounted the partition itself (`temporary: true`), it unmounts on exit.
+
+### Output sample
+
+```
+ISOs on /mnt/aegis-isos:
+
+  [✓ sha256] [✓ minisig]    1.6 GiB  ubuntu-24.04.2-live-server-amd64.iso
+  [  sha256] [  minisig]    198 MiB  alpine-3.20.3-x86_64.iso
+
+2 ISO(s) total. Legend:
+  ✓ sha256   sibling <iso>.sha256 present
+  ✓ minisig  sibling <iso>.minisig present
+  (missing sidecars mean the ISO will show GRAY verdict in rescue-tui)
+```
+
+---
+
+## `aegis-boot add`
+
+Copies an ISO + any sibling sidecars onto the stick.
+
+### Usage
+
+```bash
+aegis-boot add ~/Downloads/ubuntu.iso             # auto-find mount
+aegis-boot add ~/Downloads/ubuntu.iso /dev/sdc    # mount + copy + unmount
+aegis-boot add ~/Downloads/ubuntu.iso /mnt/aegis-isos
+aegis-boot add --help
+```
+
+### What it does
+
+1. **Validate source** — file must exist and be readable.
+2. **Mount resolution** — same rules as `list`.
+3. **Free-space check** — requires `iso_size + 10 MiB headroom` available on the target. Refuses (exit 1) if not, before touching anything.
+4. **Copy ISO** — `sudo cp <src> <mount>/<basename>`.
+5. **Copy sidecars** — for each of `.sha256`, `.SHA256SUMS`, `.minisig`, if `<src>.<ext>` exists, copy it to `<mount>/<basename>.<ext>`. Reports the count.
+6. **`sync`** — flush before the (possible) auto-unmount.
+
+### Sidecar conventions
+
+| Suffix | Purpose | Format |
+|---|---|---|
+| `<iso>.sha256` | Single-file SHA-256 checksum | `<hex>  <iso>` |
+| `<iso>.SHA256SUMS` | Multi-file checksums (some distros publish this form) | `<hex>  <filename>` per line |
+| `<iso>.minisig` | minisign signature | minisign format |
+
+If no sidecar is found, the operator gets an explicit notice in the output, and `rescue-tui` will show GRAY verdict + require a typed `boot` confirmation at boot time. We never silently accept an unverified ISO.
+
+---
+
+## Mount resolution rules
+
+Both `list` and `add` use the same logic to figure out where `AEGIS_ISOS` is:
+
+| Argument given | Behavior |
+|---|---|
+| (none) | Read `/proc/mounts`; find a line whose mount point contains `AEGIS_ISOS`. Use that. |
+| `/dev/sdX` | Use partition 2 (`/dev/sdX2`). Mount it to a tempdir under `/tmp` with `-t vfat -o rw,codepage=437,iocharset=cp437`. Unmount on exit. |
+| `/some/path` (existing dir) | Use as-is. Don't mount or unmount. |
+| `/some/path` (does not exist) | Error. |
+
+Why the explicit `codepage=437,iocharset=cp437`? Because the kernel's default `iocharset=utf8` is a separate module (`nls_utf8`) that we *do* ship in the rescue initramfs but is not always loaded on the operator's host kernel. Using cp437 avoids the dependency on the workstation side. The on-stick filenames are still readable from any modern host.
+
+## Versioning
+
+`aegis-boot --version` reports the workspace version (currently `0.12.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+
+## See also
+
+- [INSTALL.md](./INSTALL.md) — operator end-to-end walkthrough
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — common errors
+- [USB_LAYOUT.md](./USB_LAYOUT.md) — what the CLI is laying down on the stick

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,120 @@
+# Operator install guide
+
+End-to-end: get aegis-boot onto a USB stick, drop ISOs onto it, boot a target machine, and pick an ISO to kexec into. Reading time: ~5 minutes. Hands-on time: ~10 minutes plus dd.
+
+This guide assumes Linux on the operator workstation (where you write the stick). macOS / Windows flashing is tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123).
+
+## Before you start
+
+Have on hand:
+- A USB stick (8 GB or larger recommended; aegis-boot itself fits in 2 GB but you want headroom for ISOs)
+- One or more `.iso` files you want to be able to boot
+- A target machine with UEFI Secure Boot **enforcing** (the whole point of aegis-boot — if you've disabled SB, you're paying for protections you're not getting)
+- `sudo` on your workstation (we shell out to `dd`, `mount`, `umount`)
+
+## Step 1 — write aegis-boot to the stick
+
+```bash
+sudo aegis-boot flash
+```
+
+What happens:
+1. The CLI scans `/sys/block/sd*` for removable drives and shows you what it found:
+   ```
+   Detected removable drives:
+     [1] /dev/sdc  SanDisk Cruzer Blade  29.8 GB  (1 partitions)
+   ```
+2. It asks you to confirm. If only one removable drive is present, `[Y/n]`. If more than one, `[1-N]`.
+3. It asks for a typed `flash` confirmation (not `y/n`) — this is intentional friction because `dd` is destructive:
+   ```
+   ALL DATA ON /dev/sdc (SanDisk Cruzer Blade, 29.8 GB) WILL BE ERASED.
+   Type 'flash' to confirm: flash
+   ```
+4. It builds the image (`scripts/mkusb.sh`), `dd`s it to the stick with `oflag=direct conv=fsync status=progress`, syncs, and runs `partprobe`.
+
+Want to point at a specific drive instead of auto-detect? `sudo aegis-boot flash /dev/sdc`.
+
+If `aegis-boot flash` says "No removable USB drives detected", the kernel doesn't see the stick as removable. Replug it; check `lsblk -o NAME,TRAN,RM`; the stick should show `RM=1` and `TRAN=usb`.
+
+## Step 2 — add ISOs to the stick
+
+The stick now has two partitions: `AEGIS_ESP` (signed boot chain, leave it alone) and `AEGIS_ISOS` (where you drop ISOs). The CLI handles the mount/copy/unmount cycle for you:
+
+```bash
+aegis-boot add ~/Downloads/ubuntu-24.04.2-live-server-amd64.iso
+```
+
+What happens:
+1. The CLI reads `/proc/mounts` to find a currently-mounted `AEGIS_ISOS`. If none, it mounts the stick's partition 2 to a temporary directory.
+2. It checks free space (refuses if `iso_size + 10 MiB headroom` doesn't fit).
+3. It copies the ISO and any sibling sidecars: `<iso>.sha256`, `<iso>.SHA256SUMS`, `<iso>.minisig`. These let `rescue-tui` show a GREEN verification verdict instead of GRAY.
+4. It unmounts the temporary mount (if it created one).
+
+Verify:
+```bash
+aegis-boot list
+```
+
+```
+ISOs on /tmp/aegis-cli-12345-0:
+
+  [✓ sha256] [  minisig]    1.6 GiB  ubuntu-24.04.2-live-server-amd64.iso
+  [  sha256] [  minisig]    198 MiB  alpine-3.20.3-x86_64.iso
+
+2 ISO(s) total. Legend:
+  ✓ sha256   sibling <iso>.sha256 present
+  ✓ minisig  sibling <iso>.minisig present
+  (missing sidecars mean the ISO will show GRAY verdict in rescue-tui)
+```
+
+Sidecars are optional but strongly recommended — see [TROUBLESHOOTING.md § "Why is my ISO GRAY?"](./TROUBLESHOOTING.md#why-is-my-iso-gray-instead-of-green).
+
+## Step 3 — boot from the stick
+
+1. Plug the stick into the target machine.
+2. Open the firmware boot menu (commonly `F12`, `F11`, `Esc`, or `Del` at POST — varies by vendor).
+3. Pick the USB entry. It will show as "USB" or the stick's vendor name.
+4. shim verifies grub, grub verifies the kernel, the kernel runs `/init`, and `rescue-tui` starts.
+
+If the firmware refuses to show the USB entry, your boot mode might be CSM/Legacy instead of UEFI — see [TROUBLESHOOTING.md § "Stick won't appear in boot menu"](./TROUBLESHOOTING.md#stick-wont-appear-in-the-firmware-boot-menu).
+
+## Step 4 — pick an ISO
+
+`rescue-tui` shows your ISOs with verification status:
+
+```
+aegis-boot v0.12.0    SB:enforcing  TPM:available
+
+  ▸ ubuntu-24.04.2-live-server-amd64.iso        1.6 GiB  [✓ sha256]
+    alpine-3.20.3-x86_64.iso                     198 MiB  [no verify]
+
+[↑↓/jk] Move  [Enter] Boot  [/] Filter  [?] Help
+```
+
+Navigate with arrows (or `j/k`), press `Enter` to advance to the Confirm screen.
+
+The Confirm screen shows the verdict (GREEN / YELLOW / GRAY), the discovered kernel + initrd paths, and any installer warnings. **If the ISO is an installer image** (Ubuntu live-server, Fedora netinst, Windows, etc.), the screen explicitly warns:
+
+> Warning: This ISO contains an installer. If the ISO's own boot menu default is 'Install', DISKS ON THIS MACHINE MAY BE ERASED.
+
+Press `Enter` again to commit. The TUI prints a handoff banner ("Booting … screen may go blank briefly") and invokes `kexec_file_load(2)`. The selected kernel takes over.
+
+## Common outcomes
+
+- ✅ **Signed kernel boots cleanly.** You see `kexec_core: Starting new kernel` followed by the ISO's own boot.
+- ⚠️ **Unsigned kernel refused (`errno 61 ENODATA`).** The Error screen shows you the `mokutil --import` command. See [UNSIGNED_KERNEL.md](./UNSIGNED_KERNEL.md).
+- ❌ **Cross-distro kexec quirk.** Some kernels refuse to kexec other-vendor kernels. See [docs/compatibility/iso-matrix.md](./compatibility/iso-matrix.md) for the per-distro table.
+
+## Updating the stick later
+
+The signed boot chain (ESP) doesn't change between releases for the same `mkusb.sh` output — only the ISO set on `AEGIS_ISOS` changes day-to-day. So:
+
+- **Add or remove ISOs:** `aegis-boot add` / `rm` from a host mount. No reflash.
+- **Update aegis-boot itself** (new release): rerun `sudo aegis-boot flash`. This rewrites the whole stick, including erasing your ISO set — back up `AEGIS_ISOS` first if you care about its contents.
+
+## Where to go next
+
+- [docs/CLI.md](./CLI.md) — full `aegis-boot` CLI reference
+- [docs/TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — common errors and fixes
+- [docs/UNSIGNED_KERNEL.md](./UNSIGNED_KERNEL.md) — booting Alpine / Arch / NixOS via MOK enrollment
+- [docs/USB_LAYOUT.md](./USB_LAYOUT.md) — what's actually on the stick (ESP + AEGIS_ISOS scheme)

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -2,9 +2,9 @@
 
 While GitHub Actions CI is the primary validation gate, you can run the full matrix locally in ~8-15 minutes using KVM + libvirt (varies by hardware — fast NVMe + warm cargo cache hits the low end; cold cache or slower disks land closer to the high end). This is the right dev loop when:
 
-- GHA billing is constrained or paused.
 - You want instant feedback before pushing.
 - You're iterating on the QEMU-adjacent jobs (`mkusb`, `OVMF SecBoot E2E`, `kexec E2E`) that take several minutes to hit on CI.
+- CI is unavailable (rare; outage or quota issue).
 
 ## One-time setup
 
@@ -39,7 +39,7 @@ Steps it runs, in order (short-circuits on first failure):
 5. `scripts/mkusb.sh` — produces `out/aegis-boot.img`
 6. QEMU boot of the mkusb image under OVMF SecBoot — asserts SB enforcing + rescue-tui starts
 7. `scripts/qemu-kexec-e2e.sh` — asserts the rescue-tui → target-kernel kexec handoff
-8. `cargo run --release -p aegis-fitness` — repo / build / artifact health audit (added in v0.6.0)
+8. `cargo run --release -p aegis-fitness` — repo / build / artifact health audit
 
 Total runtime on a Framework laptop with warm cargo cache: ~8-10 min. Most of that is step 6 (QEMU cold boot) and step 7 (second QEMU cold boot + initramfs customization + ISO build). Cold cargo cache adds 2-5 min on top.
 
@@ -107,7 +107,7 @@ source dir, and boots under OVMF SecBoot. Image size auto-scales to
 | `sata` | AHCI module path (`ahci.ko`) | matches most desktops + older laptops |
 | `usb` | `qemu-xhci` + `usb-storage` | closest to a real USB stick plugged into a host |
 
-All three modes were verified end-to-end in v0.7.0 with Alpine 3.20 (4 ISO entries discovered).
+All three modes were verified end-to-end starting in v0.7.0 with Alpine 3.20 (4 ISO entries discovered); v0.12.0 added real-hardware shakedown via USB-passthrough on a SanDisk Cruzer 32 GB stick (Alpine refusal + Ubuntu boot, [#109](https://github.com/williamzujkowski/aegis-boot/issues/109)).
 
 ### Manual, if you want to inspect the partition
 
@@ -134,6 +134,4 @@ Then boot via `qemu-try.sh` — the TUI should list your ISOs.
 
 The scripts are deliberately identical to what CI invokes. If `dev-test.sh` passes locally, CI should too. If they diverge (different kernel, different OVMF version, different runner arch), file an issue — we want local to match the reference CI environment.
 
-## When billing is resolved
-
-Re-enable CI as the merge gate. Local testing becomes the pre-push sanity check rather than the primary validator.
+CI status is the merge gate; local testing is the pre-push sanity check. CI runs are visible at the [Actions tab](https://github.com/williamzujkowski/aegis-boot/actions).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,13 @@
 
 | Audience | Doc | What's in it |
 |---|---|---|
-| **Operator** (deploying aegis-boot) | [`USB_LAYOUT.md`](./USB_LAYOUT.md) | GPT + ESP + AEGIS_ISOS scheme; how to dd to a stick; how to drop ISOs onto the data partition |
+| **Operator** | [`INSTALL.md`](./INSTALL.md) | End-to-end: flash → add ISOs → boot → select. The first thing to read. |
+| **Operator** | [`CLI.md`](./CLI.md) | `aegis-boot` CLI reference — `flash`, `list`, `add` subcommand details |
+| **Operator** | [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) | Common errors and fixes (errno 61, won't-boot, mount issues, MOK pitfalls) |
+| **Operator** | [`UNSIGNED_KERNEL.md`](./UNSIGNED_KERNEL.md) | What to do when an ISO ships an unsigned kernel (Alpine, Arch, NixOS) |
+| **Operator** | [`USB_LAYOUT.md`](./USB_LAYOUT.md) | GPT + ESP + AEGIS_ISOS scheme; manual loop-mount workflow; FAT32 vs ext4 trade-off |
 | **Operator** | [`compatibility/iso-matrix.md`](./compatibility/iso-matrix.md) | Per-distro kexec compatibility — what works, what surfaces a quirk |
+| **Developer** | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | One-page mental model — boot chain, crate dependencies, trust boundaries |
 | **Developer** | [`LOCAL_TESTING.md`](./LOCAL_TESTING.md) | 8-stage local CI equivalent; `qemu-loaded-stick.sh --attach` modes; iteration recipes |
 | **Developer** | [`../BUILDING.md`](../BUILDING.md) | Reproducible build setup (Docker `Dockerfile.locked` + Nix `flake.nix`) |
 | **Developer** | [`../scripts/README.md`](../scripts/README.md) | What each script does and when to run it |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,159 @@
+# Troubleshooting
+
+Common errors operators hit, what they mean, and how to fix them. Organized by where you're likely to see the problem (workstation, firmware, rescue-tui, kexec).
+
+If your problem isn't here, file an issue with the output of `aegis-boot --version`, the host distro, the target firmware vendor + UEFI mode, and the relevant logs (kernel ring buffer for kexec issues; rescue-tui's stderr / journalctl for TUI issues).
+
+---
+
+## Workstation (writing the stick)
+
+### "No removable USB drives detected"
+
+`aegis-boot flash` enumerates `/sys/block/sd*` filtering by `removable=1`. If your stick doesn't show:
+
+1. `lsblk -o NAME,SIZE,TRAN,RM` — confirm the kernel sees it as `RM=1`. If `RM=0`, the device is not flagged removable (some "USB SSDs" present as fixed). Pass the device explicitly: `sudo aegis-boot flash /dev/sdX`.
+2. `dmesg | tail` — look for the device enumeration line. If absent, the host didn't see the plug event. Replug.
+3. Some USB-C hubs drop hot-plug events. Plug the stick directly into the host.
+
+### "/dev/sdX is not a removable drive (or not detected as one)"
+
+You passed an explicit device, but the kernel reports `removable=0`. Either you're targeting the wrong device (verify with `lsblk`) or the stick presents as fixed. To override the safety check, you'd need to use `dd` directly — but only after you're certain. Mistargeting destroys the wrong drive.
+
+### "mkusb.sh exited with N"
+
+The build script failed before `dd` ran. Inspect the script's stderr (printed inline by `aegis-boot flash`). Common causes:
+
+- `chmod 0644 /boot/vmlinuz-* /boot/initrd.img-*` not run after a kernel update — the script can't read the kernel.
+- Missing `shim-signed` / `grub-efi-amd64-signed` packages.
+- `mtools` / `dosfstools` / `gdisk` not installed.
+
+See [BUILDING.md](../BUILDING.md) and [LOCAL_TESTING.md § "One-time setup"](./LOCAL_TESTING.md#one-time-setup).
+
+### `dd` exited with a non-zero status partway through
+
+The stick may have failed (worn-out NAND), the cable may be flaky, or the host may have hit ENOSPC on the source side. Re-run after a replug; if the second attempt also fails on the same write offset, the stick is bad — get another.
+
+### "not enough free space" from `aegis-boot add`
+
+You're trying to add an ISO larger than what's free on `AEGIS_ISOS`. Either:
+
+- Free space: `rm` something via the host mount, or use `aegis-boot list` to see what's there and decide.
+- Reflash with a larger image: `DISK_SIZE_MB=8192 sudo aegis-boot flash` (or set the env on `mkusb.sh` if you build manually).
+- For ISOs > 4 GB on FAT32: rebuild with `DATA_FS=ext4 ./scripts/mkusb.sh`. Trade-off: ext4 isn't natively writable from macOS / Windows.
+
+---
+
+## Firmware / boot menu
+
+### Stick won't appear in the firmware boot menu
+
+1. Confirm Secure Boot is **enforcing** (not disabled, not "Audit"). aegis-boot is built for enforcing SB; on a disabled-SB host it will still boot, but you're not getting the protections you wanted.
+2. Confirm the firmware is in **UEFI mode**, not CSM/Legacy. aegis-boot ships only a UEFI boot image; CSM won't see it. Boot menu options like "USB-HDD" (legacy) vs "UEFI: USB Storage" (UEFI) are the tell.
+3. Some vendors require the stick to be plugged in *before* power-on for the firmware to enumerate it.
+4. Try a different USB port. xHCI ports usually work; older EHCI/UHCI ports sometimes need a kernel driver the firmware doesn't have.
+
+### Firmware says "Secure Boot violation" loading the stick
+
+shim's vendor cert isn't in your firmware's `db`. This is rare on consumer hardware (Microsoft's CA is essentially universal) but happens on locked-down corporate fleets. Options:
+
+- Enroll Microsoft's UEFI CA in your firmware's `db` (vendor-specific UI).
+- Re-sign shim with your own KEK (advanced; requires custom signing chain — see [#24](https://github.com/williamzujkowski/aegis-boot/issues/24) tracking).
+
+---
+
+## rescue-tui
+
+### TUI shows no ISOs
+
+1. Did you actually copy ISOs to `AEGIS_ISOS`? Verify from the host with `aegis-boot list`.
+2. The TUI scans `AEGIS_ISO_ROOTS` (default `/run/media:/mnt`). The initramfs auto-mounts the partition under `/run/media/aegis-isos/`. If you've changed `AEGIS_ISO_ROOTS` on the kernel cmdline, the partition might not be in the search path.
+3. Check the journal: at the rescue shell, `journalctl -b 0 -u rescue-tui` (or read `/var/log/messages`).
+
+### TUI shows ISOs but no kernel detected
+
+`iso-probe` couldn't parse the ISO's boot config. Most distros use isolinux / GRUB / EFI configs that we know how to parse, but some custom or very old images don't follow the standard layout. The Confirm screen will show "no kernel found" and refuse to boot. Workarounds:
+
+- Use a current image from the distro vendor instead of a re-spun community build.
+- File an issue with the ISO source URL — we may want to add parser support.
+
+### Why is my ISO GRAY instead of GREEN?
+
+GRAY = no verification sidecars present. The ISO will boot but rescue-tui requires a typed `boot` confirmation as a friction step (we don't silently accept an unverified ISO).
+
+To make it GREEN, drop sidecars next to the ISO:
+
+```bash
+# Before flashing:
+cp ubuntu-24.04.2-live-server-amd64.iso ./
+sha256sum ubuntu-24.04.2-live-server-amd64.iso > ubuntu-24.04.2-live-server-amd64.iso.sha256
+# Then:
+aegis-boot add ubuntu-24.04.2-live-server-amd64.iso   # picks up the sidecar automatically
+```
+
+For minisign signatures: distros that publish `.minisig` files (or `SHA256SUMS.gpg` you've validated yourself) — use those when you can. The verification status in the TUI is just data; the operator decides whether to accept it.
+
+---
+
+## kexec hand-off
+
+### `errno 61 (ENODATA)` — "kernel signature rejected"
+
+Expected. The ISO's kernel isn't signed by a CA in the platform keyring. This is correct Secure Boot behavior — `kexec_file_load(2)` enforces the same signature policy as the boot loader. Two paths forward:
+
+1. Use a distro-signed ISO (Ubuntu, Fedora, Debian, RHEL).
+2. Enroll the distro's signing key via MOK — see [UNSIGNED_KERNEL.md](./UNSIGNED_KERNEL.md).
+
+**Never** run `mokutil --disable-validation` to "fix" this. That's not a fix; it's disabling Secure Boot on the host.
+
+### `errno 1 (EPERM)` — "operation not permitted"
+
+Two common causes:
+
+1. The TUI is running without `CAP_SYS_BOOT`. Shouldn't happen in the shipped initramfs, but if you've customized `/init`, verify.
+2. Kernel lockdown is in `confidentiality` mode and refuses kexec entirely. This is rare on Ubuntu; some hardened distros set it. Check `/sys/kernel/security/lockdown`.
+
+### `CrossDistroKexecRefused` quirk
+
+Some kernels refuse to kexec other-vendor kernels even when the signature would otherwise verify. This isn't aegis-boot policy — it's the target kernel's own check. Documented per-distro in [docs/compatibility/iso-matrix.md](./compatibility/iso-matrix.md). Workaround: use an ISO whose kernel matches (or is closely related to) the rescue kernel's vendor.
+
+### `kexec_core: Starting new kernel` then immediate hang
+
+The new kernel loaded but its early init didn't survive the hand-off. Most common cause is an initrd that expects to be loaded by a specific bootloader and not by `kexec_file_load`. Open an issue with the kernel ring buffer captured before the hang (`dmesg -w` from the rescue shell on a separate session).
+
+### Screen goes blank after the handoff banner — is it hung?
+
+Probably not. The handoff banner ([#127](https://github.com/williamzujkowski/aegis-boot/issues/127)) prints a "screen may go blank briefly while the new kernel loads" notice exactly because the framebuffer can drop signal during kexec. Wait 10-30 seconds. If still nothing:
+
+- Some kernels need an explicit framebuffer cmdline (`fbcon=map:0` or `console=tty0 console=ttyS0,115200n8`). The ISO's own bootloader sets these; aegis-boot tries to preserve the ISO's `cmdline` but parsing failures fall back to a minimal cmdline.
+- If you have serial access (real hardware with a serial header, or QEMU serial console), check there.
+
+---
+
+## When in doubt
+
+Drop to the rescue shell from the List screen (navigate to the `[#] rescue shell` entry, press Enter). You're in a busybox shell with the full initramfs around you. Useful commands:
+
+```sh
+ls /run/media/aegis-isos/         # see what's mounted
+dmesg | tail -50                   # recent kernel messages
+cat /sys/kernel/security/lockdown  # kernel lockdown mode
+mokutil --sb-state                 # SB enforcing state (if mokutil is shipped)
+```
+
+To exit and reboot: `reboot -f` (or power-cycle).
+
+---
+
+## Filing a bug
+
+`.github/ISSUE_TEMPLATE/bug.yml` will prompt you for:
+
+- aegis-boot version (`aegis-boot --version`)
+- Host workstation distro + kernel (`uname -a`)
+- Target firmware vendor + UEFI mode + Secure Boot state
+- ISO that failed (vendor + version + URL if public)
+- Reproduction steps
+- Relevant logs
+
+For security-relevant findings, **do not file a public issue** — see [SECURITY.md](../SECURITY.md) for the private path.

--- a/docs/UNSIGNED_KERNEL.md
+++ b/docs/UNSIGNED_KERNEL.md
@@ -14,9 +14,9 @@ Under aegis-boot, **the operator chooses per-ISO** whether to trust an unsigned 
 
 The simplest path. These distros ship kernels signed by a UEFI CA that shim's built-in keyring trusts:
 
-| Distro | Verified under aegis-boot v0.11.0 |
+| Distro | Verified under aegis-boot v0.12.0 |
 |---|---|
-| Ubuntu 24.04+ | ✅ `kexec_core: Starting new kernel` (Canonical CA) |
+| Ubuntu 24.04+ | ✅ `kexec_core: Starting new kernel` (Canonical CA, real-hardware shakedown #109) |
 | Fedora 39+ | likely (Fedora CA, unverified) |
 | Debian 12+ | likely (Debian CA, unverified) |
 | RHEL / Rocky / AlmaLinux | likely (Red Hat CA); may hit `CrossDistroKexecRefused` quirk |
@@ -45,7 +45,7 @@ For distros that ship unsigned kernels — **Alpine, Arch, NixOS** — you need 
      sudo mokutil --import /run/media/aegis-isos/alpine-3.20.3-x86_64.iso.pub
    ```
 
-4. Drop to the rescue shell (press `[#]` from the List), copy that `mokutil` command, reboot to your normal system, and run it there. `mokutil` will prompt for a one-time password.
+4. Drop to the rescue shell (from the List screen, navigate to the `[#] rescue shell` entry and press Enter), copy that `mokutil` command, reboot to your normal system, and run it there. `mokutil` will prompt for a one-time password.
 
 5. Reboot — shim's MOK Manager intercepts at firmware stage, asks for the password, enrolls the key permanently.
 
@@ -65,7 +65,7 @@ Initially scoped (#126) as a `aegis.relaxed=1` cmdline opt-in that would fall ba
 
 ## Validation
 
-As of v0.11.0:
+As of v0.12.0 (real-hardware shakedown, [#109](https://github.com/williamzujkowski/aegis-boot/issues/109)):
 
 - Alpine 3.20.3 (unsigned kernel) → `errno 61 (ENODATA)` with the guidance above. ✅ expected, correct.
 - Ubuntu 24.04.2 (Canonical-signed) → `kexec_core: Starting new kernel`. ✅ boots through.

--- a/docs/USB_LAYOUT.md
+++ b/docs/USB_LAYOUT.md
@@ -67,7 +67,8 @@ sudo apt-get install -y \
     mtools dosfstools gdisk
 
 # Kernel reads require root (kernels are mode 0600 by default on modern Ubuntu).
-sudo chmod 0644 /boot/vmlinuz-*-virtual /boot/initrd.img-*-virtual
+# Catches both -virtual and -generic suffixes.
+sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-*
 
 ./scripts/build-initramfs.sh   # produces out/initramfs.cpio.gz
 ./scripts/mkusb.sh             # produces out/aegis-boot.img
@@ -117,7 +118,7 @@ sudo umount /mnt/aegis-isos
 
 ## Storage modules shipped in the initramfs
 
-For rescue-tui to see the AEGIS_ISOS partition (or any internal disk the operator might want to scan), the initramfs has to include the kernel modules for the storage controller. Most modern Ubuntu generic kernels (6.8+) compile these as modules, not built-in. As of v0.7.0 (#72), `build-initramfs.sh` ships:
+For rescue-tui to see the AEGIS_ISOS partition (or any internal disk the operator might want to scan), the initramfs has to include the kernel modules for the storage controller. Most modern Ubuntu generic kernels (6.8+) compile these as modules, not built-in. As of v0.7.0 (#72), `build-initramfs.sh` ships (current as of v0.12.0):
 
 - `libahci`, `ahci` — SATA AHCI controllers (most desktops + older laptops)
 - `nvme-core`, `nvme` — NVMe SSDs (most modern laptops)
@@ -126,7 +127,7 @@ For rescue-tui to see the AEGIS_ISOS partition (or any internal disk the operato
 
 `scsi_mod`, `sd_mod`, `usbcore`, `xhci-hcd/pci`, `ehci-hcd/pci`, and `loop`/`isofs`/`udf` are typically built-in on Ubuntu kernels and skipped at build time with an INFO log. `/init` modprobes the full set early; built-in modules return successfully without doing anything.
 
-Real-hardware boot has been validated only in QEMU simulation as of v0.7.0 (`scripts/qemu-loaded-stick.sh --attach {virtio,sata,usb}`). A Framework / ThinkPad / Dell shakedown is tracked in [#51](https://github.com/williamzujkowski/aegis-boot/issues/51).
+Real-hardware shakedown was completed in v0.12.0 ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)) on a SanDisk Cruzer 32 GB stick via QEMU USB-passthrough: Alpine 3.20.3 returned the expected `errno 61` refusal under enforcing Secure Boot, and Ubuntu 24.04.2 successfully kexec'd through (`kexec_core: Starting new kernel`). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell direct boot) is tracked in [#51](https://github.com/williamzujkowski/aegis-boot/issues/51) for v1.0.0.
 
 ## Chain of trust recap
 

--- a/docs/content-audit.md
+++ b/docs/content-audit.md
@@ -4,7 +4,8 @@ Per [#78](https://github.com/williamzujkowski/aegis-boot/issues/78), this file r
 
 | Date       | Reviewing | Files audited | Findings filed | PRs |
 |------------|-----------|---------------|----------------|-----|
-| 2026-04-15 | v0.7.0    | README, BUILDING, SECURITY, THREAT_MODEL, CHANGELOG, USB_LAYOUT, LOCAL_TESTING, all ADRs, all compatibility/, all crate Cargo.toml + top-level rustdoc | #76, #77, #78 (epics); inline fixes in this PR | #79 (this) |
+| 2026-04-16 | v0.12.0   | README, CONTRIBUTING, ROADMAP, CHANGELOG, SECURITY, THREAT_MODEL, BUILDING, all docs/* (incl. UNSIGNED_KERNEL, USB_LAYOUT, LOCAL_TESTING, content-audit), .github/CODEOWNERS, all crate Cargo.toml + crate-level rustdoc, scripts/mkusb.sh env vars | inline fixes in this PR; new docs (INSTALL, TROUBLESHOOTING, ARCHITECTURE, CLI); .github/ISSUE_TEMPLATE + pull_request_template added | (this PR) |
+| 2026-04-15 | v0.7.0    | README, BUILDING, SECURITY, THREAT_MODEL, CHANGELOG, USB_LAYOUT, LOCAL_TESTING, all ADRs, all compatibility/, all crate Cargo.toml + top-level rustdoc | #76, #77, #78 (epics); inline fixes in this PR | #79 |
 | 2026-04-15 | v0.6.0    | CHANGELOG (partial) | #52 | #58 |
 
 ## Process


### PR DESCRIPTION
## Summary

Full documentation audit ahead of (now after) making the repo public. Four parallel reviewers spawned via the agent harness; findings deduplicated and applied as one commit.

## Accuracy fixes (10 files, drift since v0.7.0)

- **README** — status v0.10.0 → v0.12.0; added `aegis-cli` to Components; restructured Quickstart into operator vs developer paths; new comparison table vs Ventoy / Rufus / balenaEtcher (the SB chain-of-trust positioning is the whole point); Runtime Configuration env-var reference for `AEGIS_*`; explicit License section.
- **CONTRIBUTING** — test count 108 → 140; reference operator CLI.
- **UNSIGNED_KERNEL** / **USB_LAYOUT** — v0.11.0 / v0.7.0 references → v0.12.0 with [#109](https://github.com/williamzujkowski/aegis-boot/issues/109) shakedown citation; chmod glob catches both `-virtual` and `-generic`.
- **LOCAL_TESTING** — dropped "billing paused" transient text.
- **THREAT_MODEL** — re-confirmed for v0.12.0 (operator CLI sits below the kernel-verification trust boundary).
- **ROADMAP** — shipped items moved to "Recently shipped"; "Now" reflects v1.0 gates ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51), [#132](https://github.com/williamzujkowski/aegis-boot/issues/132), [#123](https://github.com/williamzujkowski/aegis-boot/issues/123)).
- **content-audit** — added v0.12.0 audit entry.
- **rescue-tui doc-comment** — ASCII art `v0.7.1` → `v0.12.0`; verified `cargo build` + `cargo doc` pass.

## New operator docs (4 files, 586 lines)

- **`docs/INSTALL.md`** — flash → add ISOs → boot → select walkthrough.
- **`docs/CLI.md`** — full `aegis-boot` CLI reference grounded in the actual `flash.rs` / `inventory.rs` / `detect.rs` source.
- **`docs/TROUBLESHOOTING.md`** — common errors organized by where they hit (workstation, firmware, TUI, kexec). errno 61, "stick won't appear", GRAY verdict, etc.
- **`docs/ARCHITECTURE.md`** — one-page mental model: boot chain diagram, crate dependency graph, glossary.

## GitHub templates (`.github/`)

- **ISSUE_TEMPLATE/bug.yml** — structured bug template (version, where, what happened, repro, env, logs).
- **ISSUE_TEMPLATE/feature.yml** — structured feature template (problem, proposal, alternatives, scope, priority).
- **ISSUE_TEMPLATE/config.yml** — disables blank issues; redirects security findings to private advisory; redirects open-ended questions to Discussions.
- **pull_request_template.md** — summary / linked issue / what changed / how tested / risk / out-of-scope.

## Test plan

- [x] `cargo build --workspace` passes locally (already on main via #134)
- [x] `cargo doc -p rescue-tui` succeeds (doc-comment edit valid)
- [ ] CI green on this PR

## Out of scope (deliberate)

- Asciinema / TUI screenshots (need real captures the maintainer should record themselves).
- `.github/FUNDING.yml` (sponsorship decision is the maintainer's, not the doc-audit's).
- `scripts/check-env.sh` (separate work; tracked separately if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)