### PR TITLE
quality(iso-parser): forbid(unsafe_code) at crate root

### DIFF
--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -3,6 +3,14 @@
 //! Scans directories for ISO files, detects distribution layouts, and extracts
 //! kernel/initrd paths for boot configuration.
 //!
+//! # Safety
+//!
+//! `forbid(unsafe_code)` at the crate level — `iso-parser` ships to crates.io
+//! per [#51](https://github.com/williamzujkowski/aegis-boot/issues/51) and a
+//! library that parses untrusted ISO content has no business calling raw
+//! syscalls. The kexec syscall lives in `kexec-loader`, the only crate in the
+//! workspace that's exempt from this constraint.
+//!
 //! # Supported Distributions
 //! - **Arch Linux**: `/boot/` contains `vmlinuz` and `initrd.img`
 //! - **Debian/Ubuntu**: `/install/` or `/casper/` contains `vmlinuz` and `initrd.gz`
@@ -21,6 +29,8 @@
 //!     }
 //! }
 //! ```
+
+#![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

Adds `#![forbid(unsafe_code)]` to `iso-parser`'s crate root. iso-parser ships to crates.io per #51 — a parser library with public API has no business calling raw syscalls, and `forbid` (unlike workspace-wide `unsafe = deny`) cannot be opted out of by a future contributor adding `#[allow(unsafe_code)]`.

The `kexec-loader` crate remains the only one with `unsafe`, which is its purpose.

## Test plan

- [x] `cargo build -p iso-parser` clean
- [x] `cargo test -p iso-parser` — 18 + 1 ignored, all green
- [ ] CI

Refs epic #138 (v1.0 quality gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)