### PR TITLE
feat(install): cosign-verified curl | sh installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,12 @@ jobs:
           fi
           # Append the verification footer (kept in docs/ to avoid
           # heredoc-vs-YAML indentation hazards in this workflow file).
-          cat docs/RELEASE_NOTES_FOOTER.md >> out/release-notes.md
+          # Optional: older tags pre-dating the footer file just skip it.
+          if [ -f docs/RELEASE_NOTES_FOOTER.md ]; then
+            cat docs/RELEASE_NOTES_FOOTER.md >> out/release-notes.md
+          else
+            echo "(no docs/RELEASE_NOTES_FOOTER.md at this ref — skipping verification footer)" >&2
+          fi
           echo "path=out/release-notes.md" >> "$GITHUB_OUTPUT"
 
       # ---------- Create release if missing, then upload assets ------

--- a/README.md
+++ b/README.md
@@ -50,17 +50,37 @@ aegis-boot is the right pick when you need to boot operator-supplied ISOs **with
 
 ## Quickstart — operators
 
-Pre-built binaries are published per release; build from source per [BUILDING.md](./BUILDING.md) if needed.
+Install the operator CLI (Linux x86_64 today; cross-platform tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123)):
 
 ```bash
-# 1. write aegis-boot to a USB stick (3-step guided; auto-detects removable drives)
+# Cosign-verified install from the latest GitHub release.
+curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh
+
+# Or pin a version: sh install.sh --version v0.12.0
+# Or skip cosign (NOT recommended): sh install.sh --no-verify
+# Build from source: see BUILDING.md.
+```
+
+Each release ships a static-musl `aegis-boot-x86_64-linux` binary plus its Sigstore cosign signature + certificate; the installer checks the cert is bound to *this* repo's `release.yml` workflow before installing. See `docs/RELEASE_NOTES_FOOTER.md` for the manual `cosign verify-blob` recipe.
+
+Then the operator flow:
+
+```bash
+# 0. (recommended) check host + stick health before doing anything destructive
+aegis-boot doctor
+
+# 1. browse the curated catalog — known-good signed-or-MOK-needed ISOs
+aegis-boot recommend
+aegis-boot recommend ubuntu-24.04-live-server   # one entry's download recipe
+
+# 2. write aegis-boot to a USB stick (3-step guided; auto-detects removable drives)
 sudo aegis-boot flash             # or: sudo aegis-boot flash /dev/sdc
 
-# 2. add ISOs to the stick (auto-detects mount; copies sidecars too)
+# 3. add ISOs to the stick (auto-detects mount; copies sidecars too)
 aegis-boot add ~/Downloads/ubuntu-24.04.2-live-server-amd64.iso
 aegis-boot list                   # show what's on the stick
 
-# 3. plug the stick into a target machine, boot from it (UEFI + SB enabled)
+# 4. plug the stick into a target machine, boot from it (UEFI + SB enabled)
 #    The TUI discovers ISOs, shows verification status, and kexecs on Enter.
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,6 +12,25 @@ Have on hand:
 - A target machine with UEFI Secure Boot **enforcing** (the whole point of aegis-boot — if you've disabled SB, you're paying for protections you're not getting)
 - `sudo` on your workstation (we shell out to `dd`, `mount`, `umount`)
 
+## Step 0 — install the operator CLI
+
+```bash
+curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh
+```
+
+This downloads the latest release's `aegis-boot-x86_64-linux` static binary, verifies its Sigstore cosign signature against this repo's `release.yml` workflow identity, and installs to `/usr/local/bin` (root) or `~/.local/bin` (non-root).
+
+The installer itself does NOT need root unless you're installing to `/usr/local/bin`. To inspect first: `curl -sSL ... -o install.sh && less install.sh && sh install.sh`.
+
+Sanity check:
+
+```bash
+aegis-boot --version       # → aegis-boot v0.12.0
+aegis-boot doctor          # 0–100 health score for host + stick
+```
+
+If `aegis-boot doctor` reports anything FAIL, fix that first — its NEXT ACTION line tells you exactly what.
+
 ## Step 1 — write aegis-boot to the stick
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,280 @@
+#!/bin/sh
+# aegis-boot installer.
+#
+# Downloads the latest (or a specific) release of the `aegis-boot`
+# operator CLI, verifies its Sigstore cosign signature, and installs
+# the binary to /usr/local/bin (or ~/.local/bin if non-root).
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh
+#   sh install.sh --version v0.12.0
+#   sh install.sh --prefix ~/.local/bin
+#   sh install.sh --no-verify             # skip cosign (NOT recommended)
+#
+# Exit codes:
+#   0  success
+#   1  install failed (download / verify / write)
+#   2  usage error
+#   64 cosign missing and verification was requested
+#
+# This script is wrapped in a `main` function so that a truncated
+# `curl | sh` download will fail to define `main` and exit cleanly
+# rather than executing partial logic.
+
+set -eu
+
+REPO="williamzujkowski/aegis-boot"
+DEFAULT_PREFIX_ROOT="/usr/local/bin"
+DEFAULT_PREFIX_USER="$HOME/.local/bin"
+COSIGN_IDENTITY_REGEXP='^https://github\.com/williamzujkowski/aegis-boot/\.github/workflows/release\.yml@refs/tags/v.+$'
+COSIGN_OIDC_ISSUER='https://token.actions.githubusercontent.com'
+
+usage() {
+    cat <<EOF
+aegis-boot installer
+
+USAGE:
+  install.sh [--version VER] [--prefix DIR] [--no-verify] [--help]
+
+OPTIONS:
+  --version VER   Install a specific release tag (e.g. v0.12.0).
+                  Default: latest GitHub release.
+  --prefix DIR    Install destination. Default: $DEFAULT_PREFIX_ROOT
+                  if running as root, else $DEFAULT_PREFIX_USER.
+  --no-verify     Skip cosign signature verification.
+                  Strongly discouraged outside dev/test.
+  --help          This message.
+
+EXAMPLES:
+  curl -sSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh
+  sh install.sh --version v0.12.0
+  sudo sh install.sh --prefix /usr/local/bin
+EOF
+}
+
+# --- platform detection ----------------------------------------------------
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux)  echo "linux" ;;
+        Darwin) echo "darwin" ;;
+        *) echo "unsupported" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        *) echo "unsupported" ;;
+    esac
+}
+
+# --- helpers ---------------------------------------------------------------
+
+err() { printf 'install.sh: error: %s\n' "$*" >&2; }
+note() { printf 'install.sh: %s\n' "$*"; }
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "missing required command: $1"
+        return 1
+    fi
+}
+
+# Print a download URL for an asset on a given release tag.
+# Uses the `latest` API when tag = "" (empty).
+asset_url() {
+    asset="$1"
+    tag="$2"
+    if [ -z "$tag" ]; then
+        printf 'https://github.com/%s/releases/latest/download/%s' "$REPO" "$asset"
+    else
+        printf 'https://github.com/%s/releases/download/%s/%s' "$REPO" "$tag" "$asset"
+    fi
+}
+
+# Download with curl or wget, whichever's available. Writes to $2.
+download() {
+    url="$1"
+    dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            --output "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget --quiet --output-document "$dest" "$url"
+    else
+        err "neither curl nor wget found — install one and retry"
+        return 1
+    fi
+}
+
+# --- main ------------------------------------------------------------------
+
+main() {
+    version=""
+    prefix=""
+    skip_verify=0
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --version)
+                shift
+                version="${1:-}"
+                if [ -z "$version" ]; then
+                    err "--version requires a tag argument"
+                    return 2
+                fi
+                ;;
+            --version=*)
+                version="${1#*=}"
+                ;;
+            --prefix)
+                shift
+                prefix="${1:-}"
+                if [ -z "$prefix" ]; then
+                    err "--prefix requires a directory argument"
+                    return 2
+                fi
+                ;;
+            --prefix=*)
+                prefix="${1#*=}"
+                ;;
+            --no-verify)
+                skip_verify=1
+                ;;
+            --help|-h)
+                usage
+                return 0
+                ;;
+            *)
+                err "unknown option: $1"
+                usage >&2
+                return 2
+                ;;
+        esac
+        shift
+    done
+
+    # Resolve install prefix.
+    if [ -z "$prefix" ]; then
+        if [ "$(id -u)" -eq 0 ]; then
+            prefix="$DEFAULT_PREFIX_ROOT"
+        else
+            prefix="$DEFAULT_PREFIX_USER"
+        fi
+    fi
+
+    # Detect platform.
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    if [ "$os" = "unsupported" ] || [ "$arch" = "unsupported" ]; then
+        err "unsupported platform: $(uname -s)/$(uname -m)"
+        err "supported today: linux/x86_64 (linux/aarch64, darwin/*, windows tracked in #137 and #123)"
+        return 1
+    fi
+    if [ "$os" != "linux" ] || [ "$arch" != "x86_64" ]; then
+        err "no published binary for $os/$arch yet"
+        err "today's release ships only linux/x86_64; cross-platform expansion is tracked in #123"
+        return 1
+    fi
+
+    asset="aegis-boot-${arch}-${os}"
+    note "platform: $os/$arch"
+    note "release:  ${version:-latest}"
+    note "prefix:   $prefix"
+    if [ "$skip_verify" -eq 1 ]; then
+        note "WARNING: cosign verification disabled (--no-verify). Trust at your own risk."
+    fi
+
+    # Need curl or wget for downloads.
+    require_cmd uname || return 1
+    if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+        err "need curl or wget"
+        return 1
+    fi
+
+    # Cosign required unless --no-verify.
+    if [ "$skip_verify" -eq 0 ]; then
+        if ! command -v cosign >/dev/null 2>&1; then
+            err "cosign not found in PATH. Install from https://docs.sigstore.dev/cosign/installation/"
+            err "or re-run with --no-verify (not recommended)"
+            return 64
+        fi
+    fi
+
+    # Stage downloads in a tempdir.
+    tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/aegis-boot-install.XXXXXX")"
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    note "downloading $asset..."
+    download "$(asset_url "$asset" "$version")" "$tmpdir/$asset"
+    if [ "$skip_verify" -eq 0 ]; then
+        download "$(asset_url "${asset}.sig" "$version")" "$tmpdir/$asset.sig"
+        download "$(asset_url "${asset}.pem" "$version")" "$tmpdir/$asset.pem"
+    fi
+
+    # Verify cosign signature.
+    if [ "$skip_verify" -eq 0 ]; then
+        note "verifying cosign signature..."
+        if ! cosign verify-blob \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
+            --signature "$tmpdir/$asset.sig" \
+            --certificate "$tmpdir/$asset.pem" \
+            "$tmpdir/$asset" >/dev/null 2>&1
+        then
+            err "cosign verification FAILED for $asset"
+            err "this binary did NOT come from $REPO's release.yml workflow"
+            err "do NOT install. Re-download from a different network if you suspect MITM."
+            return 1
+        fi
+        note "  cosign: OK (identity matches $REPO release workflow)"
+    fi
+
+    # Install.
+    chmod +x "$tmpdir/$asset"
+    target="$prefix/aegis-boot"
+
+    if [ ! -d "$prefix" ]; then
+        # Try to create with the right tool.
+        if [ "$prefix" = "$DEFAULT_PREFIX_USER" ] || [ -w "$(dirname "$prefix")" ]; then
+            mkdir -p "$prefix"
+        else
+            err "$prefix does not exist and $(id -un) cannot create it"
+            err "create it first (e.g. sudo mkdir -p $prefix) and re-run"
+            return 1
+        fi
+    fi
+
+    if [ -w "$prefix" ]; then
+        cp "$tmpdir/$asset" "$target"
+    elif command -v sudo >/dev/null 2>&1; then
+        note "elevating with sudo to write $prefix"
+        sudo cp "$tmpdir/$asset" "$target"
+    else
+        err "$prefix not writable and sudo not available"
+        err "re-run with --prefix \$HOME/.local/bin or as root"
+        return 1
+    fi
+
+    note "installed: $target"
+
+    # Helpful PATH notice.
+    case ":$PATH:" in
+        *":$prefix:"*) ;;
+        *)
+            note ""
+            note "NOTE: $prefix is not in your PATH."
+            note "      Add it to your shell rc, e.g.:"
+            note "        echo 'export PATH=\"$prefix:\$PATH\"' >> ~/.bashrc"
+            ;;
+    esac
+
+    note ""
+    note "Try it:"
+    note "  $target --version"
+    note "  $target doctor"
+    note "  $target recommend"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Ships \`scripts/install.sh\` and rewires README + docs/INSTALL.md to lead with a one-line installer. Closes the second-biggest day-1 friction (after \"how do I get a binary?\"): now \`curl -sSL ... | sh\` works.

## UX

\`\`\`bash
curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh

# or:
sh install.sh --version v0.12.0
sh install.sh --prefix ~/.local/bin
sh install.sh --no-verify       # NOT recommended
\`\`\`

## Safety

- **Truncation-safe**: wrapped in \`main()\` called at end of file. A truncated \`curl | sh\` exits cleanly because \`main\` is undefined.
- **Cosign required by default**: missing cosign → exit 64 with install hint. Skipping requires explicit \`--no-verify\` with a loud warning.
- **Identity bound**: cosign verifies the cert is bound to \`^https://github.com/williamzujkowski/aegis-boot/.github/workflows/release.yml@refs/tags/v.+\$\`. Copycat forks won't match.
- **No-sudo when possible**: writes to \`~/.local/bin\` for non-root by default; uses sudo only when the prefix is root-owned (e.g. \`/usr/local/bin\`).
- **PATH hint**: warns if the install prefix isn't in \$PATH.
- **Trap-based cleanup** of the tempdir.

## Tested

- [x] \`shellcheck scripts/install.sh\` — clean
- [x] \`sh install.sh --help\` — output looks right
- [x] \`sh -n scripts/install.sh\` — POSIX syntax valid
- [ ] End-to-end install against v0.12.0's backfilled assets (in flight via workflow_dispatch run 24516893016)
- [ ] CI

## Out of scope

- Homebrew formula (separate distribution channel; tracked under epic #137)
- Debian/Ubuntu PPA (same)
- Cross-platform binaries (#123 gates Linux x86_64 → mac/win)

Refs epic #137 (v1.0 onboarding + discoverability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)