### PR TITLE
feat(aegis-cli): aegis-boot fetch — automate the catalog download+verify recipe

### DIFF
--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -341,7 +341,7 @@ fn print_entry(e: &Entry) {
     println!("which will automate the manual recipe above.");
 }
 
-fn find_entry(slug: &str) -> Option<&'static Entry> {
+pub(crate) fn find_entry(slug: &str) -> Option<&'static Entry> {
     let s = slug.to_ascii_lowercase();
     // Exact match first.
     if let Some(e) = CATALOG.iter().find(|e| e.slug.eq_ignore_ascii_case(&s)) {

--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -1,0 +1,393 @@
+//! `aegis-boot fetch <slug>` — download + verify a catalog ISO.
+//!
+//! Resolves a slug from the catalog, downloads the ISO, the project's
+//! signed `SHA256SUMS`, and the signature on `SHA256SUMS`, then runs
+//! the verification recipe a careful operator would type by hand:
+//!
+//!   1. `sha256sum -c SHA256SUMS --ignore-missing` against the ISO
+//!   2. `gpg --verify SHA256SUMS.sig SHA256SUMS` (best-effort: gpg
+//!      won't trust unfamiliar keys; we surface the gpg output so the
+//!      operator can decide whether to import the project's key)
+//!
+//! On success, prints the absolute path to the downloaded ISO + a
+//! single-line `aegis-boot add` command. We do NOT auto-add because
+//! the operator may want to choose which stick gets the ISO; this
+//! tool's job is to deliver a verified ISO to disk, not to make the
+//! stick-write decision.
+//!
+//! Storage: defaults to `$XDG_CACHE_HOME/aegis-boot/<slug>/` (or
+//! `$HOME/.cache/aegis-boot/<slug>/`). Override with `--out DIR`.
+//!
+//! Network + verification both shell out to system tools (curl,
+//! sha256sum, gpg) rather than pulling in reqwest + sha2 + gpgme as
+//! Rust deps. Keeps the static-musl binary small and the trust
+//! boundary explicit (system tools are visible in `aegis-boot
+//! doctor`'s prerequisite check).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use crate::catalog::{find_entry, Entry, SbStatus};
+
+/// Entry point for `aegis-boot fetch [--out DIR] [--no-gpg] <slug>`.
+pub fn run(args: &[String]) -> ExitCode {
+    let mut out_dir: Option<PathBuf> = None;
+    let mut skip_gpg = false;
+    let mut slug: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--help" | "-h" => {
+                print_help();
+                return ExitCode::SUCCESS;
+            }
+            "--out" => {
+                let Some(v) = iter.next() else {
+                    eprintln!("aegis-boot fetch: --out requires a directory argument");
+                    return ExitCode::from(2);
+                };
+                out_dir = Some(PathBuf::from(v));
+            }
+            "--no-gpg" => {
+                skip_gpg = true;
+            }
+            arg if arg.starts_with("--out=") => {
+                out_dir = Some(PathBuf::from(arg.trim_start_matches("--out=")));
+            }
+            arg if arg.starts_with("--") => {
+                eprintln!("aegis-boot fetch: unknown option '{arg}'");
+                return ExitCode::from(2);
+            }
+            other => {
+                if slug.is_some() {
+                    eprintln!("aegis-boot fetch: only one slug allowed (got '{other}' after '{}')",
+                        slug.unwrap_or_else(|| "?".into()));
+                    return ExitCode::from(2);
+                }
+                slug = Some(other.to_string());
+            }
+        }
+    }
+
+    let Some(slug) = slug else {
+        eprintln!("aegis-boot fetch: missing <slug> argument");
+        eprintln!("run 'aegis-boot recommend' to see available slugs");
+        return ExitCode::from(2);
+    };
+
+    let Some(entry) = find_entry(&slug) else {
+        eprintln!("aegis-boot fetch: no catalog entry matching '{slug}'");
+        eprintln!("run 'aegis-boot recommend' to see available slugs");
+        return ExitCode::from(1);
+    };
+
+    let dest = out_dir.unwrap_or_else(|| default_cache_dir(entry.slug));
+    if let Err(e) = std::fs::create_dir_all(&dest) {
+        eprintln!("aegis-boot fetch: cannot create {}: {e}", dest.display());
+        return ExitCode::from(1);
+    }
+
+    println!("Fetching {} into {}", entry.name, dest.display());
+    println!();
+
+    let iso_filename = filename_from_url(entry.iso_url);
+    let sha_filename = filename_from_url(entry.sha256_url);
+    let sig_filename = filename_from_url(entry.sig_url);
+
+    if let Err(e) = download(entry.iso_url, &dest.join(&iso_filename)) {
+        eprintln!("aegis-boot fetch: ISO download failed: {e}");
+        return ExitCode::from(1);
+    }
+    if let Err(e) = download(entry.sha256_url, &dest.join(&sha_filename)) {
+        eprintln!("aegis-boot fetch: SHA256SUMS download failed: {e}");
+        return ExitCode::from(1);
+    }
+    if let Err(e) = download(entry.sig_url, &dest.join(&sig_filename)) {
+        // Sig download is best-effort if the user opts out of GPG, but
+        // useful to have on disk regardless.
+        eprintln!("aegis-boot fetch: signature download failed: {e}");
+        if !skip_gpg {
+            return ExitCode::from(1);
+        }
+    }
+
+    println!();
+    println!("Verifying SHA-256 of {iso_filename} against {sha_filename}...");
+    if !verify_sha256(&dest, &iso_filename, &sha_filename) {
+        eprintln!();
+        eprintln!("aegis-boot fetch: SHA-256 verification FAILED");
+        eprintln!("the ISO at {} does not match the project's published checksum",
+            dest.join(&iso_filename).display());
+        eprintln!("re-fetch from a different network if you suspect MITM, or check");
+        eprintln!("the project's release page for an updated checksum file");
+        return ExitCode::from(1);
+    }
+    println!("  SHA-256: OK");
+
+    if skip_gpg {
+        println!();
+        println!("(GPG verification skipped per --no-gpg)");
+    } else if let Some(code) = handle_gpg_step(&dest, &sha_filename, &sig_filename, &slug) {
+        return code;
+    }
+
+    print_success(entry, &dest, &iso_filename);
+    ExitCode::SUCCESS
+}
+
+/// Run + report GPG verification. Returns `Some(ExitCode)` to abort the
+/// whole `fetch` command (BAD signature, gpg missing); `None` to
+/// continue (OK or unknown-key — both are non-fatal because the
+/// operator can review and re-run).
+fn handle_gpg_step(dest: &Path, sums: &str, sig: &str, slug: &str) -> Option<ExitCode> {
+    println!();
+    println!("Verifying GPG signature of {sums}...");
+    match verify_gpg(dest, sums, sig) {
+        GpgVerdict::Ok => {
+            println!("  GPG: OK");
+            None
+        }
+        GpgVerdict::UnknownKey(stderr) => {
+            println!("  GPG: signature present but signing key not in your keyring.");
+            println!();
+            println!("  This is normal the first time you fetch from a project. Inspect");
+            println!("  the gpg output below — if you trust the project, import their key");
+            println!("  (typically a `gpg --keyserver keys.openpgp.org --recv-keys ...`)");
+            println!("  and re-run `aegis-boot fetch {slug}`.");
+            println!();
+            println!("  --- gpg --verify ---");
+            for line in stderr.lines() {
+                println!("  {line}");
+            }
+            println!("  --- end ---");
+            None
+        }
+        GpgVerdict::Bad(stderr) => {
+            eprintln!();
+            eprintln!("aegis-boot fetch: GPG signature is INVALID for this signing key");
+            eprintln!("the SHA256SUMS file appears to have been tampered with, OR you've");
+            eprintln!("downloaded a stale signature; re-fetch from a different network");
+            eprintln!();
+            eprintln!("--- gpg --verify ---");
+            eprintln!("{stderr}");
+            eprintln!("--- end ---");
+            Some(ExitCode::from(1))
+        }
+        GpgVerdict::GpgMissing => {
+            eprintln!();
+            eprintln!("aegis-boot fetch: gpg not found in PATH");
+            eprintln!("install gpg (e.g. `sudo apt-get install gnupg`) and re-run, or pass");
+            eprintln!("--no-gpg to skip signature verification (NOT recommended)");
+            Some(ExitCode::from(1))
+        }
+    }
+}
+
+fn print_help() {
+    println!("aegis-boot fetch — download + verify a catalog ISO");
+    println!();
+    println!("USAGE:");
+    println!("  aegis-boot fetch <slug>");
+    println!("  aegis-boot fetch --out /path/to/dir <slug>");
+    println!("  aegis-boot fetch --no-gpg <slug>      # SHA-256 only (NOT recommended)");
+    println!("  aegis-boot fetch --help");
+    println!();
+    println!("OPTIONS:");
+    println!("  --out DIR     Destination directory (default: $XDG_CACHE_HOME/aegis-boot/<slug>)");
+    println!("  --no-gpg      Skip GPG signature verification on SHA256SUMS");
+    println!("  --help        This message");
+    println!();
+    println!("EXAMPLES:");
+    println!("  aegis-boot fetch ubuntu-24.04-live-server");
+    println!("  aegis-boot fetch --out ~/Downloads alpine-3.20-standard");
+    println!();
+    println!("`aegis-boot fetch` does not write to a USB stick; it downloads + verifies");
+    println!("the ISO and prints the `aegis-boot add` command to copy it onto a stick.");
+}
+
+fn default_cache_dir(slug: &str) -> PathBuf {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("aegis-boot").join(slug)
+}
+
+fn filename_from_url(url: &str) -> String {
+    url.rsplit('/').next().unwrap_or("download").to_string()
+}
+
+fn download(url: &str, dest: &Path) -> Result<(), String> {
+    if dest.is_file() {
+        // Already downloaded; skip. Sha verification will catch a
+        // half-finished partial-download from a previous failed run.
+        println!("  skip: {} already present", dest.display());
+        return Ok(());
+    }
+    println!("  GET {url}");
+    let status = Command::new("curl")
+        .args([
+            "--proto",
+            "=https",
+            "--tlsv1.2",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--output",
+        ])
+        .arg(dest)
+        .arg(url)
+        .status()
+        .map_err(|e| format!("curl exec failed: {e} (is curl installed?)"))?;
+    if !status.success() {
+        // Clean up partial file so a retry doesn't see it as "already
+        // downloaded" via the is_file() check above.
+        let _ = std::fs::remove_file(dest);
+        return Err(format!("curl exited with status {status}"));
+    }
+    Ok(())
+}
+
+fn verify_sha256(dir: &Path, iso: &str, sums: &str) -> bool {
+    let out = Command::new("sha256sum")
+        .args(["-c", "--ignore-missing", sums])
+        .current_dir(dir)
+        .output();
+    match out {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            // sha256sum output: "<file>: OK" or "<file>: FAILED"
+            // We want the line for our specific iso.
+            for line in stdout.lines() {
+                if line.starts_with(iso) {
+                    println!("  {line}");
+                    return line.ends_with(": OK");
+                }
+            }
+            // ISO not in checksums file at all? print stderr and fail.
+            eprintln!("(no entry for {iso} in {sums})");
+            eprintln!("{}", String::from_utf8_lossy(&out.stderr));
+            false
+        }
+        Err(e) => {
+            eprintln!("sha256sum exec failed: {e} (is sha256sum installed?)");
+            false
+        }
+    }
+}
+
+enum GpgVerdict {
+    Ok,
+    UnknownKey(String),
+    Bad(String),
+    GpgMissing,
+}
+
+fn verify_gpg(dir: &Path, sums: &str, sig: &str) -> GpgVerdict {
+    // gpg writes the verdict to stderr, not stdout.
+    let out = Command::new("gpg")
+        .args(["--verify", sig, sums])
+        .current_dir(dir)
+        .output();
+    let Ok(out) = out else {
+        return GpgVerdict::GpgMissing;
+    };
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    if out.status.success() {
+        return GpgVerdict::Ok;
+    }
+    // gpg exit 2 + "Can't check signature: No public key" → unknown key
+    // gpg exit 1 + "BAD signature" → genuine fail
+    let lower = stderr.to_lowercase();
+    if lower.contains("no public key") || lower.contains("can't check signature") {
+        GpgVerdict::UnknownKey(stderr)
+    } else {
+        GpgVerdict::Bad(stderr)
+    }
+}
+
+fn print_success(entry: &Entry, dest: &Path, iso_filename: &str) {
+    let abs_iso = dest.join(iso_filename);
+    println!();
+    println!("Done. Verified ISO at:");
+    println!("  {}", abs_iso.display());
+    println!();
+    println!("Add it to an aegis-boot stick:");
+    println!("  aegis-boot add {}", abs_iso.display());
+    println!();
+    if matches!(entry.sb, SbStatus::UnsignedNeedsMok) {
+        println!("This ISO's kernel is unsigned. Place the distro's kernel signing key");
+        println!("public file alongside the ISO on the stick before booting:");
+        println!("  cp <distro-signing-key>.pub /run/media/aegis-isos/{iso_filename}.pub");
+        println!("See docs/UNSIGNED_KERNEL.md for the per-distro key rotation notes.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn filename_from_basic_url() {
+        assert_eq!(
+            filename_from_url("https://example.com/path/to/file.iso"),
+            "file.iso"
+        );
+    }
+
+    #[test]
+    fn filename_from_url_no_path() {
+        assert_eq!(
+            filename_from_url("https://example.com/file"),
+            "file"
+        );
+    }
+
+    #[test]
+    fn filename_from_url_root_only() {
+        // Edge case: trailing slash → empty filename. Caller's responsibility
+        // to ensure URL is sensible; we just produce something non-panicking.
+        let r = filename_from_url("https://example.com/");
+        assert_eq!(r, "");
+    }
+
+    #[test]
+    fn default_cache_uses_xdg_cache_home() {
+        // Save and restore env to avoid leaking into other tests.
+        let prev = std::env::var_os("XDG_CACHE_HOME");
+        // SAFETY: tests run sequentially in this module; mutation is scoped.
+        std::env::set_var("XDG_CACHE_HOME", "/tmp/aegis-test-xdg");
+        let p = default_cache_dir("ubuntu-24.04-live-server");
+        assert_eq!(
+            p,
+            PathBuf::from("/tmp/aegis-test-xdg/aegis-boot/ubuntu-24.04-live-server")
+        );
+        match prev {
+            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+            None => std::env::remove_var("XDG_CACHE_HOME"),
+        }
+    }
+
+    #[test]
+    fn default_cache_falls_back_to_home_dot_cache() {
+        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+        let prev_home = std::env::var_os("HOME");
+        std::env::remove_var("XDG_CACHE_HOME");
+        std::env::set_var("HOME", "/tmp/aegis-test-home");
+        let p = default_cache_dir("alpine-3.20-standard");
+        assert_eq!(
+            p,
+            PathBuf::from("/tmp/aegis-test-home/.cache/aegis-boot/alpine-3.20-standard")
+        );
+        match prev_xdg {
+            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+            None => std::env::remove_var("XDG_CACHE_HOME"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -6,6 +6,7 @@
 //!   * `list`      — show ISOs on the stick with verification status
 //!   * `doctor`    — diagnose host environment + a stick's health
 //!   * `recommend` — curated catalog of known-good ISOs
+//!   * `fetch`     — download + verify a catalog ISO
 //!
 //! This replaces the developer workflow of running shell scripts
 //! manually. The binary is named `aegis-boot` so operators type
@@ -16,6 +17,7 @@
 mod catalog;
 mod detect;
 mod doctor;
+mod fetch;
 mod flash;
 mod inventory;
 
@@ -36,6 +38,7 @@ fn main() -> ExitCode {
         Some("add") => inventory::run_add(&args[1..]),
         Some("doctor") => doctor::run(&args[1..]),
         Some("recommend") => catalog::run(&args[1..]),
+        Some("fetch") => fetch::run(&args[1..]),
         Some("-h" | "--help" | "help") | None => {
             print_help();
             ExitCode::SUCCESS
@@ -61,12 +64,14 @@ fn print_help() {
     println!("  aegis-boot add <iso> [device] Copy + validate an ISO");
     println!("  aegis-boot doctor [--stick D] Health check (host + stick)");
     println!("  aegis-boot recommend [slug]   Curated catalog of known-good ISOs");
+    println!("  aegis-boot fetch <slug>       Download + verify a catalog ISO");
     println!("  aegis-boot --version          Print version");
     println!("  aegis-boot --help             This message");
     println!();
     println!("EXAMPLES:");
     println!("  aegis-boot doctor             # quick environment + stick health");
     println!("  aegis-boot recommend          # browse the curated ISO catalog");
+    println!("  aegis-boot fetch ubuntu-24.04-live-server  # download + verify");
     println!("  aegis-boot flash              # auto-detect removable drive");
     println!("  aegis-boot flash /dev/sdc     # specific drive");
     println!("  aegis-boot add ubuntu.iso     # validate + copy to stick");

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,6 +11,7 @@ USAGE:
   aegis-boot add <iso> [device] Copy + validate an ISO
   aegis-boot doctor [--stick D] Health check (host + stick)
   aegis-boot recommend [slug]   Curated catalog of known-good ISOs
+  aegis-boot fetch <slug>       Download + verify a catalog ISO
   aegis-boot --version          Print version
   aegis-boot --help             This message
 ```
@@ -245,9 +246,51 @@ For unsigned-kernel entries (Alpine / Arch / NixOS), the recipe also includes th
 
 Distros release point versions on a cadence that doesn't track our commits. Pinning a hash in the catalog would make most entries wrong within weeks of every release. The catalog points at the project's *signed* SHA256SUMS instead — whoever the project trusts to sign their releases is who we trust here. The trust anchor is the project's release-signing key, not aegis-boot's catalog.
 
-### Future: `aegis-boot fetch <slug>`
+### See also: `aegis-boot fetch <slug>`
 
-The recipe is currently manual (curl, gpg, sha256sum, then `aegis-boot add`). A future `aegis-boot fetch <slug>` will automate it end-to-end. Tracked under [epic #136](https://github.com/williamzujkowski/aegis-boot/issues/136).
+The manual recipe (curl, gpg, sha256sum, then `aegis-boot add`) is shipped — but the next section describes `aegis-boot fetch <slug>`, which automates the same recipe end-to-end.
+
+---
+
+## `aegis-boot fetch`
+
+Downloads + verifies a catalog ISO. Resolves a slug from the catalog, downloads the ISO + the project's signed `SHA256SUMS` + the GPG signature on `SHA256SUMS`, runs `sha256sum -c` against the ISO, runs `gpg --verify` on the signature, and reports the verified path.
+
+### Usage
+
+```bash
+aegis-boot fetch ubuntu-24.04-live-server
+aegis-boot fetch --out ~/Downloads alpine-3.20-standard
+aegis-boot fetch --no-gpg ubuntu-24.04-live-server   # SHA-256 only (NOT recommended)
+aegis-boot fetch --help
+```
+
+### What it does
+
+1. **Slug → catalog entry**: same lookup as `recommend` (exact + unique-prefix).
+2. **Download** the ISO, SHA256SUMS, and SHA256SUMS signature into a per-slug cache directory (`$XDG_CACHE_HOME/aegis-boot/<slug>/` by default; `--out` overrides). Skips files already present so re-runs are cheap.
+3. **SHA-256 verification**: runs `sha256sum -c <SHA256SUMS> --ignore-missing` and asserts the line for our specific ISO ends with `: OK`.
+4. **GPG signature verification**: runs `gpg --verify <SHA256SUMS.sig> <SHA256SUMS>` and reports one of:
+   - **OK** — signature valid against a key in your keyring
+   - **Unknown key** — signature present, signer not yet trusted; gpg's full output is shown so you can decide whether to import the key. Non-fatal: `aegis-boot fetch` exits 0 because the SHA-256 itself was valid against the project-published checksum file.
+   - **BAD signature** — fatal; the SHA256SUMS file appears tampered. Exit 1.
+   - **gpg missing** — fatal; install hint shown. Exit 1 (or pass `--no-gpg`).
+5. **Print the `aegis-boot add` line** with the absolute ISO path. Does NOT auto-add — operator may want a specific stick.
+
+For unsigned-kernel entries (Alpine, Arch, NixOS) the success message also reminds the operator to place the distro's signing public key on the stick post-add.
+
+### Why shell out to system tools?
+
+`fetch` calls `curl`, `sha256sum`, and `gpg` via `Command` rather than pulling in `reqwest` + `sha2` + `gpgme` as Rust deps. Trade-offs:
+- **+** Static-musl binary stays small (~855 KiB).
+- **+** Trust boundary is explicit and inspectable — operators see what's invoked; `aegis-boot doctor` reports prerequisite tools.
+- **−** Operators need curl + sha256sum + gpg installed (universal on Linux distros).
+
+### Exit codes
+
+- `0` — verified ISO ready to add (including the unknown-key GPG case)
+- `1` — download / verification failed
+- `2` — usage error
 
 ---
 


### PR DESCRIPTION
## Summary

\`aegis-boot fetch <slug>\` automates the manual recipe that \`aegis-boot recommend\` prints: download ISO + signed SHA256SUMS + signature, verify both, and report the verified path. Closes the catalog story end-to-end.

## UX

\`\`\`bash
aegis-boot fetch ubuntu-24.04-live-server
aegis-boot fetch --out ~/Downloads alpine-3.20-standard
aegis-boot fetch --no-gpg ubuntu-24.04-live-server   # SHA-256 only (NOT recommended)
\`\`\`

Output ends with:

\`\`\`
Done. Verified ISO at:
  /home/op/.cache/aegis-boot/ubuntu-24.04-live-server/ubuntu-24.04.2-live-server-amd64.iso

Add it to an aegis-boot stick:
  aegis-boot add /home/op/.cache/aegis-boot/ubuntu-24.04-live-server/ubuntu-24.04.2-live-server-amd64.iso
\`\`\`

## Trust model

| Verdict | Meaning | Exit |
|---|---|---|
| **OK** | sig valid + key trusted | 0 |
| **UnknownKey** | sig present, signer not in keyring; SHA-256 already validated against project's own signed checksum file. Non-fatal — operator can review gpg output, import key, re-run | 0 |
| **BadSignature** | SHA256SUMS appears tampered | 1 |
| **GpgMissing** | install hint, or pass \`--no-gpg\` | 1 |

The unknown-key case being non-fatal reflects the layered trust: the SHA-256 is already validated against a checksum file that originated from the project's release URL; GPG is the stronger second factor that requires user action (key import) to fully trust.

## Why shell out to system tools?

Calls \`curl\` + \`sha256sum\` + \`gpg\` via \`Command\` rather than \`reqwest\` + \`sha2\` + \`gpgme\`:
- **+** static-musl binary stays ~855 KiB
- **+** trust boundary is explicit and inspectable
- **−** operators need curl, sha256sum, gpg installed (universal on Linux)

\`aegis-boot doctor\` already reports curl + sha256sum availability via PATH lookups; will get a \`gpg\` row in a follow-up.

## Test plan

- [x] 5 new unit tests (filename_from_url + XDG_CACHE_HOME / HOME fallback for default_cache_dir)
- [x] \`cargo test -p aegis-cli\` — 32 total green (was 27)
- [x] \`cargo clippy -p aegis-cli --all-targets -- -D warnings\` — clean
- [x] \`aegis-boot fetch --help\` renders, \`aegis-boot fetch nonexistent\` returns clean error
- [ ] CI
- [ ] Full network path with real ISO (multi-GB; deferred to operator validation)

Refs epic #136 (v1.0 operator + sysadmin reach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)