### PR TITLE
docs+ux: doctor checks for fetch prereqs + hardware compat doc

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -194,6 +194,21 @@ pub fn run(args: &[String]) -> ExitCode {
         "lsblk",
         "lists removable drives for `flash` auto-detect",
     );
+    check_command_present(
+        &mut report,
+        "curl",
+        "downloads catalog ISOs (`aegis-boot fetch`) and the install one-liner",
+    );
+    check_command_present(
+        &mut report,
+        "sha256sum",
+        "verifies catalog ISO checksums (`aegis-boot fetch`)",
+    );
+    check_command_present(
+        &mut report,
+        "gpg",
+        "verifies catalog SHA256SUMS signatures (`aegis-boot fetch`)",
+    );
     check_secureboot_state(&mut report);
     check_removable_drives(&mut report);
     println!();

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -160,6 +160,7 @@ aegis-boot doctor --help
 **Host checks:**
 - `operating system` — Linux today (macOS/Windows tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123))
 - `command: dd` / `sudo` / `sgdisk` / `lsblk` — the prerequisites for `flash` and stick inspection
+- `command: curl` / `sha256sum` / `gpg` — prerequisites for `aegis-boot fetch`
 - `Secure Boot (host)` — `mokutil --sb-state` first, falling back to reading `/sys/firmware/efi/efivars/SecureBoot-*` directly
 - `removable USB drives` — list / count
 

--- a/docs/HARDWARE_COMPAT.md
+++ b/docs/HARDWARE_COMPAT.md
@@ -1,0 +1,81 @@
+# Hardware compatibility
+
+A community-curated table of machines aegis-boot has been seen to boot on (or fail on) under enforcing UEFI Secure Boot. The point: when an operator asks "will this work on my laptop?", the answer is concrete instead of a shrug.
+
+If you successfully boot — or fail to boot — aegis-boot on a machine not listed here, please **submit a report** (see [How to report](#how-to-report) below). One report from one operator is more useful than zero from many.
+
+## How to read this
+
+| Column | Meaning |
+|---|---|
+| **Machine** | Vendor + model + (year if relevant). |
+| **Firmware** | UEFI vendor / version. Fast-boot status if known. |
+| **SB state** | Secure Boot mode at boot time. **enforcing** = the goal; **audit/setup/disabled** = aegis-boot still boots but the trust claim is weakened. |
+| **Boot key** | Firmware boot-menu key (varies by vendor: F12, F11, Esc, Del). |
+| **Stick → boot** | Did aegis-boot's signed chain reach rescue-tui? |
+| **kexec** | Did the operator-selected ISO actually kexec? |
+| **Quirks** | Anything an operator should know before booting this machine. |
+| **Reported by** | GitHub handle (or anonymous). |
+
+A row in this table represents **one** operator's outcome. Multiple rows for the same machine are fine — the more data, the better.
+
+---
+
+## Validated platforms
+
+### Real hardware
+
+| Machine | Firmware | SB state | Boot key | Stick → boot | kexec | Quirks | Reported by | Date |
+|---|---|---|---|---|---|---|---|---|
+| Generic SanDisk Cruzer Blade 32GB on x86_64 host | OVMF 4M (Debian package, MS-enrolled vars) | enforcing | n/a (USB-passthrough → QEMU) | ✅ | ✅ Ubuntu 24.04.2 boots; ✅ Alpine 3.20.3 correctly refused with `errno 61` | None observed in shakedown (#109) | @williamzujkowski | 2026-04-16 |
+
+The shakedown was performed via QEMU USB-passthrough on a real SanDisk Cruzer 32 GB stick written by `aegis-boot flash`. Direct boot on physical Framework / ThinkPad / Dell hardware is the next gate ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)) and would expand this table considerably.
+
+### QEMU / virtualized
+
+QEMU + OVMF + the MS-enrolled VARs file is the reference test environment. It boots cleanly on every CI run; consider it the floor of what aegis-boot supports.
+
+| Environment | OVMF version | SB state | Stick → boot | kexec | Notes |
+|---|---|---|---|---|---|
+| QEMU q35 + OVMF (Ubuntu 22.04 packaged `OVMF_CODE_4M.secboot.fd` + `OVMF_VARS_4M.ms.fd`) | 2024.02-2 | enforcing | ✅ | ✅ | The reference test environment used by all CI workflows. |
+
+---
+
+## How to report
+
+### What we want to capture
+
+For a successful boot:
+- Machine vendor + model + (year)
+- Firmware vendor + version (often visible in BIOS settings; on Linux: `sudo dmidecode -s bios-version` and `sudo dmidecode -s bios-vendor`)
+- Secure Boot state (`mokutil --sb-state` from a Linux ISO booted on the machine, or read from BIOS)
+- Boot-menu key
+- Which ISO you booted (vendor + version)
+- Output of `aegis-boot --version` from the workstation that wrote the stick
+
+For a failure:
+- Same as above
+- The exact failure mode (won't appear in firmware boot menu? grub starts but kernel doesn't? rescue-tui starts but kexec fails?)
+- Relevant `dmesg` output if the kernel reached you (the [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) guide has notes on capturing this)
+
+### Where to submit
+
+Open a GitHub issue with the **`hardware-report`** label using the bug template at [`.github/ISSUE_TEMPLATE/bug.yml`](../.github/ISSUE_TEMPLATE/bug.yml) — the same fields apply. We'll periodically curate accepted reports into this document.
+
+Alternatively, open a PR adding a row to the table directly. We'll accept PRs from any contributor who's actually booted aegis-boot on the machine in question.
+
+### What we don't want
+
+- Speculation ("I think a ThinkPad X1 should work because aegis-boot uses standard EFI…"). The whole point of this table is verified outcomes — please only report machines you've personally booted or failed to boot.
+- Reports under disabled Secure Boot. aegis-boot still works, but the trust claim that justifies its existence is undermined; SB-disabled outcomes don't help operators who specifically want SB-preserving boot.
+
+## Future: automated reports
+
+A planned feature ([epic #137](https://github.com/williamzujkowski/aegis-boot/issues/137)) is `aegis-boot doctor --report` — opt-in anonymous telemetry that posts the host's firmware vendor / model / SB state / outcome. The data shape will be public and operators will see exactly what's submitted before consenting per-run. No data is collected today.
+
+## See also
+
+- [INSTALL.md](./INSTALL.md) — operator install walkthrough
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) — common failure modes by category
+- [UNSIGNED_KERNEL.md](./UNSIGNED_KERNEL.md) — what to do when an ISO's kernel isn't signed
+- [#51](https://github.com/williamzujkowski/aegis-boot/issues/51) — the multi-vendor real-hardware shakedown gate for v1.0.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | **Operator** | [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) | Common errors and fixes (errno 61, won't-boot, mount issues, MOK pitfalls) |
 | **Operator** | [`UNSIGNED_KERNEL.md`](./UNSIGNED_KERNEL.md) | What to do when an ISO ships an unsigned kernel (Alpine, Arch, NixOS) |
 | **Operator** | [`USB_LAYOUT.md`](./USB_LAYOUT.md) | GPT + ESP + AEGIS_ISOS scheme; manual loop-mount workflow; FAT32 vs ext4 trade-off |
+| **Operator** | [`HARDWARE_COMPAT.md`](./HARDWARE_COMPAT.md) | Community-curated table of validated machines; how to submit your own report |
 | **Operator** | [`compatibility/iso-matrix.md`](./compatibility/iso-matrix.md) | Per-distro kexec compatibility — what works, what surfaces a quirk |
 | **Developer** | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | One-page mental model — boot chain, crate dependencies, trust boundaries |
 | **Developer** | [`LOCAL_TESTING.md`](./LOCAL_TESTING.md) | 8-stage local CI equivalent; `qemu-loaded-stick.sh --attach` modes; iteration recipes |


### PR DESCRIPTION
## Summary

Two coupled additions toward the v1.0 onboarding story (epic #137):

1. **`aegis-boot doctor`** now checks for \`curl\`, \`sha256sum\`, and \`gpg\` in addition to the existing \`dd\`/\`sudo\`/\`sgdisk\`/\`lsblk\`. \`aegis-boot fetch\` (just shipped in #145) needs all three; the prereq audit should report missing ones so operators fix gaps before hitting them at fetch-time. Score went 93 → 95 on this workstation (more PASS rows in denominator).

2. **\`docs/HARDWARE_COMPAT.md\`** — community-curated table of validated machines. Seeded with the v0.12.0 shakedown (#109) result and the QEMU/OVMF reference environment. Includes a column-by-column reading guide, "How to report" section, explicit "what we don't want" notes (no speculation; no SB-disabled outcomes), and a forward-pointer to the planned \`aegis-boot doctor --report\` telemetry mechanism.

## Sample doctor output

\`\`\`
Host checks:
  [✓ PASS] operating system                  Linux (supported)
  [✓ PASS] command: dd                       /usr/bin/dd
  [✓ PASS] command: sudo                     /usr/bin/sudo
  [✓ PASS] command: sgdisk                   /usr/sbin/sgdisk
  [✓ PASS] command: lsblk                    /usr/bin/lsblk
  [✓ PASS] command: curl                     /usr/bin/curl              ← NEW
  [✓ PASS] command: sha256sum                /usr/bin/sha256sum         ← NEW
  [✓ PASS] command: gpg                      /usr/bin/gpg               ← NEW
  [! WARN] Secure Boot (host)                disabled on this host (target machine SB state is what matters)
  [✓ PASS] removable USB drives              /dev/sda (Cruzer, 29.8 GB)
  ...
  Health score: 95/100 (EXCELLENT)
\`\`\`

## Test plan

- [x] \`cargo test -p aegis-cli\` — 32 green
- [x] \`cargo clippy -p aegis-cli --all-targets -- -D warnings\` — clean
- [x] Live tested doctor — new rows render
- [ ] CI

Refs epic #137 (v1.0 onboarding + discoverability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)