### PR TITLE
feat(distribution): Homebrew tap formula for aegis-boot

### DIFF
--- a/Formula/README.md
+++ b/Formula/README.md
@@ -1,0 +1,37 @@
+# Homebrew formula
+
+This directory makes the aegis-boot repo a [Homebrew tap](https://docs.brew.sh/Taps): a third-party formula source that operators can install from.
+
+## Install
+
+```bash
+brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
+brew install aegis-boot
+```
+
+After that, `brew upgrade aegis-boot` picks up new formula versions when they're committed here.
+
+## What gets installed
+
+- `bin/aegis-boot` — the operator CLI (Linux x86_64 binary downloaded from GitHub Releases)
+- Runtime deps via Brew: `curl`, `gnupg`, `gptfdisk`, `coreutils` (only auto-installed on macOS — Linux ships these in the base system)
+
+## Platforms
+
+- **Linux x86_64**: supported today via the cosign-signed release binary.
+- **macOS, Windows, Linux aarch64**: not yet supported — the formula errors with a pointer to [#123](https://github.com/williamzujkowski/aegis-boot/issues/123) (cross-platform flash CLI) and [#137](https://github.com/williamzujkowski/aegis-boot/issues/137) (cross-platform binaries epic). For now, build from source: `cargo install --path crates/aegis-cli`.
+
+## Verifying the binary cosign signature
+
+The Brew install pulls the same binary the manual `curl | sh` installer does, so the same Sigstore cosign verification recipe applies — see [docs/RELEASE_NOTES_FOOTER.md](../docs/RELEASE_NOTES_FOOTER.md).
+
+## Updating the formula
+
+When a new release is tagged, this file needs:
+
+1. Bump `version "X.Y.Z"`
+2. Update the URL to the new tag
+3. Update `sha256 "..."` to the new binary's hash (from the release's `SHA256SUMS` asset)
+4. Possibly extend the `test do` block as new subcommands ship
+
+A future PR (tracked under [epic #137](https://github.com/williamzujkowski/aegis-boot/issues/137)) will add a release-time CI step that bumps the formula automatically alongside the GitHub release.

--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -1,0 +1,87 @@
+# Homebrew formula for aegis-boot.
+#
+# Install:
+#   brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
+#   brew install aegis-boot
+#
+# Cross-platform support: Linux/x86_64 only today. macOS, Windows,
+# and Linux/aarch64 builds are tracked under #123 and #137.
+class AegisBoot < Formula
+  desc "Signed UEFI Secure Boot rescue environment for booting any ISO from USB"
+  homepage "https://github.com/williamzujkowski/aegis-boot"
+  version "0.12.0"
+  license any_of: ["Apache-2.0", "MIT"]
+
+  on_linux do
+    on_intel do
+      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.12.0/aegis-boot-x86_64-linux"
+      sha256 "2c1b15f423823532766859ee70f929aeebce05cae5901fa080512ca7d1340953"
+    end
+  end
+
+  # Runtime dependencies the operator CLI shells out to. Listed
+  # explicitly so brew installs them; aegis-boot doctor will also
+  # verify them at runtime.
+  depends_on "curl"
+  depends_on "gnupg"
+  depends_on "gptfdisk" # provides sgdisk
+  uses_from_macos "coreutils" # provides sha256sum (Linux always has it)
+
+  def install
+    if OS.linux? && Hardware::CPU.intel?
+      bin.install "aegis-boot-x86_64-linux" => "aegis-boot"
+    else
+      odie <<~EOS
+        aegis-boot binaries are currently published only for Linux x86_64.
+
+        Cross-platform support is tracked in:
+          https://github.com/williamzujkowski/aegis-boot/issues/123
+          https://github.com/williamzujkowski/aegis-boot/issues/137
+
+        Build from source today:
+          git clone https://github.com/williamzujkowski/aegis-boot
+          cd aegis-boot
+          cargo install --path crates/aegis-cli
+      EOS
+    end
+  end
+
+  def caveats
+    <<~EOS
+      aegis-boot is a USB-imaging tool intended for Linux operator workstations.
+
+      Quick start:
+        aegis-boot doctor              # check host + stick health
+        aegis-boot recommend           # browse the curated ISO catalog
+        aegis-boot fetch ubuntu-24.04-live-server
+        sudo aegis-boot flash          # write a stick (auto-detect)
+        aegis-boot add ubuntu-24.04.2-live-server-amd64.iso
+
+      Docs: https://github.com/williamzujkowski/aegis-boot/blob/main/docs/INSTALL.md
+
+      All release artifacts are Sigstore-cosign-signed. To verify the
+      binary you just installed:
+        cosign verify-blob \\
+          --certificate-identity-regexp '^https://github\\.com/williamzujkowski/aegis-boot/.+@refs/tags/v.+$' \\
+          --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
+          --signature aegis-boot-x86_64-linux.sig \\
+          --certificate aegis-boot-x86_64-linux.pem \\
+          aegis-boot-x86_64-linux
+      (download .sig + .pem from the same release)
+    EOS
+  end
+
+  test do
+    # Sanity: binary runs and reports the expected version.
+    assert_match "aegis-boot v#{version}", shell_output("#{bin}/aegis-boot --version")
+    # Help renders without panicking.
+    assert_match "Signed boot. Any ISO. Your keys.",
+      shell_output("#{bin}/aegis-boot --help")
+    # `aegis-boot flash` without args + without removable drives
+    # exits non-zero with a clear message — exercise that without
+    # actually invoking dd. (Wrap shell_output with explicit exit
+    # status check so brew doesn't fail on the expected non-zero.)
+    output = shell_output("#{bin}/aegis-boot flash 2>&1", 1)
+    assert_match(/no removable USB drives detected|not detected as one/i, output)
+  end
+end

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Install the operator CLI (Linux x86_64 today; cross-platform tracked in [#123](h
 # Cosign-verified install from the latest GitHub release.
 curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh
 
+# OR via Homebrew (Linux):
+brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
+brew install aegis-boot
+
 # Or pin a version: sh install.sh --version v0.12.0
 # Or skip cosign (NOT recommended): sh install.sh --no-verify
 # Build from source: see BUILDING.md.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,13 +14,25 @@ Have on hand:
 
 ## Step 0 — install the operator CLI
 
+Pick your channel:
+
 ```bash
+# Option A — cosign-verified install one-liner
 curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scripts/install.sh | sh
+
+# Option B — Homebrew (Linux only today)
+brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
+brew install aegis-boot
+
+# Option C — build from source (any platform with Rust 1.85+)
+cargo install --git https://github.com/williamzujkowski/aegis-boot --bin aegis-boot --path crates/aegis-cli
 ```
 
-This downloads the latest release's `aegis-boot-x86_64-linux` static binary, verifies its Sigstore cosign signature against this repo's `release.yml` workflow identity, and installs to `/usr/local/bin` (root) or `~/.local/bin` (non-root).
+Both A and B install the same binary (Linux x86_64 today; cross-platform tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123)).
 
-The installer itself does NOT need root unless you're installing to `/usr/local/bin`. To inspect first: `curl -sSL ... -o install.sh && less install.sh && sh install.sh`.
+Option A downloads the latest release's `aegis-boot-x86_64-linux` static binary, verifies its Sigstore cosign signature against this repo's `release.yml` workflow identity, and installs to `/usr/local/bin` (root) or `~/.local/bin` (non-root). The installer itself does NOT need root unless you're installing to `/usr/local/bin`. To inspect first: `curl -sSL ... -o install.sh && less install.sh && sh install.sh`.
+
+Option B (Homebrew) auto-installs the Brew-tracked runtime deps (`curl`, `gnupg`, `gptfdisk`, `coreutils`). Runs the same cosign-verifiable binary; verify the cosign signature manually if you want to confirm — see [Formula/README.md](../Formula/README.md).
 
 Sanity check:
 


### PR DESCRIPTION
## Summary

This repo now doubles as a Homebrew tap. Operators install with:

\`\`\`bash
brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
brew install aegis-boot
\`\`\`

Formula sits at \`Formula/aegis-boot.rb\` (Brew auto-detects the \`Formula/\` directory).

## Formula details

- Pinned to v0.12.0 with the canonical SHA-256 from the release's signed \`SHA256SUMS\` (\`2c1b15f4...\`).
- Linux x86_64 only — \`on_linux do; on_intel do; ... end; end\` gates the URL/SHA. Other platforms hit a clear \`odie()\` pointing at [#123](https://github.com/williamzujkowski/aegis-boot/issues/123) + [#137](https://github.com/williamzujkowski/aegis-boot/issues/137) and a build-from-source fallback.
- Brew-tracked runtime deps: \`curl\`, \`gnupg\`, \`gptfdisk\` (sgdisk), \`coreutils\` (sha256sum on macOS). Matches what \`aegis-boot doctor\` checks at runtime.
- \`caveats\` block prints operator quickstart + cosign verification recipe — trust is testable post-install.
- \`test do\` exercises \`--version\`, \`--help\`, and \`flash\` with no removable drives (a stable, no-network, no-USB-required path that v0.12.0 supports).

## Maintenance

When a new release is tagged, the formula needs version + URL + SHA-256 bumped. A future release-time CI step (epic #137) will automate this.

## Test plan

- [x] \`ruby -c Formula/aegis-boot.rb\` — syntax OK
- [x] README.md + docs/INSTALL.md updated to list Brew alongside the curl|sh installer + cargo build-from-source fallback
- [x] New \`Formula/README.md\` documents the tap setup + maintenance procedure
- [ ] CI
- [ ] Manual brew install test from the merged tap (deferred — needs the PR merged so the tap URL points at main)

## Out of scope

- Submission to homebrew-core (separate; high bar for a security-critical tool)
- macOS / Windows / Linux aarch64 binaries (#123, #137)
- Auto-bump CI step (#137 follow-up)

Refs epic #137 (v1.0 onboarding + discoverability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)