### PR TITLE
chore(release): v0.13.0 — best-in-class push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+(no changes yet — this section captures work landing after v0.13.0)
+
+## [0.13.0] — 2026-04-16
+
 The **best-in-class push** — what landed after v0.12.0 went out and the repo went public, working through epics #136 (operator + sysadmin reach), #137 (onboarding + discoverability), and #138 (quality gates).
 
 ### Operator surface area expansion (epic #136)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -390,7 +390,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kexec-loader"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -614,7 +614,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "crossterm",
  "hex",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.12.0 — operator CLI shipped; real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.13.0 — best-in-class push: 5 new operator subcommands (`doctor`, `recommend`, `fetch`, `attest list/show`), cosign-signed prebuilt binaries, install one-liner, Homebrew tap, attestation receipts on every flash. Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/aegis-fitness/Cargo.toml
+++ b/crates/aegis-fitness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-fitness"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-parser"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -380,7 +380,7 @@ Matching logic: the destination mount path → owning device (from `/proc/mounts
 
 ## Versioning
 
-`aegis-boot --version` reports the workspace version (currently `0.12.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.13.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
 ## See also
 


### PR DESCRIPTION
## v0.13.0 — best-in-class push

Twelve PRs of new operator surface + distribution + quality work landed since v0.12.0 went out and the repo went public.

### Operator surface (epic #136)

- aegis-boot doctor — host + stick health (#141)
- aegis-boot recommend — curated 13-entry catalog (#142)
- aegis-boot fetch — automated download + verify (#145)
- aegis-boot attest list/show — chain-of-custody receipts (#147)
- attestation appended on every add (#148)
- attestation summary in list (#149)

### Distribution + onboarding (epic #137)

- cosign-signed prebuilt binaries via GH Releases (#143)
- curl|sh installer with cosign verification (#144)
- Homebrew tap formula (#150)
- auto-bump formula on tag push (#151)
- HARDWARE_COMPAT.md community table (#146)

### Quality gates (epic #138)

- forbid(unsafe_code) on iso-parser (#140)

### What this release also validates end-to-end

- **#143's cosign-signing pipeline** — every artifact in the v0.13.0 release should land with a \`.sig\` + \`.pem\` Sigstore signature
- **#151's auto-bump-formula job** — after the tag pushes, release.yml's bump-brew-formula sub-job should commit \`Formula/aegis-boot.rb\` v0.13.0 + new SHA-256 to main automatically (no manual maintenance)

### Stats

- 186 workspace tests (was 140 at v0.12.0)
- 6 crates bumped to 0.13.0
- README status updated; CHANGELOG [Unreleased] renamed to [0.13.0] with a fresh empty [Unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)