### PR TITLE
ci(catalog): weekly URL revalidation (cron + dispatch)

### DIFF
--- a/.github/workflows/catalog-revalidate.yml
+++ b/.github/workflows/catalog-revalidate.yml
@@ -1,0 +1,36 @@
+name: Catalog URL revalidation
+
+# Runs `scripts/catalog-revalidate.sh` to check every URL in the
+# `aegis-boot recommend` catalog. Catches URL rot (distros moving
+# files, changing mirror paths, etc.) before operators hit a 404.
+#
+# Triggers:
+#   * Weekly cron (Monday 12:00 UTC), matching the CATALOG_POLICY cadence
+#   * workflow_dispatch for ad-hoc checks (e.g. immediately after
+#     merging a PR that adds a new catalog entry, to verify URLs)
+#
+# Deliberately NOT gated on pull_request: the catalog has accumulated
+# URL rot (CDN moves, sig-file pattern drift across distros) and we
+# don't want unrelated PRs to be blocked by pre-existing rot. The
+# scheduled run + dispatch surface the rot to the maintainer, who
+# opens follow-up PRs to fix or remove entries.
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  revalidate:
+    name: Catalog URL health check
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run catalog-revalidate.sh
+        run: bash scripts/catalog-revalidate.sh

--- a/scripts/catalog-revalidate.sh
+++ b/scripts/catalog-revalidate.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Re-validate all URLs in the `aegis-boot recommend` catalog.
+#
+# Reads iso_url / sha256_url / sig_url fields from
+# crates/aegis-cli/src/catalog.rs via grep and runs `curl -sI` on
+# each. Reports status per URL and exits 1 if any URL returns
+# something other than 200 or a 30x redirect.
+#
+# Runs per-entry (slug line → next Entry {) so a broken URL is
+# reported with its slug for context.
+#
+# Intended to run on a weekly CI schedule (see
+# .github/workflows/catalog-revalidate.yml) and via workflow_dispatch
+# for ad-hoc checks. Also runnable locally:
+#   bash scripts/catalog-revalidate.sh
+#
+# Exit codes:
+#   0 — all URLs OK
+#   1 — at least one URL broken
+#   2 — usage / script error (catalog file missing, curl unavailable)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CATALOG="$ROOT_DIR/crates/aegis-cli/src/catalog.rs"
+
+if [[ ! -f "$CATALOG" ]]; then
+    echo "error: catalog not found at $CATALOG" >&2
+    exit 2
+fi
+command -v curl >/dev/null 2>&1 || {
+    echo "error: curl not found in PATH" >&2
+    exit 2
+}
+
+# Parse: for each Entry { ... } block, extract slug + iso_url +
+# sha256_url + sig_url. awk is fine for this; the catalog is small.
+awk '
+/slug:/ {
+    match($0, /"[^"]+"/); slug = substr($0, RSTART+1, RLENGTH-2)
+}
+/iso_url:/ {
+    match($0, /"[^"]+"/); iso = substr($0, RSTART+1, RLENGTH-2)
+}
+/sha256_url:/ {
+    match($0, /"[^"]+"/); sha = substr($0, RSTART+1, RLENGTH-2)
+}
+/sig_url:/ {
+    match($0, /"[^"]+"/); sig = substr($0, RSTART+1, RLENGTH-2)
+    if (slug != "" && iso != "" && sha != "" && sig != "") {
+        print slug "|iso|" iso
+        print slug "|sha256|" sha
+        print slug "|sig|" sig
+        slug=""; iso=""; sha=""; sig=""
+    }
+}
+' "$CATALOG" > /tmp/catalog-urls.$$
+
+total=$(wc -l < /tmp/catalog-urls.$$)
+fail=0
+printf '%-32s %-8s %-12s %s\n' "SLUG" "KIND" "STATUS" "URL"
+printf '%-32s %-8s %-12s %s\n' "----" "----" "------" "---"
+
+while IFS='|' read -r slug kind url; do
+    # Range-GET the first byte rather than HEAD: many CDNs (esp.
+    # sourceforge, archlinux, kali) reject HEAD with 403/404 while
+    # serving GETs fine. --range 0-0 asks for byte 0 only so we
+    # don't download multi-GB ISOs. 200 + 206 Partial Content both
+    # mean "URL exists".
+    http_code=$(curl -sS --range 0-0 --max-time 30 \
+        --location --user-agent "aegis-boot-catalog-revalidate/1.0" \
+        --write-out '%{http_code}' \
+        --output /dev/null "$url" 2>/dev/null || echo "000")
+    case "$http_code" in
+        200|206)  status="OK"      ;;
+        2*)       status="OK$http_code" ;;
+        3*)       status="REDIR"   ;;
+        4*|5*)    status="HTTP$http_code"; fail=$((fail+1)) ;;
+        000)      status="TIMEOUT"; fail=$((fail+1)) ;;
+        *)        status="UNK$http_code"; fail=$((fail+1)) ;;
+    esac
+    printf '%-32s %-8s %-12s %s\n' "$slug" "$kind" "$status" "$url"
+done < /tmp/catalog-urls.$$
+
+rm -f /tmp/catalog-urls.$$
+
+echo
+echo "Checked $total URLs across $(awk '/slug:/ {c++} END {print c}' "$CATALOG") catalog entries."
+if (( fail > 0 )); then
+    echo "BROKEN: $fail URL(s) failed" >&2
+    exit 1
+fi
+echo "All URLs OK."


### PR DESCRIPTION
## Summary

Implements the re-validation cadence promised in \`docs/CATALOG_POLICY.md\`. Weekly cron runs \`scripts/catalog-revalidate.sh\`, which parses the catalog and curls each iso_url / sha256_url / sig_url, surfacing URL rot before operators hit a 404.

## Script behavior

- Range-GET (not HEAD — many CDNs reject HEAD with 403/404) with byte range 0-0 so we don't download multi-GB ISOs
- Custom UA so bot-unfriendly servers don't block us
- Per-URL report: OK / REDIR / HTTPxxx / TIMEOUT
- Exit 1 if any URL fails, 0 if all OK

## Workflow schedule

- Weekly cron Monday 12:00 UTC
- \`workflow_dispatch\` for ad-hoc checks (use after adding a catalog entry)
- **NOT** gated on \`pull_request\` — the catalog has pre-existing URL rot we don't want to block unrelated PRs on. The scheduled run surfaces the rot for the maintainer to fix.

## Known state on first run

I ran the script locally against the current 18-entry catalog and got **25/54 URLs broken**. Typical issues:

- Sourceforge \`files/latest/download\` rewrite → 404 on range-GET; browsers work via GET-follow. Workaround: point at versioned URL.
- sig_url patterns: several entries assume \`.sha256.asc\` / \`.sha256.sig\` when the project ships \`.SHA256SUMS.gpg\` on a different base.
- Point-release rotation: fixed-version URLs (Debian 12.7.0, Fedora 41-1.4, Rocky 9-latest-minimal) rot on each upstream release.

**Cleanup of the 25 broken URLs is deliberately a follow-up PR** — this PR ships the *infrastructure* that surfaces the rot. A dedicated tracking issue (will file after merge) enumerates the specific fixes.

## Test plan

- [x] \`shellcheck scripts/catalog-revalidate.sh\` — clean
- [x] Local dry-run against the 54 URLs in the current catalog — tool reports correct pass/fail per URL
- [x] Workflow YAML validates (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [ ] CI (the revalidate workflow itself won't run on this PR — intentional)
- [ ] First scheduled run will show 25 URLs broken; maintainer opens fix-up PRs

Refs epic #136. Closes the revalidation-cadence commitment from \`docs/CATALOG_POLICY.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)