### PR TITLE
ci(brew): validate Formula/aegis-boot.rb on changes + weekly

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -46,22 +46,26 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
-      # Style + audit on the formula. We pass the file directly rather
-      # than tapping, so breakage is caught without a full tap install.
-      # `--strict --online` matches what a homebrew-core submission
-      # would see, minus the core-specific rules we don't need.
-      - name: brew audit
-        run: brew audit --strict --online Formula/aegis-boot.rb
+      # Tap this repo first — `brew audit` no longer accepts paths;
+      # it requires a tapped name. The first `brew tap <user>/<name>
+      # <local-path>` also exercises what operators will type
+      # (modulo the local path being a URL in production).
+      - name: Tap this repo
+        run: brew tap williamzujkowski/aegis-boot "$(pwd)"
 
+      # Style check on the formula file (still accepts a path). Catches
+      # ruby/formula convention issues before install.
       - name: brew style
         run: brew style Formula/aegis-boot.rb
 
-      # Tap this repo and install from it. This exercises the real
-      # path operators will use: `brew tap` + `brew install <name>`.
-      - name: Tap this repo
-        run: brew tap williamzujkowski/aegis-boot "$(pwd)"
+      # Audit the tapped formula by name. `--strict --online` matches
+      # what a homebrew-core submission would see; some cask-specific
+      # rules don't apply to a tap formula, so we run without the
+      # `--new-formula` flag.
+      - name: brew audit
+        run: brew audit --strict --online aegis-boot
 
       - name: brew install aegis-boot
         run: brew install --verbose aegis-boot

--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -1,0 +1,78 @@
+name: Homebrew formula test
+
+# Validates Formula/aegis-boot.rb on every change and periodically
+# against brew CLI updates. Catches three classes of breakage:
+#
+#   1. Formula syntax / style errors (`brew audit`, `brew style`)
+#   2. Install failure — URL unreachable, sha256 mismatch, missing
+#      dependency (`brew install`)
+#   3. Binary runtime failure — `test do` block in the formula runs
+#      `aegis-boot --version`, `--help`, and `flash` (expected exit 1
+#      in a runner with no USB drives)
+#
+# Triggers:
+#   * push to main when Formula/ changes — catches the auto-bump
+#     commits from release.yml before users brew upgrade
+#   * pull_request when Formula/ or this workflow changes
+#   * weekly cron (Monday 12:30 UTC, 30 min after catalog-revalidate
+#     so they don't contend) — catches brew-CLI changes that break
+#     the formula even without us touching it
+#   * workflow_dispatch for ad-hoc
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Formula/**"
+      - ".github/workflows/brew-test.yml"
+  pull_request:
+    paths:
+      - "Formula/**"
+      - ".github/workflows/brew-test.yml"
+  schedule:
+    - cron: "30 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  brew-test:
+    name: brew audit + install + test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      # Style + audit on the formula. We pass the file directly rather
+      # than tapping, so breakage is caught without a full tap install.
+      # `--strict --online` matches what a homebrew-core submission
+      # would see, minus the core-specific rules we don't need.
+      - name: brew audit
+        run: brew audit --strict --online Formula/aegis-boot.rb
+
+      - name: brew style
+        run: brew style Formula/aegis-boot.rb
+
+      # Tap this repo and install from it. This exercises the real
+      # path operators will use: `brew tap` + `brew install <name>`.
+      - name: Tap this repo
+        run: brew tap williamzujkowski/aegis-boot "$(pwd)"
+
+      - name: brew install aegis-boot
+        run: brew install --verbose aegis-boot
+
+      - name: brew test aegis-boot
+        run: brew test --verbose aegis-boot
+
+      # Final sanity: the installed binary should work from $PATH.
+      - name: Smoke test installed binary
+        run: |
+          aegis-boot --version
+          aegis-boot --help | head -5
+          # `recommend` is a no-network read — always passes.
+          aegis-boot recommend | head -5

--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -12,20 +12,20 @@ class AegisBoot < Formula
   version "0.13.0"
   license any_of: ["Apache-2.0", "MIT"]
 
+  # Runtime dependencies the operator CLI shells out to. Listed
+  # explicitly so brew installs them; aegis-boot doctor will also
+  # verify them at runtime. Must precede `on_linux` per brew audit
+  # ComponentsOrder rule.
+  depends_on "curl"
+  depends_on "gnupg"
+  depends_on "gptfdisk" # provides sgdisk
+
   on_linux do
     on_intel do
       url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.13.0/aegis-boot-x86_64-linux"
       sha256 "7d8747c970ad59d79d73c298a6fbad3cdf41de32ea7e11cd97f41f3e23c21bcf"
     end
   end
-
-  # Runtime dependencies the operator CLI shells out to. Listed
-  # explicitly so brew installs them; aegis-boot doctor will also
-  # verify them at runtime.
-  depends_on "curl"
-  depends_on "gnupg"
-  depends_on "gptfdisk" # provides sgdisk
-  uses_from_macos "coreutils" # provides sha256sum (Linux always has it)
 
   def install
     if OS.linux? && Hardware::CPU.intel?


### PR DESCRIPTION
## Summary

Closes a gap from #150 + #151 (Brew tap + auto-bump formula): nothing was verifying the formula actually worked. The auto-bump job sed-edits version + URL + sha256 unconditionally — if any edit lands wrong, operators see the breakage at \`brew install\` time.

## What it does

\`\`\`
brew audit --strict --online Formula/aegis-boot.rb
brew style Formula/aegis-boot.rb
brew tap williamzujkowski/aegis-boot "\$PWD"
brew install --verbose aegis-boot
brew test --verbose aegis-boot
aegis-boot --version && aegis-boot --help | head -5 && aegis-boot recommend | head -5
\`\`\`

## Triggers

- **push to main** when \`Formula/\` changes → catches auto-bump commits *before* \`brew upgrade\` hits users
- **pull_request** when \`Formula/\` changes → catches PR breakage
- **weekly cron** Monday 12:30 UTC (30 min after catalog-revalidate so they don't contend) → catches brew-CLI changes that break us even without us touching the formula
- **workflow_dispatch** for ad-hoc

Uses \`Homebrew/actions/setup-homebrew@master\` — the standard brew setup action, no auth required.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(...)"\` — YAML valid
- [ ] CI on this PR (workflow will run because the PR changes \`.github/workflows/brew-test.yml\`)
- First run will either exercise the brew-install path fully or surface an issue we can fix in a follow-up

Refs epic #137. Closes the formula-validation loop opened by #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)