### PR TITLE
fix(rescue-tui): efivars scan fallback for OVMF (closes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+### Bugs
+
+- **OVMF SB detection fallback** ([#118](https://github.com/williamzujkowski/aegis-boot/issues/118)) — `rescue-tui`'s `SecureBootStatus::detect()` now scans `/sys/firmware/efi/efivars` for any filename starting with `SecureBoot-` when the two upstream-spec paths (global-GUID and plain) miss. Handles OVMF firmware builds that publish the variable under a non-spec suffix — observed under QEMU+OVMF SecBoot shakedown where rescue-tui's header showed `SB:unknown` despite SB enforcing. Parallels the existing scan fallback in `aegis-cli doctor` (doctor.rs:371).
+
 ### Operator experience
 
 - **Two more `init` profiles** — `minimal` (alpine-only, ~200 MiB, fastest) and `server` (ubuntu-server + rocky + almalinux, ~6 GiB, enterprise RHEL + Ubuntu rescue triple). Operators can now pick `aegis-boot init --profile <panic-room|minimal|server>` to fit the target-environment shape. Every profile slug is enforced to be in the verified catalog at test time (`every_profile_slug_is_in_catalog`).

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -194,6 +194,18 @@ pub enum TpmStatus {
 impl SecureBootStatus {
     /// Detect SB status from /sys/firmware/efi/efivars. Best-effort —
     /// returns Unknown on any read error so the TUI can boot anywhere.
+    ///
+    /// Checks, in order:
+    ///   1. Global-variables-namespace GUID suffix
+    ///      (`SecureBoot-8be4df61-…`) — the upstream spec name.
+    ///   2. Plain `SecureBoot` — seen on some older kernels / distros
+    ///      that rename on mount.
+    ///   3. Directory scan for anything starting with `SecureBoot-` —
+    ///      catches OVMF firmware builds that use a different-looking
+    ///      suffix (observed under our QEMU `SecBoot` shakedown, #118).
+    ///
+    /// EFI var wire format for all three cases is identical: 4 bytes
+    /// of attributes, then one byte of data (0/1). We read `bytes[4]`.
     #[must_use]
     pub fn detect() -> Self {
         // EFI var format: 4 bytes attributes, 1 byte data (0/1).
@@ -202,17 +214,40 @@ impl SecureBootStatus {
             "/sys/firmware/efi/efivars/SecureBoot",
         ];
         for path in candidates {
-            if let Ok(bytes) = std::fs::read(path) {
-                if let Some(&value) = bytes.get(4) {
-                    return if value == 1 {
-                        Self::Enforcing
-                    } else {
-                        Self::Disabled
-                    };
+            if let Some(s) = Self::read_sb_bit(std::path::Path::new(path)) {
+                return s;
+            }
+        }
+        // Fallback: scan the efivars directory for any variable whose
+        // filename starts with "SecureBoot-". Covers OVMF firmware
+        // builds that publish the variable under a different suffix
+        // than the upstream-spec one we check above. (#118)
+        if let Ok(entries) = std::fs::read_dir("/sys/firmware/efi/efivars") {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_s = name.to_string_lossy();
+                if name_s.starts_with("SecureBoot-") {
+                    if let Some(s) = Self::read_sb_bit(&entry.path()) {
+                        return s;
+                    }
                 }
             }
         }
         Self::Unknown
+    }
+
+    /// Read and interpret the 5-byte `[attrs][value]` layout at `path`.
+    /// Returns `None` if the file can't be read or is truncated.
+    /// Extracted so `detect`'s scan-fallback can reuse the same parse
+    /// without duplicating the magic-offset read.
+    fn read_sb_bit(path: &std::path::Path) -> Option<Self> {
+        let bytes = std::fs::read(path).ok()?;
+        let value = *bytes.get(4)?;
+        Some(if value == 1 {
+            Self::Enforcing
+        } else {
+            Self::Disabled
+        })
     }
 
     /// Short user-facing label for the TUI header banner.


### PR DESCRIPTION
## Summary

\`rescue-tui\`'s \`SecureBootStatus::detect()\` previously tried two fixed paths and gave up:

\`\`\`
/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c  # spec GUID
/sys/firmware/efi/efivars/SecureBoot                                       # plain
\`\`\`

Under the QEMU+OVMF SecBoot shakedown the TUI header still showed \`SB:unknown\` despite SB enforcing — OVMF firmware builds sometimes publish the variable under a non-spec suffix.

## Fix

Added a directory-scan fallback in \`detect()\`:

\`\`\`rust
// Fallback: scan the efivars directory for any variable whose
// filename starts with \"SecureBoot-\".
for entry in std::fs::read_dir(\"/sys/firmware/efi/efivars\")?.flatten() {
    if entry.file_name().to_string_lossy().starts_with(\"SecureBoot-\") {
        return Self::read_sb_bit(&entry.path());
    }
}
\`\`\`

Also extracted \`Self::read_sb_bit()\` so the fixed-path iteration and the scan-fallback share one parse helper — avoids duplicating the 4-byte-offset read of \`[attrs][value]\`.

Parallels the existing scan fallback in \`aegis-cli doctor.rs:371\` so the two SB-detection surfaces stay in sync.

## Test plan

- [x] \`cargo test --workspace\` — 218 tests pass (no new tests; exercise requires a /sys/firmware mount)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt\` — clean
- [ ] CI green on push
- [ ] (Follow-up on real hardware / OVMF) confirm rescue-tui header shows \`SB:enforcing\` when SB is on

## Out of scope

- Adding a unit test — exercising this requires either mocking \`/sys/firmware/efi/efivars\` via a trait injection (invasive) or running under QEMU+OVMF (not a unit-test path). The equivalent \`doctor\` scan in aegis-cli doesn't have one either — consistent test coverage for both surfaces is a follow-up if we add the trait injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)