### PR TITLE
fix(scripts): depmod fatal-exit + sgdisk offset validation (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ### Bugs
 
+- **Script safety guards** ([#138](https://github.com/williamzujkowski/aegis-boot/issues/138) children) — two long-standing silent-failure paths in the build scripts now fail fast. `scripts/build-initramfs.sh` exits on `depmod` failure (was: logged a warning and continued, producing an image whose `modules.dep` still pointed at the original `.ko.zst` paths — storage modules would silently miss at boot). Set `AEGIS_ALLOW_MISSING_DEPMOD=1` to bypass. `scripts/mkusb.sh` now validates sgdisk-derived partition start sectors are non-empty, numeric, and non-zero before using them as `dd seek=` — an empty awk result yielded `seek=0`, silently overwriting the freshly-written GPT at sector 0.
 - **OVMF SB detection fallback** ([#118](https://github.com/williamzujkowski/aegis-boot/issues/118)) — `rescue-tui`'s `SecureBootStatus::detect()` now scans `/sys/firmware/efi/efivars` for any filename starting with `SecureBoot-` when the two upstream-spec paths (global-GUID and plain) miss. Handles OVMF firmware builds that publish the variable under a non-spec suffix — observed under QEMU+OVMF SecBoot shakedown where rescue-tui's header showed `SB:unknown` despite SB enforcing. Parallels the existing scan fallback in `aegis-cli doctor` (doctor.rs:371).
 
 ### Operator experience

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -283,11 +283,29 @@ if [[ -n "$KMOD_SRC" && -d "$KMOD_SRC" ]]; then
     # Regenerate modules.dep so it references our decompressed .ko paths
     # (source kernel's modules.dep points at .ko.zst). depmod -b rebuilds
     # into the staged tree; no runtime kernel match needed.
+    #
+    # Fail hard on depmod failure (#138): a silent warning here was
+    # producing silent boot-time failures (storage modules missing at
+    # the busybox modprobe call in /init because modules.dep still
+    # points at the original .ko.zst paths). If depmod is genuinely
+    # missing on the build host, the operator should know before
+    # producing an image they'll then have to debug under OVMF. Set
+    # AEGIS_ALLOW_MISSING_DEPMOD=1 to bypass.
     if command -v depmod >/dev/null 2>&1; then
-        depmod -b "$STAGE_DIR" "$KVER" 2>/dev/null || \
-            log "WARNING: depmod failed; busybox modprobe may miss deps"
+        depmod_stderr=$(depmod -b "$STAGE_DIR" "$KVER" 2>&1 >/dev/null) || {
+            log "FATAL: depmod -b '$STAGE_DIR' '$KVER' failed"
+            log "  stderr: $depmod_stderr"
+            log "  busybox modprobe would miss dependencies at boot time; aborting."
+            log "  (set AEGIS_ALLOW_MISSING_DEPMOD=1 to bypass — not recommended)"
+            [ -n "${AEGIS_ALLOW_MISSING_DEPMOD:-}" ] || exit 1
+            log "WARNING: proceeding despite depmod failure — AEGIS_ALLOW_MISSING_DEPMOD set."
+        }
     else
-        log "WARNING: depmod not on PATH; modules will load only with explicit paths"
+        log "FATAL: depmod not on PATH; cannot regenerate modules.dep for staged modules."
+        log "  install kmod (e.g. 'apt-get install kmod' / 'dnf install kmod') and retry."
+        log "  (set AEGIS_ALLOW_MISSING_DEPMOD=1 to bypass — not recommended)"
+        [ -n "${AEGIS_ALLOW_MISSING_DEPMOD:-}" ] || exit 1
+        log "WARNING: proceeding without depmod — AEGIS_ALLOW_MISSING_DEPMOD set."
     fi
 else
     log "WARNING: no kernel modules source found; iso9660 mounts will fail"

--- a/scripts/mkusb.sh
+++ b/scripts/mkusb.sh
@@ -234,6 +234,29 @@ sgdisk \
 # them from the partition table we just wrote.
 ESP_START=$(sgdisk -i 1 "$IMG" | awk '/First sector:/ {print $3}')
 DATA_START=$(sgdisk -i 2 "$IMG" | awk '/First sector:/ {print $3}')
+
+# Validate offsets are non-empty numeric and non-zero before handing
+# them to `dd seek=` — an empty awk result yields `seek=` which bash
+# collapses to `seek=0`, silently overwriting the freshly-written GPT
+# at sector 0. A 0 value means sgdisk reported partition 1 starting at
+# sector 0, which is also wrong (GPT header occupies sector 0). (#138)
+for pair in "ESP:$ESP_START" "DATA:$DATA_START"; do
+    name="${pair%%:*}"
+    value="${pair#*:}"
+    case "$value" in
+        ''|*[!0-9]*)
+            log "FATAL: sgdisk returned non-numeric start sector for $name: '$value'"
+            log "  partition table parse failed; refusing to dd onto sector 0 and corrupt GPT."
+            exit 1
+            ;;
+    esac
+    if [ "$value" -eq 0 ] 2>/dev/null; then
+        log "FATAL: sgdisk returned sector 0 as start for $name partition"
+        log "  that overlaps the GPT header at sector 0; refusing to proceed."
+        exit 1
+    fi
+done
+
 log "  ESP  @ sector $ESP_START"
 log "  data @ sector $DATA_START"
 


### PR DESCRIPTION
## Summary

Two silent-failure paths called out in epic [#138](https://github.com/williamzujkowski/aegis-boot/issues/138) now fail fast with structured log lines.

### \`build-initramfs.sh\` — depmod fatal-exit

Was: WARNING + continue on \`depmod\` failure or missing binary. That produced an image whose \`modules.dep\` still pointed at the original \`.ko.zst\` paths — storage modules silently missed at boot time. The image looked correct; the operator found out under OVMF.

Now: FATAL + \`exit 1\` on either branch, with a specific log line naming what failed. Escape hatch \`AEGIS_ALLOW_MISSING_DEPMOD=1\` for operators on minimal hosts who genuinely can't install kmod and accept the risk.

### \`mkusb.sh\` — sgdisk offset validation

Was:

\`\`\`bash
ESP_START=\$(sgdisk -i 1 \"\$IMG\" | awk '/First sector:/ {print \$3}')
dd if=... bs=512 seek=\"\$ESP_START\" ...
\`\`\`

If awk returned empty (sgdisk format drift, missing partition, locale inversion), bash collapsed \`seek=\` to \`seek=0\` — silently overwriting the GPT header we just wrote.

Now: each start sector must be non-empty, numeric, **and** non-zero before it reaches \`dd\`. Fail fast with a specific log line naming the partition.

## Test plan

- [x] \`bash -n scripts/build-initramfs.sh\` — syntax clean
- [x] \`bash -n scripts/mkusb.sh\` — syntax clean
- [x] Shellcheck findings pre-existed (not introduced by this PR)
- [ ] CI green — both scripts exercised on every push (reproducible-build builds initramfs; mkusb-image job builds the disk image)

## Scope

Two scripts, three RUN blocks. No dependencies added, no interfaces changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)