### PR TITLE
feat(rescue-tui): actionable empty-state screen (#85 Tier 2)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -110,7 +110,7 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
             "discovered ISO"
         );
     }
-    let mut state = AppState::new(isos);
+    let mut state = AppState::new(isos).with_scanned_roots(roots.to_vec());
     if let Ok(name) = env::var("AEGIS_THEME") {
         state.theme = theme::Theme::from_name(&name);
         tracing::info!(theme = %name, "rescue-tui: theme override applied");

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -507,14 +507,80 @@ fn draw_confirm_quit_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState
     );
 }
 
+/// Render the empty-state screen when `discover()` returned zero ISOs.
+///
+/// Replaces the terse "No bootable ISOs found. Press q to quit, or check
+/// that `AEGIS_ISO_ROOTS` points at a directory containing `.iso` files."
+/// with a concrete diagnosis: the exact paths that were scanned, the
+/// paths' existence state, and three specific actionable next steps
+/// (mount media, copy an ISO, drop to rescue shell). (#85 Tier 2)
+fn draw_empty_list(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        "No bootable ISOs found.",
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    if state.scanned_roots.is_empty() {
+        lines.push(Line::from(
+            "(paths scanned: none — AEGIS_ISO_ROOTS parsing returned an empty list)",
+        ));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "Scanned these paths:",
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for root in &state.scanned_roots {
+            let exists_marker = if root.exists() { "exists" } else { "MISSING" };
+            lines.push(Line::from(format!(
+                "  {}  ({exists_marker})",
+                root.display()
+            )));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Next steps:",
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(
+        "  1. On the host, copy an ISO into the AEGIS_ISOS partition:",
+    ));
+    lines.push(Line::from("       aegis-boot add /path/to/distro.iso"));
+    lines.push(Line::from(
+        "     (or drag-and-drop the .iso file onto the stick via your file manager).",
+    ));
+    lines.push(Line::from(
+        "  2. If the AEGIS_ISOS partition is on this stick but wasn't auto-mounted,",
+    ));
+    lines.push(Line::from(
+        "     boot this stick on a host and run `aegis-boot doctor --stick /dev/sdX`.",
+    ));
+    lines.push(Line::from(
+        "  3. Select the always-present rescue shell entry below (if enabled) to",
+    ));
+    lines.push(Line::from(
+        "     drop to a busybox prompt and mount/inspect filesystems by hand.",
+    ));
+    lines.push(Line::from(""));
+    lines.push(Line::from("Press q to reboot, ? for keybindings."));
+
+    let panel = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" aegis-boot — no ISOs discovered "),
+        )
+        .wrap(Wrap { trim: false });
+    frame.render_widget(panel, area);
+}
+
 fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
     use crate::state::ViewEntry;
     if state.isos.is_empty() {
-        let empty = Paragraph::new(
-            "No bootable ISOs found.\n\nPress q to quit, or check that AEGIS_ISO_ROOTS\npoints at a directory containing .iso files.",
-        )
-        .block(Block::default().borders(Borders::ALL).title("aegis-boot"));
-        frame.render_widget(empty, area);
+        draw_empty_list(frame, area, state);
         return;
     }
 
@@ -1086,6 +1152,69 @@ mod tests {
         let s = render_to_string(&state);
         assert!(s.contains("No bootable ISOs"));
         assert!(s.contains("aegis-boot"));
+    }
+
+    #[test]
+    fn empty_list_shows_next_steps_with_actionable_commands() {
+        // (#85 Tier 2) — empty state must tell the operator WHAT to do,
+        // not just "no ISOs found". Verify the three actionable next
+        // steps all render.
+        let state = AppState::new(vec![]);
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("Next steps"),
+            "missing 'Next steps' heading in: {s}"
+        );
+        assert!(
+            s.contains("aegis-boot add"),
+            "missing `aegis-boot add` recipe in: {s}",
+        );
+        assert!(
+            s.contains("aegis-boot doctor"),
+            "missing `aegis-boot doctor` recipe in: {s}",
+        );
+        assert!(
+            s.contains("rescue shell"),
+            "missing rescue-shell escape-hatch mention in: {s}",
+        );
+    }
+
+    #[test]
+    fn empty_list_surfaces_scanned_roots() {
+        // Operator seeing "no ISOs" needs to know WHERE we looked. The
+        // TUI should echo each scanned path with its existence state.
+        let state = AppState::new(vec![]).with_scanned_roots(vec![
+            std::path::PathBuf::from("/this-path-definitely-does-not-exist"),
+            std::path::PathBuf::from("/tmp"),
+        ]);
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("/this-path-definitely-does-not-exist"),
+            "missing scanned path 1 in: {s}",
+        );
+        assert!(
+            s.contains("MISSING"),
+            "missing existence marker for non-existent path in: {s}",
+        );
+        assert!(s.contains("/tmp"), "missing scanned path 2 in: {s}",);
+        assert!(
+            s.contains("exists"),
+            "missing existence marker for existing path in: {s}",
+        );
+    }
+
+    #[test]
+    fn empty_list_with_no_scanned_roots_explains_why() {
+        // Degenerate case: AEGIS_ISO_ROOTS parsing returned empty —
+        // unusual but possible if env var is literally empty. Tell
+        // the operator rather than silently showing no paths.
+        let state = AppState::new(vec![]);
+        // Default state has scanned_roots = vec![] (not set by main.rs in tests).
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("AEGIS_ISO_ROOTS") || s.contains("paths scanned: none"),
+            "empty-state with no-roots must explain: {s}",
+        );
     }
 
     #[test]

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -115,6 +115,12 @@ pub struct AppState {
     pub filter_editing: bool,
     /// Sort order for the List screen view. Cycled with `s`.
     pub sort_order: SortOrder,
+    /// Paths that `iso_probe::discover()` was asked to scan. Surfaced
+    /// in the empty-state screen so operators see where we looked
+    /// (rather than "no bootable ISOs found" with no actionable
+    /// detail). Populated by `main.rs` after reading `AEGIS_ISO_ROOTS`;
+    /// default empty in tests. (#85 Tier 2)
+    pub scanned_roots: Vec<std::path::PathBuf>,
 }
 
 /// Sort order applied to the List view. Cycled with the `s` key.
@@ -299,7 +305,19 @@ impl AppState {
             filter: String::new(),
             filter_editing: false,
             sort_order: SortOrder::Name,
+            scanned_roots: Vec::new(),
         }
+    }
+
+    /// Attach the paths `discover()` was asked to scan. Called from
+    /// `main.rs` before entering the event loop so the empty-state
+    /// screen can tell the operator where we looked. Safe to skip in
+    /// tests — field defaults to empty and renders a no-paths variant.
+    /// (#85 Tier 2)
+    #[must_use]
+    pub fn with_scanned_roots(mut self, roots: Vec<std::path::PathBuf>) -> Self {
+        self.scanned_roots = roots;
+        self
     }
 
     /// Ordered list of entries displayed on the List screen (#90).


### PR DESCRIPTION
## Problem

Previous empty-state screen was terse:

\`\`\`
No bootable ISOs found.

Press q to quit, or check that AEGIS_ISO_ROOTS
points at a directory containing .iso files.
\`\`\`

An operator seeing this has no way to know:
- Which paths were actually scanned (\`AEGIS_ISO_ROOTS\` may have defaulted to \`/run/media:/mnt\`)
- Whether those paths existed at scan time
- What the specific next step is

## Fix

New empty-state panel:

\`\`\`
No bootable ISOs found.

Scanned these paths:
  /run/media/aegis-isos  (MISSING)
  /mnt/aegis-isos        (exists)

Next steps:
  1. On the host, copy an ISO into the AEGIS_ISOS partition:
       aegis-boot add /path/to/distro.iso
     (or drag-and-drop the .iso file via your file manager)
  2. If the AEGIS_ISOS partition wasn't auto-mounted, boot this
     stick on a host and run \`aegis-boot doctor --stick /dev/sdX\`.
  3. Select the rescue shell entry below to drop to busybox and
     mount/inspect filesystems by hand.

Press q to reboot, ? for keybindings.
\`\`\`

## Mechanics

- \`AppState\` gains \`scanned_roots: Vec<PathBuf>\` (defaults empty; non-breaking)
- New \`AppState::with_scanned_roots(roots)\` builder method
- \`main.rs\` populates it from the parsed \`AEGIS_ISO_ROOTS\` paths before entering the event loop
- \`render.rs::draw_empty_list()\` replaces the one-line \`Paragraph::new(\"No bootable ISOs...\")\`

## Test plan

- [x] \`cargo test --workspace\` — 225 tests pass (+3 new: \`empty_list_shows_next_steps_with_actionable_commands\`, \`empty_list_surfaces_scanned_roots\`, \`empty_list_with_no_scanned_roots_explains_why\`)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt\` — clean
- [ ] CI green

## Scope

Three files (\`state.rs\`, \`main.rs\`, \`render.rs\`). Closes one of two remaining Tier 2 children in epic #85; the inline error band remains for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)