### PR TITLE
fix(init): enable kernel.sysrq in initramfs (#93)

### DIFF
--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -378,6 +378,17 @@ else
 fi
 /bin/mount -t tmpfs  run   /run
 
+# Enable kernel SysRq for emergency escape hatches that rescue-tui's
+# Help overlay advertises (Alt+SysRq+b reboot, +s sync, +e SIGTERM).
+# Without this, those keybind cheatsheets lie — kernel.sysrq=0 is the
+# common distro default. Write 1 (all SysRq functions enabled) since
+# this is a rescue environment an operator explicitly booted. (#93)
+if /bin/echo 1 > /proc/sys/kernel/sysrq 2>/dev/null; then
+    /bin/echo "init: SysRq enabled (kernel.sysrq=1) — operator escape hatches active"
+else
+    /bin/echo "init: WARNING could not enable SysRq (kernel built without CONFIG_MAGIC_SYSRQ?)"
+fi
+
 # #109 shakedown: every /bin/echo "init: ..." below is ALSO captured
 # to /run/aegis-init.log via a simple helper. After AEGIS_ISOS
 # mounts, the file is copied onto the data partition so the


### PR DESCRIPTION
## Problem

rescue-tui's Help overlay at \`crates/rescue-tui/src/render.rs:463-466\` advertises emergency SysRq escape hatches:

\`\`\`
Emergency escape hatches (kernel SysRq)
  Alt+SysRq+b   reboot now
  Alt+SysRq+s   sync disks
  Alt+SysRq+e   SIGTERM all userspace
\`\`\`

…but \`/init\` never enabled \`kernel.sysrq\`. Most distro kernels default to either \`kernel.sysrq=0\` (all SysRq functions disabled) or \`kernel.sysrq=176\` (a restricted subset). The cheatsheet was advertising functionality that didn't exist — an operator hitting Alt+SysRq+b on a wedged TUI would see nothing happen.

## Fix

\`/init\` now writes \`1\` to \`/proc/sys/kernel/sysrq\` right after \`/proc\` mounts, enabling all SysRq functions. Logs either success or a specific fallback message if the kernel was compiled without CONFIG_MAGIC_SYSRQ.

This is a rescue environment an operator explicitly booted — the \"SysRq can hose an unprepared production system\" concern doesn't apply.

## Scope

One line in one shell script (plus log + error handling). Closes the last of the #93 P1 children for SysRq ceremony; the cheatsheet in Help now describes real behavior.

## Test plan

- [x] \`bash -n scripts/build-initramfs.sh\` — syntax clean
- [ ] CI QEMU smoke-boot exercises \`/init\` end-to-end. A successful boot confirms the SysRq-enable path doesn't break the init script.
- [ ] (Post-merge, on real hardware) Alt+SysRq+s then Alt+SysRq+b from rescue-tui should sync + reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)