### PR TITLE
chore(cli): cross-reference flash/init success with aegis-boot subcommands

### DIFF
--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -68,13 +68,22 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
         Ok(()) => {
             println!();
             println!("Done. Next steps:");
-            println!("  1. Mount the AEGIS_ISOS partition and copy .iso files onto it:");
+            println!("  1. Add ISOs to the stick (handles mount, verify, attestation):");
+            println!("       aegis-boot add /path/to/distro.iso");
+            println!("     (or — for a curated bundle in one command —)");
             println!(
-                "       sudo mount {}2 /mnt && cp *.iso /mnt/ && sudo umount /mnt",
+                "       aegis-boot init {} --profile panic-room",
                 drive.dev.display()
             );
-            println!("  2. Boot from the stick (UEFI boot menu, select the USB entry).");
-            println!("  3. In rescue-tui, pick an ISO and press Enter.");
+            println!("  2. Safely power-off the stick before removal:");
+            println!("       aegis-boot eject {}", drive.dev.display());
+            println!("  3. Boot the target machine from the stick (UEFI boot menu),");
+            println!("     pick an ISO in rescue-tui, and press Enter.");
+            println!();
+            println!(
+                "Manual fallback: sudo mount {}2 /mnt && cp *.iso /mnt/ && sudo umount /mnt",
+                drive.dev.display()
+            );
             Ok(())
         }
         Err(e) => {

--- a/crates/aegis-cli/src/init.rs
+++ b/crates/aegis-cli/src/init.rs
@@ -324,7 +324,8 @@ fn print_success(profile: &Profile) {
     );
     println!();
     println!("Next steps:");
-    println!("  1. Eject: sudo sync && sudo eject /dev/sdX");
+    println!("  1. Eject the stick safely: aegis-boot eject /dev/sdX");
+    println!("     (manual fallback: sudo sync && sudo eject /dev/sdX)");
     println!("  2. Boot the target machine (UEFI boot menu → USB entry).");
     println!("  3. In rescue-tui, pick an ISO and press Enter.");
     println!();


### PR DESCRIPTION
## Summary

Post-success screens for \`aegis-boot flash\` and \`aegis-boot init\` were pointing operators at raw shell recipes (\`sudo mount... cp... eject\`) when higher-UX CLI subcommands now cover the same work:

- \`add\` exists since v0.12
- \`init --profile ...\` since #162 earlier this session
- \`eject\` since #174 just merged

Updated both post-success screens to recommend the subcommand path first, with the raw shell recipe preserved as a "Manual fallback" footer for operators on unusual distros.

## Before — flash success

\`\`\`
Done. Next steps:
  1. Mount the AEGIS_ISOS partition and copy .iso files onto it:
       sudo mount /dev/sdc2 /mnt && cp *.iso /mnt/ && sudo umount /mnt
  2. Boot from the stick (UEFI boot menu, select the USB entry).
  3. In rescue-tui, pick an ISO and press Enter.
\`\`\`

## After — flash success

\`\`\`
Done. Next steps:
  1. Add ISOs to the stick (handles mount, verify, attestation):
       aegis-boot add /path/to/distro.iso
     (or — for a curated bundle in one command —)
       aegis-boot init /dev/sdc --profile panic-room
  2. Safely power-off the stick before removal:
       aegis-boot eject /dev/sdc
  3. Boot the target machine from the stick (UEFI boot menu),
     pick an ISO in rescue-tui, and press Enter.

Manual fallback: sudo mount /dev/sdc2 /mnt && cp *.iso /mnt/ && sudo umount /mnt
\`\`\`

## Scope

Two files — \`flash.rs\` and \`init.rs\` — prose only. No behavior change; tests still pass.

## Test plan

- [x] \`cargo test --workspace\` — 231 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)