### PR TITLE
feat(cli): aegis-boot init --list-profiles for dynamic completion

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -63,5 +63,5 @@ aegis-boot uses raw argv parsing (not clap) to keep the static-musl binary small
 
 - The bash completion hardcodes the subcommand list — if a new subcommand is added to `main.rs`, add it to the `subcommands` variable at the top of `aegis-boot.bash`.
 - Same for zsh's `subcommands` array.
-- The profile list (`panic-room minimal server`) is hardcoded — it'd be ideal to have `aegis-boot init --list-profiles` but the count is small and drift would be obvious (PR CI surfaces it).
-- Catalog slugs are ALWAYS dynamic via `--slugs-only`, so they can't drift.
+- Profile names are dynamic via `aegis-boot init --list-profiles`.
+- Catalog slugs are dynamic via `aegis-boot recommend --slugs-only`.

--- a/completions/_aegis-boot
+++ b/completions/_aegis-boot
@@ -26,9 +26,6 @@ _aegis-boot() {
         'eject:Safely power-off a stick before removal'
     )
 
-    local -a profiles
-    profiles=(panic-room minimal server)
-
     _arguments -C \
         '1: :->subcmd' \
         '*:: :->args'
@@ -41,12 +38,17 @@ _aegis-boot() {
         args)
             case "$line[1]" in
                 init)
+                    # Pull live profile list from the binary so zsh
+                    # completion stays in sync with the installed catalog.
+                    local -a profiles
+                    profiles=(${(f)"$(aegis-boot init --list-profiles 2>/dev/null)"})
                     _arguments \
-                        '--profile[profile name]:profile:('"${profiles[*]}"')' \
+                        "--profile[profile name]:profile:($profiles)" \
                         '--yes[skip interactive confirmations]' \
                         '-y[skip interactive confirmations]' \
                         '--no-doctor[skip doctor preflight]' \
                         '--no-gpg[skip GPG verification]' \
+                        '--list-profiles[machine-readable profile list]' \
                         '--help[show help]' \
                         '*:device:_files -g "/dev/sd*"'
                     ;;

--- a/completions/aegis-boot.bash
+++ b/completions/aegis-boot.bash
@@ -18,7 +18,6 @@ _aegis_boot() {
     _init_completion || return
 
     local subcommands="init flash list add doctor recommend fetch attest eject --help --version"
-    local profiles="panic-room minimal server"
     local attest_actions="list show"
 
     # Top-level subcommand or global flag.
@@ -34,7 +33,13 @@ _aegis_boot() {
             # Device arg — complete block device paths + typical flags.
             case "$prev" in
                 --profile)
-                    COMPREPLY=($(compgen -W "$profiles" -- "$cur"))
+                    # Pull live profile list from the binary; stays in
+                    # sync with whatever the installed aegis-boot ships.
+                    local profiles
+                    profiles="$(aegis-boot init --list-profiles 2>/dev/null)"
+                    if [[ -n "$profiles" ]]; then
+                        COMPREPLY=($(compgen -W "$profiles" -- "$cur"))
+                    fi
                     return 0
                     ;;
             esac

--- a/crates/aegis-cli/src/init.rs
+++ b/crates/aegis-cli/src/init.rs
@@ -92,6 +92,17 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    // Machine-readable profile enumeration for shell completion scripts
+    // (complements `aegis-boot recommend --slugs-only`). One profile name
+    // per line, nothing else on stdout. Stable contract — completion
+    // scripts parse this line-for-line.
+    if args.iter().any(|a| a == "--list-profiles") {
+        for profile in PROFILES {
+            println!("{}", profile.name);
+        }
+        return ExitCode::SUCCESS;
+    }
+
     let parsed = match parse_flags(args) {
         Ok(p) => p,
         Err(msg) => {
@@ -346,11 +357,12 @@ fn print_help() {
     println!("  aegis-boot init [/dev/sdX] [OPTIONS]");
     println!();
     println!("OPTIONS:");
-    println!("  --profile NAME    Profile to install (default: panic-room)");
-    println!("  --yes, -y         Skip interactive confirmations (destructive)");
-    println!("  --no-doctor       Skip doctor preflight (not recommended)");
-    println!("  --no-gpg          Skip GPG verification on fetched ISOs");
-    println!("  --help, -h        This message");
+    println!("  --profile NAME     Profile to install (default: panic-room)");
+    println!("  --yes, -y          Skip interactive confirmations (destructive)");
+    println!("  --no-doctor        Skip doctor preflight (not recommended)");
+    println!("  --no-gpg           Skip GPG verification on fetched ISOs");
+    println!("  --list-profiles    Print profile names, one per line (for completion)");
+    println!("  --help, -h         This message");
     println!();
     println!("PROFILES:");
     for p in PROFILES {


### PR DESCRIPTION
## Summary

Matches the \`--slugs-only\` pattern on \`recommend\` shipped in #176. \`aegis-boot init --list-profiles\` emits one profile name per line (nothing else) on stdout; the shell completion scripts now call it dynamically instead of hardcoding \`panic-room minimal server\`.

## Why

Profile list was manually-maintained in the completion files. As profiles get added (planned: \`desktop\`, \`privacy\`, …), the hardcoded completion would drift silently. Same reasoning as #176's \`--slugs-only\` mode for the catalog.

## Changes

- \`init.rs\` — accept \`--list-profiles\` before normal flag parse; print \`PROFILES\` names + exit 0
- \`completions/aegis-boot.bash\` — \`--profile\` completion calls the binary
- \`completions/_aegis-boot\` — zsh equivalent
- \`completions/README.md\` — "Keeping completions honest" section updated

## Test plan

- [x] \`aegis-boot init --list-profiles\` prints 3 lines (\`panic-room / minimal / server\`), exit 0
- [x] \`bash -n completions/aegis-boot.bash\` — syntax clean
- [x] \`cargo test --workspace\` — 232 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] CI green on push

## Scope

~15 LOC across 4 files. No new subcommand; extends existing \`init\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)