### PR TITLE
fix(lints): tighten workspace unwrap_used + expect_used to deny (#138)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,11 @@ missing_docs = "warn"
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
+# unwrap_used/expect_used tightened to `deny` (#138). Production code
+# must surface errors explicitly rather than panic; test modules opt
+# back out with `#[allow(clippy::unwrap_used, clippy::expect_used)]`
+# at the `#[cfg(test)] mod …` boundary, where unwrap/expect are
+# legitimate for clarity. CI already runs with `-D warnings` so this
+# tightening blocks new unwrap/expect in production at PR time.
+unwrap_used = "deny"
+expect_used = "deny"


### PR DESCRIPTION
## Summary

Closes the \`unwrap_used\`/\`expect_used = deny\` child in [#138](https://github.com/williamzujkowski/aegis-boot/issues/138). Was blocked on #83's iso-parser test cleanup; #179 merged, unblocked.

## Before

\`\`\`toml
[workspace.lints.clippy]
unwrap_used = "warn"
expect_used = "warn"
\`\`\`

Over 19 merges this session, zero PRs failed on a new production unwrap/expect. The warn-level made them invisible.

## After

\`\`\`toml
[workspace.lints.clippy]
unwrap_used = "deny"
expect_used = "deny"
\`\`\`

CI's \`-D warnings\` now blocks new production unwrap/expect at PR time. Test modules already carry the per-module allow from #179 so existing tests are unaffected.

## Verification

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 232 tests pass
- [x] \`cargo fmt\` — clean
- [ ] CI green on push

## Why now

The trust narrative ("aegis-boot proves what's on the stick") is undermined by code that silently panics on an unwrap_or(0) and claims verification ran. Tightening to \`deny\` matches \`unsafe_code = deny\`'s tier — both are boundary conditions that need positive review before entering the codebase.

## Scope

Single-file change to workspace \`Cargo.toml\`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)