### PR TITLE
feat(cli): aegis-boot verify — re-verify every ISO on a stick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,10 @@ version = 4
 name = "aegis-cli"
 version = "0.13.0"
 dependencies = [
+ "iso-probe",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 [dependencies]
 serde = { workspace = true }
 serde_json = "1.0"
+iso-probe = { path = "../iso-probe" }
+
+[dev-dependencies]
+tempfile = "3.14"
 
 [lints]
 workspace = true

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -196,19 +196,23 @@ fn print_attestation_summary(mount_path: &Path) {
     println!();
 }
 
-struct Mount {
-    path: PathBuf,
+/// A resolved mount point — either an existing directory or one we
+/// created ourselves. Promoted to `pub(crate)` so other subcommands
+/// (currently `verify`) can reuse the mount-resolution logic without
+/// duplicating it.
+pub(crate) struct Mount {
+    pub(crate) path: PathBuf,
     /// If true, we mounted the partition ourselves and should unmount on exit.
-    temporary: bool,
+    pub(crate) temporary: bool,
     #[allow(dead_code)]
-    device: Option<PathBuf>,
+    pub(crate) device: Option<PathBuf>,
 }
 
 /// Resolve the target mount from either:
 ///   - no arg: find an already-mounted `AEGIS_ISOS` partition, or auto-mount `/dev/sdX2`
 ///   - `/dev/sdX`: find partition 2, mount it (temp dir), return that
 ///   - `/some/path`: use as-is (assume already mounted)
-fn resolve_mount(arg: Option<&str>) -> Result<Mount, String> {
+pub(crate) fn resolve_mount(arg: Option<&str>) -> Result<Mount, String> {
     if let Some(raw) = arg {
         let p = PathBuf::from(raw);
         if p.is_dir() {
@@ -281,7 +285,7 @@ fn mount_dev(dev: &Path) -> Result<Mount, String> {
     })
 }
 
-fn unmount_temp(m: &Mount) {
+pub(crate) fn unmount_temp(m: &Mount) {
     let _ = Command::new("sudo")
         .args(["umount", &m.path.display().to_string()])
         .status();

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -11,6 +11,7 @@
 //!   * `attest`    — list / show attestation receipts for past flashes
 //!   * `eject`     — safely power-off and prepare a USB stick for removal
 //!   * `update`    — in-place signed-chain rotation (phase 1: eligibility check)
+//!   * `verify`    — re-run sha256 verification on every ISO on the stick
 //!
 //! This replaces the developer workflow of running shell scripts
 //! manually. The binary is named `aegis-boot` so operators type
@@ -28,6 +29,7 @@ mod flash;
 mod init;
 mod inventory;
 mod update;
+mod verify;
 
 use std::env;
 use std::process::ExitCode;
@@ -51,6 +53,7 @@ fn main() -> ExitCode {
         Some("attest") => attest::run(&args[1..]),
         Some("eject") => eject::run(&args[1..]),
         Some("update") => update::run(&args[1..]),
+        Some("verify") => verify::run(&args[1..]),
         Some("-h" | "--help" | "help") | None => {
             print_help();
             ExitCode::SUCCESS
@@ -81,6 +84,7 @@ fn print_help() {
     println!("  aegis-boot attest [list|show] Attestation receipts for past flashes");
     println!("  aegis-boot eject [device]     Safely power-off a stick before removal");
     println!("  aegis-boot update <device>    Check eligibility for in-place update");
+    println!("  aegis-boot verify [device]    Re-verify every ISO's sha256 against its sidecar");
     println!("  aegis-boot --version          Print version");
     println!("  aegis-boot --help             This message");
     println!();

--- a/crates/aegis-cli/src/verify.rs
+++ b/crates/aegis-cli/src/verify.rs
@@ -1,0 +1,370 @@
+//! `aegis-boot verify [device|mount]` — re-verify every ISO on a stick.
+//!
+//! Closes the trust-narrative loop (flash → add → *verify*). For each
+//! `.iso` under the `AEGIS_ISOS` partition, re-runs `iso_probe::verify_iso_hash`
+//! against its sibling checksum file and aggregates the result.
+//!
+//! This is deliberately separate from rescue-tui's in-TUI `v` key —
+//! that's operator-initiated during a boot, while this is a host-side
+//! preflight operators can run before ejecting a stick into a customer
+//! environment.
+//!
+//! # Exit codes
+//!
+//! - `0` — every ISO verified OR the only verdicts are `NotPresent`
+//!   (no sidecar checksum to verify against; not an error)
+//! - `1` — at least one `Mismatch`, `Forged`, or `Unreadable` verdict
+//! - `2` — invalid arguments or could not resolve the target
+//!
+//! The "`NotPresent` is OK" semantics matches what rescue-tui does —
+//! an operator adding a random ISO without a `.sha256` sidecar isn't
+//! making a security claim, so `verify()` shouldn't reject it.
+//!
+//! Tracked as the "aegis-boot verify" item consensus-voted highest-
+//! leverage after the `update` epic #181.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use iso_probe::HashVerification;
+
+use crate::inventory::{resolve_mount, unmount_temp};
+
+/// Entry point for `aegis-boot verify [device|mount]`.
+pub fn run(args: &[String]) -> ExitCode {
+    match try_run(args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(code) => ExitCode::from(code),
+    }
+}
+
+/// Inner runner returning a typed result.
+pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
+    if args.first().map(String::as_str) == Some("--help")
+        || args.first().map(String::as_str) == Some("-h")
+    {
+        print_help();
+        return Ok(());
+    }
+
+    let mount = match resolve_mount(args.first().map(String::as_str)) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("aegis-boot verify: {e}");
+            return Err(2);
+        }
+    };
+
+    let isos = scan_iso_files(&mount.path);
+    if isos.is_empty() {
+        println!(
+            "No .iso files on {} — nothing to verify.",
+            mount.path.display()
+        );
+        if mount.temporary {
+            unmount_temp(&mount);
+        }
+        return Ok(());
+    }
+
+    println!(
+        "Verifying {} ISO(s) on {}...",
+        isos.len(),
+        mount.path.display()
+    );
+    println!();
+
+    let mut tally = Tally::default();
+    for iso in &isos {
+        let verdict = iso_probe::verify_iso_hash(iso).unwrap_or_else(|e| {
+            // Failure to read the ISO file itself — distinct from
+            // failure to read the sidecar. Map to Unreadable with the
+            // ISO path as source so the operator sees the cause.
+            HashVerification::Unreadable {
+                source: iso.display().to_string(),
+                reason: e.to_string(),
+            }
+        });
+        let iso_name = iso
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("(unknown)");
+        print_verdict(iso_name, &verdict);
+        tally.record(&verdict);
+    }
+
+    println!();
+    tally.print_summary();
+
+    if mount.temporary {
+        unmount_temp(&mount);
+    }
+
+    // Exit code: any Mismatch, Forged, or Unreadable is a fail. NotPresent
+    // alone is OK — see module doc for the rationale.
+    if tally.any_failure() {
+        Err(1)
+    } else {
+        Ok(())
+    }
+}
+
+fn print_help() {
+    println!("aegis-boot verify — re-verify every ISO on a stick against its sidecar checksum");
+    println!();
+    println!("USAGE:");
+    println!("  aegis-boot verify                 Auto-find mounted AEGIS_ISOS");
+    println!("  aegis-boot verify /dev/sdX        Mount partition 2 and verify");
+    println!("  aegis-boot verify /mnt/iso-dir    Use explicit mount path");
+    println!("  aegis-boot verify --help");
+    println!();
+    println!("EXIT CODES:");
+    println!("  0  every ISO verified (or only NotPresent verdicts — no sidecars)");
+    println!("  1  any Mismatch / Forged / Unreadable verdict");
+    println!("  2  invalid arguments or could not resolve the target");
+    println!();
+    println!("RELATED:");
+    println!("  aegis-boot list      — view verification state + attestation summary");
+    println!("  aegis-boot add       — copy + verify a new ISO onto the stick");
+    println!("  (In rescue-tui, press `v` on an ISO for the in-boot re-verification.)");
+}
+
+/// List every `.iso` file at the top level of `dir`. Non-recursive —
+/// `AEGIS_ISOS` is a flat layout. Files are sorted alphabetically so
+/// verify output is deterministic.
+fn scan_iso_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("iso"))
+            && p.is_file()
+        {
+            out.push(p);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn print_verdict(iso_name: &str, verdict: &HashVerification) {
+    match verdict {
+        HashVerification::Verified { source, .. } => {
+            let sidecar = short_source(source);
+            println!("  [\u{2713} verified ] {iso_name}   (sidecar: {sidecar})");
+        }
+        HashVerification::Mismatch {
+            actual,
+            expected,
+            source,
+        } => {
+            let sidecar = short_source(source);
+            println!("  [\u{2717} MISMATCH] {iso_name}   (sidecar: {sidecar})");
+            println!("      expected: {expected}");
+            println!("      actual:   {actual}");
+        }
+        HashVerification::Unreadable { source, reason } => {
+            let sidecar = short_source(source);
+            println!("  [! UNREAD  ] {iso_name}   (sidecar: {sidecar})");
+            println!("      reason: {reason}");
+        }
+        HashVerification::NotPresent => {
+            println!("  [ no sidecar] {iso_name}   (no .sha256 or SHA256SUMS)");
+        }
+    }
+}
+
+/// Short-form the sidecar path so a multi-hundred-char /run/media
+/// path doesn't hide the operative signal.
+fn short_source(source: &str) -> String {
+    // Take the last two path components if there's a '/'; otherwise
+    // return as-is.
+    let p = Path::new(source);
+    let parent = p.parent().and_then(|pp| pp.file_name());
+    let basename = p.file_name();
+    match (parent, basename) {
+        (Some(par), Some(base)) => format!("{}/{}", par.to_string_lossy(), base.to_string_lossy()),
+        _ => source.to_string(),
+    }
+}
+
+#[derive(Default)]
+struct Tally {
+    verified: usize,
+    mismatch: usize,
+    unreadable: usize,
+    not_present: usize,
+}
+
+impl Tally {
+    fn record(&mut self, v: &HashVerification) {
+        match v {
+            HashVerification::Verified { .. } => self.verified += 1,
+            HashVerification::Mismatch { .. } => self.mismatch += 1,
+            HashVerification::Unreadable { .. } => self.unreadable += 1,
+            HashVerification::NotPresent => self.not_present += 1,
+        }
+    }
+
+    fn any_failure(&self) -> bool {
+        self.mismatch > 0 || self.unreadable > 0
+    }
+
+    fn total(&self) -> usize {
+        self.verified + self.mismatch + self.unreadable + self.not_present
+    }
+
+    fn print_summary(&self) {
+        println!("Summary: {} ISO(s) total", self.total());
+        println!("  verified:     {}", self.verified);
+        if self.not_present > 0 {
+            println!(
+                "  no sidecar:   {}  (NotPresent — not a failure)",
+                self.not_present
+            );
+        }
+        if self.mismatch > 0 {
+            println!("  MISMATCH:     {}  (failure)", self.mismatch);
+        }
+        if self.unreadable > 0 {
+            println!("  UNREADABLE:   {}  (failure)", self.unreadable);
+        }
+        println!();
+        if self.any_failure() {
+            println!("Overall: FAIL — do not ship this stick without resolving the above.");
+        } else if self.verified == 0 {
+            println!(
+                "Overall: no verification performed — no .sha256 / SHA256SUMS sidecars present."
+            );
+        } else {
+            println!("Overall: OK — every ISO with a sidecar verifies.");
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::missing_panics_doc)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn verified() -> HashVerification {
+        HashVerification::Verified {
+            digest: "abc123".to_string(),
+            source: "/mnt/iso/u.iso.sha256".to_string(),
+        }
+    }
+
+    fn mismatch() -> HashVerification {
+        HashVerification::Mismatch {
+            actual: "aaa".to_string(),
+            expected: "bbb".to_string(),
+            source: "/mnt/iso/u.iso.sha256".to_string(),
+        }
+    }
+
+    fn unreadable() -> HashVerification {
+        HashVerification::Unreadable {
+            source: "/mnt/iso/u.iso.sha256".to_string(),
+            reason: "permission denied".to_string(),
+        }
+    }
+
+    #[test]
+    fn tally_counts_each_variant() {
+        let mut t = Tally::default();
+        t.record(&verified());
+        t.record(&verified());
+        t.record(&mismatch());
+        t.record(&HashVerification::NotPresent);
+        t.record(&unreadable());
+        assert_eq!(t.verified, 2);
+        assert_eq!(t.mismatch, 1);
+        assert_eq!(t.not_present, 1);
+        assert_eq!(t.unreadable, 1);
+        assert_eq!(t.total(), 5);
+    }
+
+    #[test]
+    fn any_failure_true_for_mismatch() {
+        let mut t = Tally::default();
+        t.record(&mismatch());
+        assert!(t.any_failure());
+    }
+
+    #[test]
+    fn any_failure_true_for_unreadable() {
+        let mut t = Tally::default();
+        t.record(&unreadable());
+        assert!(t.any_failure());
+    }
+
+    #[test]
+    fn any_failure_false_for_verified_plus_not_present() {
+        // The non-negotiable exit-code rule: NotPresent alone is OK.
+        let mut t = Tally::default();
+        t.record(&verified());
+        t.record(&HashVerification::NotPresent);
+        t.record(&HashVerification::NotPresent);
+        assert!(!t.any_failure());
+    }
+
+    #[test]
+    fn any_failure_false_for_all_not_present() {
+        // Every ISO lacks a sidecar — not a failure, just no
+        // verification material.
+        let mut t = Tally::default();
+        for _ in 0..5 {
+            t.record(&HashVerification::NotPresent);
+        }
+        assert!(!t.any_failure());
+    }
+
+    #[test]
+    fn short_source_keeps_last_two_components() {
+        assert_eq!(
+            short_source("/run/media/aegis-isos/ubuntu.iso.sha256"),
+            "aegis-isos/ubuntu.iso.sha256"
+        );
+    }
+
+    #[test]
+    fn short_source_handles_bare_filename() {
+        assert_eq!(short_source("ubuntu.iso.sha256"), "ubuntu.iso.sha256");
+    }
+
+    #[test]
+    fn scan_iso_files_returns_sorted_iso_filenames() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join("b.iso"), b"").unwrap();
+        std::fs::write(root.join("a.iso"), b"").unwrap();
+        std::fs::write(root.join("readme.txt"), b"").unwrap(); // non-iso
+        std::fs::write(root.join("c.ISO"), b"").unwrap(); // upper-case ext
+        let found = scan_iso_files(root);
+        let names: Vec<_> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["a.iso", "b.iso", "c.ISO"]);
+    }
+
+    #[test]
+    fn scan_iso_files_empty_on_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let found = scan_iso_files(tmp.path());
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn scan_iso_files_empty_on_nonexistent_dir() {
+        let found = scan_iso_files(&PathBuf::from(
+            "/this-path-does-not-exist-for-aegis-boot-verify-test",
+        ));
+        assert!(found.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the trust-narrative loop: **create → verify**. For each \`.iso\` on the \`AEGIS_ISOS\` partition, re-runs \`iso_probe::verify_iso_hash\` against its sibling checksum file and aggregates the verdicts.

## Why this one

Consensus-voted highest-leverage next step after #182 (architect 0.82, security 0.95; PM timed out). Both agents independently ranked \`verify\` #1:

- Reuses the existing cryptographic primitive — no new architectural surface
- Direct security value (catches tampering, corruption, sidecar rot)
- Fully testable without root / losetup / network (unlike the loopback-init E2E alternative)
- Standalone value; doesn't depend on #182 landing

## Usage

\`\`\`bash
aegis-boot verify                  # auto-find mounted AEGIS_ISOS
aegis-boot verify /dev/sdX         # mount part 2 + verify
aegis-boot verify /mnt/iso-dir     # explicit mount path
\`\`\`

## Exit-code policy

| Code | Meaning                                                                 |
| ---- | ----------------------------------------------------------------------- |
| 0    | Every ISO verified OR only \`NotPresent\` verdicts (no sidecar)         |
| 1    | Any \`Mismatch\` / \`Forged\` / \`Unreadable\` verdict                  |
| 2    | Invalid args or unresolvable target                                     |

The "\`NotPresent\` alone is OK" rule matches rescue-tui semantics: an operator adding a random ISO without a \`.sha256\` sidecar isn't making a security claim, so verify shouldn't reject it.

## Mechanics

- New \`crates/aegis-cli/src/verify.rs\` (~330 LOC)
- Reuses \`inventory::resolve_mount\` + \`inventory::unmount_temp\` (promoted from \`fn\` to \`pub(crate) fn\` — zero-risk surface change, stays crate-private)
- Depends on \`iso-probe\` as a workspace crate dep (first aegis-cli → iso-probe edge)

## Differentiation from \`v\` in rescue-tui

- \`v\` in rescue-tui: **in-boot**, operator-initiated during a boot attempt, with a live progress bar
- \`aegis-boot verify\`: **host-side**, pre-ship preflight the operator runs before handing a stick to a customer

Two contexts, same underlying crypto primitive.

## Test plan

- [x] \`cargo test --workspace\` — 252 pass (+10 new verify tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean under the new \`unwrap_used = deny\` from #180
- [x] \`cargo fmt\` — clean
- [x] Manual: \`aegis-boot verify --help\` shows the new surface correctly
- [ ] CI green on push

## Test coverage (10 new)

- \`tally_counts_each_variant\` — counting \`Verified\` / \`Mismatch\` / \`NotPresent\` / \`Unreadable\` separately
- \`any_failure_true_for_mismatch\` and \`_for_unreadable\`
- \`any_failure_false_for_verified_plus_not_present\` — **non-negotiable rule**: \`NotPresent\` alone is OK
- \`any_failure_false_for_all_not_present\` — all NotPresent also OK
- \`short_source_keeps_last_two_components\` and \`_handles_bare_filename\`
- \`scan_iso_files_returns_sorted_iso_filenames\` — deterministic output, case-insensitive \`.iso\` extension, non-iso files skipped
- \`scan_iso_files_empty_on_empty_dir\` and \`_on_nonexistent_dir\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)