### PR TITLE
feat(cli): --json mode on list + attest (consensus A)

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -372,13 +372,17 @@ pub fn record_flash(drive: &Drive, img_path: &Path, img_size: u64) -> Result<Pat
 /// Entry point for `aegis-boot attest [list|show <file>] [--help]`.
 pub fn run(args: &[String]) -> ExitCode {
     let sub = args.first().map(String::as_str);
+    // --json is accepted on `list` (applies to the enumeration).
+    let json_mode = args.iter().any(|a| a == "--json");
     match sub {
         None | Some("--help" | "-h" | "help") => {
             print_help();
             ExitCode::SUCCESS
         }
-        Some("list") => run_list(),
+        Some("list") => run_list(json_mode),
         Some("show") => run_show(&args[1..]),
+        // Bare `aegis-boot attest --json` == `aegis-boot attest list --json`
+        Some("--json") => run_list(true),
         Some(other) => {
             eprintln!("aegis-boot attest: unknown subcommand '{other}'");
             eprintln!("run 'aegis-boot attest --help' for usage");
@@ -404,10 +408,14 @@ fn print_help() {
     println!("  aegis-boot attest show ~/.local/share/aegis-boot/attestations/abc123-2026-04-16T12-34-56Z.json");
 }
 
-fn run_list() -> ExitCode {
+fn run_list(json_mode: bool) -> ExitCode {
     let dir = data_dir().join("attestations");
     if !dir.is_dir() {
-        println!("(no attestations recorded yet — run `aegis-boot flash` to create one)");
+        if json_mode {
+            println!("{{ \"schema_version\": 1, \"attestations\": [] }}");
+        } else {
+            println!("(no attestations recorded yet — run `aegis-boot flash` to create one)");
+        }
         return ExitCode::SUCCESS;
     }
     let mut entries: Vec<_> = match fs::read_dir(&dir) {
@@ -416,11 +424,22 @@ fn run_list() -> ExitCode {
             .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
             .collect(),
         Err(e) => {
-            eprintln!("aegis-boot attest list: read_dir {}: {e}", dir.display());
+            if json_mode {
+                println!(
+                    "{{ \"schema_version\": 1, \"error\": \"{}\" }}",
+                    crate::doctor::json_escape(&format!("read_dir {}: {e}", dir.display()))
+                );
+            } else {
+                eprintln!("aegis-boot attest list: read_dir {}: {e}", dir.display());
+            }
             return ExitCode::from(1);
         }
     };
     entries.sort_by_key(std::fs::DirEntry::path);
+    if json_mode {
+        print_attest_list_json(&dir, &entries);
+        return ExitCode::SUCCESS;
+    }
     if entries.is_empty() {
         println!("(no attestations in {})", dir.display());
         return ExitCode::SUCCESS;
@@ -451,6 +470,79 @@ fn run_list() -> ExitCode {
         entries.len()
     );
     ExitCode::SUCCESS
+}
+
+/// Emit the attestation list as a stable `schema_version=1` JSON
+/// document on stdout. Each entry carries the parsed attestation
+/// summary plus the on-disk manifest path so downstream tooling can
+/// follow the chain to `aegis-boot attest show <file>` for full detail.
+fn print_attest_list_json(dir: &Path, entries: &[std::fs::DirEntry]) {
+    use crate::doctor::json_escape;
+    println!("{{");
+    println!("  \"schema_version\": 1,");
+    println!("  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
+    println!(
+        "  \"attestations_dir\": \"{}\",",
+        json_escape(&dir.display().to_string())
+    );
+    println!("  \"count\": {},", entries.len());
+    println!("  \"attestations\": [");
+    let last = entries.len().saturating_sub(1);
+    for (i, entry) in entries.iter().enumerate() {
+        let path = entry.path();
+        let comma = if i == last { "" } else { "," };
+        match read_attestation(&path) {
+            Ok(att) => {
+                // Emit a subset of the full manifest — enough to drive
+                // a CI/monitoring dashboard without requiring the
+                // consumer to re-parse each file. Full detail is one
+                // `aegis-boot attest show <path>` away.
+                println!("    {{");
+                println!(
+                    "      \"manifest_path\": \"{}\",",
+                    json_escape(&path.display().to_string())
+                );
+                println!("      \"schema_version\": {},", att.schema_version);
+                println!(
+                    "      \"tool_version\": \"{}\",",
+                    json_escape(&att.tool_version)
+                );
+                println!(
+                    "      \"flashed_at\": \"{}\",",
+                    json_escape(&att.flashed_at)
+                );
+                println!("      \"operator\": \"{}\",", json_escape(&att.operator));
+                println!(
+                    "      \"target_device\": \"{}\",",
+                    json_escape(&att.target.device)
+                );
+                println!(
+                    "      \"target_model\": \"{}\",",
+                    json_escape(&att.target.model)
+                );
+                println!(
+                    "      \"disk_guid\": \"{}\",",
+                    json_escape(&att.target.disk_guid)
+                );
+                println!("      \"iso_count\": {}", att.isos.len());
+                println!("    }}{comma}");
+            }
+            Err(e) => {
+                println!("    {{");
+                println!(
+                    "      \"manifest_path\": \"{}\",",
+                    json_escape(&path.display().to_string())
+                );
+                println!(
+                    "      \"error\": \"{}\"",
+                    json_escape(&format!("parse failed: {e}"))
+                );
+                println!("    }}{comma}");
+            }
+        }
+    }
+    println!("  ]");
+    println!("}}");
 }
 
 fn run_show(args: &[String]) -> ExitCode {

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -240,9 +240,12 @@ fn band_for_score(score: u8) -> &'static str {
 }
 
 /// Minimal JSON string escaper: handles the five characters RFC 8259
-/// requires (`"`, `\`, `\n`, `\r`, `\t`). Sufficient for check names /
-/// details — doctor doesn't carry arbitrary user input.
-fn json_escape(s: &str) -> String {
+/// requires (`"`, `\`, `\n`, `\r`, `\t`), plus control characters
+/// below `0x20` as `\u00XX`. Sufficient for check names / details —
+/// doctor doesn't carry arbitrary user input. Shared with other
+/// `--json` surfaces (`list --json`, `attest --json`) so every
+/// aegis-boot structured-output formatter uses the same escape rules.
+pub(crate) fn json_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -15,51 +15,114 @@ pub fn run_list(args: &[String]) -> ExitCode {
     {
         println!("aegis-boot list — inventory ISOs on the stick");
         println!();
-        println!("USAGE: aegis-boot list [/dev/sdX | /mnt/aegis-isos]");
-        println!("  No argument = auto-find the mounted AEGIS_ISOS partition");
+        println!("USAGE:");
+        println!("  aegis-boot list [/dev/sdX | /mnt/aegis-isos]");
+        println!("  aegis-boot list --json [target]   # machine-readable output");
+        println!();
+        println!("  No target argument = auto-find the mounted AEGIS_ISOS partition.");
         return ExitCode::SUCCESS;
     }
 
-    let mount = match resolve_mount(args.first().map(String::as_str)) {
+    // --json is a mode flag; accepted in any position. Everything else
+    // is positional (the target mount path or device).
+    let json_mode = args.iter().any(|a| a == "--json");
+    let target = args
+        .iter()
+        .find(|a| !a.starts_with("--"))
+        .map(String::as_str);
+
+    let mount = match resolve_mount(target) {
         Ok(m) => m,
         Err(e) => {
-            eprintln!("aegis-boot list: {e}");
+            if json_mode {
+                println!(
+                    "{{ \"schema_version\": 1, \"error\": \"{}\" }}",
+                    crate::doctor::json_escape(&e)
+                );
+            } else {
+                eprintln!("aegis-boot list: {e}");
+            }
             return ExitCode::from(1);
         }
     };
 
-    print_attestation_summary(&mount.path);
-
     let isos = scan_isos(&mount.path);
-    if isos.is_empty() {
-        println!("No .iso files on {}", mount.path.display());
-        if mount.temporary {
-            unmount_temp(&mount);
-        }
-        return ExitCode::SUCCESS;
-    }
 
-    println!("ISOs on {}:", mount.path.display());
-    println!();
-    for iso in &isos {
-        let sha_marker = if iso.has_sha256 { "\u{2713}" } else { " " };
-        let sig_marker = if iso.has_minisig { "\u{2713}" } else { " " };
-        println!(
-            "  [{sha_marker} sha256] [{sig_marker} minisig]  {:>8}  {}",
-            humanize(iso.size),
-            iso.name
-        );
+    if json_mode {
+        print_list_json(&mount.path, &isos);
+    } else {
+        print_attestation_summary(&mount.path);
+        if isos.is_empty() {
+            println!("No .iso files on {}", mount.path.display());
+        } else {
+            println!("ISOs on {}:", mount.path.display());
+            println!();
+            for iso in &isos {
+                let sha_marker = if iso.has_sha256 { "\u{2713}" } else { " " };
+                let sig_marker = if iso.has_minisig { "\u{2713}" } else { " " };
+                println!(
+                    "  [{sha_marker} sha256] [{sig_marker} minisig]  {:>8}  {}",
+                    humanize(iso.size),
+                    iso.name
+                );
+            }
+            println!();
+            println!("{} ISO(s) total. Legend:", isos.len());
+            println!("  \u{2713} sha256   sibling <iso>.sha256 present");
+            println!("  \u{2713} minisig  sibling <iso>.minisig present");
+            println!("  (missing sidecars mean the ISO will show GRAY verdict in rescue-tui)");
+        }
     }
-    println!();
-    println!("{} ISO(s) total. Legend:", isos.len());
-    println!("  \u{2713} sha256   sibling <iso>.sha256 present");
-    println!("  \u{2713} minisig  sibling <iso>.minisig present");
-    println!("  (missing sidecars mean the ISO will show GRAY verdict in rescue-tui)");
 
     if mount.temporary {
         unmount_temp(&mount);
     }
     ExitCode::SUCCESS
+}
+
+/// Emit the list inventory as a stable `schema_version=1` JSON document
+/// on stdout. Matches the shape of `aegis-boot doctor --json` so
+/// downstream tooling has one parser.
+fn print_list_json(mount_path: &Path, isos: &[IsoEntry]) {
+    use crate::doctor::json_escape;
+    println!("{{");
+    println!("  \"schema_version\": 1,");
+    println!("  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
+    println!(
+        "  \"mount_path\": \"{}\",",
+        json_escape(&mount_path.display().to_string())
+    );
+    // Attestation summary if any — stays null when the mount has no
+    // attestation (operator flashed elsewhere, or pre-v0.13.0 stick).
+    match crate::attest::summary_for_mount(mount_path) {
+        Some(s) => {
+            println!("  \"attestation\": {{");
+            println!("    \"flashed_at\": \"{}\",", json_escape(&s.flashed_at));
+            println!("    \"operator\": \"{}\",", json_escape(&s.operator));
+            println!("    \"isos_recorded\": {},", s.isos_recorded);
+            println!(
+                "    \"manifest_path\": \"{}\"",
+                json_escape(&s.manifest_path.display().to_string())
+            );
+            println!("  }},");
+        }
+        None => println!("  \"attestation\": null,"),
+    }
+    println!("  \"count\": {},", isos.len());
+    println!("  \"isos\": [");
+    let last = isos.len().saturating_sub(1);
+    for (i, iso) in isos.iter().enumerate() {
+        let comma = if i == last { "" } else { "," };
+        println!(
+            "    {{ \"name\": \"{}\", \"size_bytes\": {}, \"has_sha256\": {}, \"has_minisig\": {} }}{comma}",
+            json_escape(&iso.name),
+            iso.size,
+            iso.has_sha256,
+            iso.has_minisig,
+        );
+    }
+    println!("  ]");
+    println!("}}");
 }
 
 /// Entry point for `aegis-boot add <iso> [mount-or-device]`.


### PR DESCRIPTION
## Summary

Extends the #184 \`doctor --json\` pattern to \`list\` and \`attest\`. Gives downstream tooling (CI, monitoring, \`jq\` pipelines) a uniform structured-output surface across every aegis-boot subcommand that enumerates state.

## New surfaces

### \`aegis-boot list --json\`

\`\`\`json
{
  "schema_version": 1,
  "tool_version": "0.14.0-dev",
  "mount_path": "/media/aegis/AEGIS_ISOS",
  "attestation": null,
  "count": 2,
  "isos": [
    { "name": "alpine.iso", "size_bytes": 219152384, "has_sha256": false, "has_minisig": false },
    { "name": "ubuntu.iso", "size_bytes": 3213064192, "has_sha256": false, "has_minisig": false }
  ]
}
\`\`\`

On mount-resolution failure still emits structured JSON: \`{"schema_version": 1, "error": "..."}\`.

### \`aegis-boot attest list --json\` (shorthand: \`aegis-boot attest --json\`)

\`\`\`json
{
  "schema_version": 1,
  "tool_version": "0.14.0-dev",
  "attestations_dir": "~/.local/share/aegis-boot/attestations",
  "count": 1,
  "attestations": [
    {
      "manifest_path": "...",
      "schema_version": 1,
      "tool_version": "0.13.0",
      "flashed_at": "2026-04-16T19:18:11Z",
      "operator": "william",
      "target_device": "/dev/sdc",
      "target_model": "Cruzer",
      "disk_guid": "abcdef01-...",
      "iso_count": 2
    }
  ]
}
\`\`\`

Per-entry parse failures render as \`{"manifest_path": "...", "error": "..."}\` so a broken manifest doesn't tank the whole list.

## Why this over \"fresh-chain diff\"

Split consensus this round:
- Architect favored B (fresh-chain diff) for positioning weight
- Security engineer favored A (\`--json\` extension) because B needs secure tempdir + symlink-safe ops before it can write fresh ESP images to \`/tmp\`

Picked A per security's assessment — B is landing in a separate PR with proper precautions.

## Shared infrastructure

- \`doctor::json_escape()\` promoted from private to \`pub(crate)\` — single source of truth for \`"\`, \`\\\`, \`\\n\`, \`\\r\`, \`\\t\`, \`\\u00XX\` escape rules across all three \`--json\` formatters.
- Hand-rolled JSON (no \`serde_json\` dep added to the static-musl binary).
- \`--json\` flag detection tolerates flag anywhere in args.

## Test plan

- [x] \`cargo test --workspace\` — 260 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt\` — clean
- [x] \`aegis-boot list --json | python3 -m json.tool\` — valid JSON, correct content on a live stick with 2 ISOs
- [x] \`aegis-boot attest list --json | python3 -m json.tool\` — valid JSON, empty-dir case handled
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)