### PR TITLE
feat(rescue-tui): inline error band for skipped ISOs (closes #85 Tier 2)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -69,6 +69,50 @@ fn tracing_subscriber_init() {
     }
 }
 
+/// Count the number of `.iso` files present under any of `roots`.
+/// Depth-limited walk (max 3 levels) since `AEGIS_ISOS` is a flat
+/// layout in practice; goes 3 deep to catch operators who nested one
+/// or two levels. Matches the depth bound in `iso_probe::find_iso_size`.
+///
+/// Used for the #85 Tier 2 inline error band: `discover()` silently
+/// drops per-ISO parse failures; we need an independent count to
+/// spot "N ISOs on disk, M discovered, N-M skipped" and surface that
+/// to the operator without requiring them to read journalctl.
+fn count_iso_files_on_disk(roots: &[PathBuf]) -> usize {
+    const MAX_DEPTH: u32 = 3;
+    fn walk(dir: &std::path::Path, depth: u32) -> usize {
+        if depth == 0 {
+            return 0;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        let mut n = 0usize;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_file()
+                && path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("iso"))
+            {
+                n += 1;
+            } else if ft.is_dir() {
+                n += walk(&path, depth - 1);
+            }
+        }
+        n
+    }
+    let mut total = 0usize;
+    for root in roots {
+        if root.exists() {
+            total += walk(root, MAX_DEPTH);
+        }
+    }
+    total
+}
+
 fn parse_roots(env_var: Option<&str>) -> Vec<PathBuf> {
     match env_var {
         Some(s) if !s.is_empty() => s.split(':').map(PathBuf::from).collect(),
@@ -82,6 +126,13 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
         roots = ?roots,
         "rescue-tui starting"
     );
+    // Count .iso files on disk BEFORE calling discover(). iso-probe
+    // silently drops ISOs it can't parse (malformed layout, unsupported
+    // distro, loopback mount failure after PR #170 surfaces a warn).
+    // Tracing logs the details; the TUI inline band shows the count so
+    // operators can act without reading journalctl. (#85 Tier 2)
+    let on_disk_iso_count = count_iso_files_on_disk(roots);
+
     let isos = match iso_probe::discover(roots) {
         Ok(v) => v,
         Err(iso_probe::ProbeError::NoIsosFound) => {
@@ -93,14 +144,25 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
+    let skipped = on_disk_iso_count.saturating_sub(isos.len());
     // Startup banner to stderr — mirrored via tracing::info! so structured
     // consumers (journald, CI smoke greps) see the same signal as humans
     // reading the serial console directly.
     eprintln!(
-        "aegis-boot rescue-tui starting: discovered {} ISO(s)",
-        isos.len()
+        "aegis-boot rescue-tui starting: discovered {} ISO(s){}",
+        isos.len(),
+        if skipped > 0 {
+            format!(" ({skipped} skipped — see logs)")
+        } else {
+            String::new()
+        }
     );
-    tracing::info!(discovered = isos.len(), "ISO discovery complete");
+    tracing::info!(
+        discovered = isos.len(),
+        on_disk = on_disk_iso_count,
+        skipped,
+        "ISO discovery complete"
+    );
     for iso in &isos {
         tracing::debug!(
             label = %iso.label,
@@ -110,7 +172,9 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
             "discovered ISO"
         );
     }
-    let mut state = AppState::new(isos).with_scanned_roots(roots.to_vec());
+    let mut state = AppState::new(isos)
+        .with_scanned_roots(roots.to_vec())
+        .with_skipped_iso_count(skipped);
     if let Ok(name) = env::var("AEGIS_THEME") {
         state.theme = theme::Theme::from_name(&name);
         tracing::info!(theme = %name, "rescue-tui: theme override applied");

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -577,6 +577,47 @@ fn draw_empty_list(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     frame.render_widget(panel, area);
 }
 
+/// Compute layout + render the optional inline error band (#85 Tier 2
+/// last child) on the List screen. Returns `(info_area, list_area)`
+/// for the caller to render into. Extracted from `draw_list` so the
+/// main draw function stays under the workspace-wide 100-line cap.
+fn split_list_chrome(frame: &mut Frame<'_>, area: Rect, state: &AppState) -> (Rect, Rect) {
+    // Tier 2 (#85) — info bar above list shows filter + sort state.
+    // When some ISOs on disk failed to parse, insert a one-line inline
+    // error band ABOVE the info bar so it's unmissable without modal
+    // interruption — memtest86+-style "one-frame warning".
+    if state.skipped_iso_count > 0 {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // error band
+                Constraint::Length(1), // info bar
+                Constraint::Min(1),    // list
+            ])
+            .split(area);
+        let band = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " \u{26A0} SKIPPED ",
+                Style::default()
+                    .fg(state.theme.warning)
+                    .add_modifier(Modifier::REVERSED | Modifier::BOLD),
+            ),
+            Span::raw(format!(
+                "  {} ISO(s) on disk failed to parse — see journalctl -u rescue-tui (iso_parser warnings)",
+                state.skipped_iso_count
+            )),
+        ]));
+        frame.render_widget(band, chunks[0]);
+        (chunks[1], chunks[2])
+    } else {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .split(area);
+        (chunks[0], chunks[1])
+    }
+}
+
 fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
     use crate::state::ViewEntry;
     if state.isos.is_empty() {
@@ -584,12 +625,7 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
         return;
     }
 
-    // Tier 2 (#85) — info bar above list shows filter + sort state.
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(1)])
-        .split(area);
-    let (info_area, list_area) = (chunks[0], chunks[1]);
+    let (info_area, list_area) = split_list_chrome(frame, area, state);
 
     // Design-review #102: filter-mode visual was too subtle (trailing
     // `_` the only indicator). Now: when editing, render a reversed-
@@ -1224,6 +1260,31 @@ mod tests {
         assert!(s.contains("alpha"));
         assert!(s.contains("beta"));
         assert!(s.contains("Debian/Ubuntu"));
+    }
+
+    #[test]
+    fn list_inline_band_appears_when_some_isos_skipped() {
+        // (#85 Tier 2 last child) — operator sees "N ISO(s) on disk
+        // failed to parse" without needing to read journalctl.
+        let state = AppState::new(vec![fake_iso("ok")]).with_skipped_iso_count(2);
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("SKIPPED") && s.contains("2 ISO(s) on disk failed to parse"),
+            "expected inline error band in: {s}",
+        );
+        // The good ISO should still render alongside the band.
+        assert!(s.contains("ok"));
+    }
+
+    #[test]
+    fn list_no_inline_band_when_nothing_skipped() {
+        // Default count is 0; band should not appear.
+        let state = AppState::new(vec![fake_iso("ok")]);
+        let s = render_to_string(&state);
+        assert!(
+            !s.contains("SKIPPED"),
+            "unexpected error band in clean-state render: {s}",
+        );
     }
 
     #[test]

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -121,6 +121,14 @@ pub struct AppState {
     /// detail). Populated by `main.rs` after reading `AEGIS_ISO_ROOTS`;
     /// default empty in tests. (#85 Tier 2)
     pub scanned_roots: Vec<std::path::PathBuf>,
+    /// Count of `.iso` files found on disk under `scanned_roots` that
+    /// DID NOT parse into a `DiscoveredIso` (silently dropped by
+    /// `iso-probe::discover()` due to malformed layout, unsupported
+    /// distro, etc). Populated by `main.rs` via a direct fs walk that
+    /// runs alongside `discover()`. Surfaced as a yellow inline band
+    /// above the List when >0 so the operator knows the list is
+    /// incomplete. (#85 Tier 2 last child)
+    pub skipped_iso_count: usize,
 }
 
 /// Sort order applied to the List view. Cycled with the `s` key.
@@ -306,6 +314,7 @@ impl AppState {
             filter_editing: false,
             sort_order: SortOrder::Name,
             scanned_roots: Vec::new(),
+            skipped_iso_count: 0,
         }
     }
 
@@ -317,6 +326,16 @@ impl AppState {
     #[must_use]
     pub fn with_scanned_roots(mut self, roots: Vec<std::path::PathBuf>) -> Self {
         self.scanned_roots = roots;
+        self
+    }
+
+    /// Record how many `.iso` files on disk were silently skipped by
+    /// `discover()` (malformed ISO, unsupported layout, parse failure).
+    /// Populated by `main.rs` — tests default to 0 via `AppState::new()`.
+    /// (#85 Tier 2 last child — inline error band)
+    #[must_use]
+    pub fn with_skipped_iso_count(mut self, n: usize) -> Self {
+        self.skipped_iso_count = n;
         self
     }
 


### PR DESCRIPTION
## Summary

Closes the last Tier 2 child of [#85](https://github.com/williamzujkowski/aegis-boot/issues/85). When \`iso-probe::discover()\` silently drops an ISO it can't parse (malformed layout, unsupported distro, losetup failure), the List screen now surfaces an inline yellow band one line above the info bar:

\`\`\`
[⚠ SKIPPED]  2 ISO(s) on disk failed to parse — see journalctl -u rescue-tui (iso_parser warnings)
\`\`\`

Operators see the list is incomplete without needing to read \`journalctl\`. Matches memtest86+'s \"one frame = one warning\" design — unmissable but non-modal (the modal Error screen stays reserved for kexec failures).

## Mechanics

- **main.rs** counts \`.iso\` files on disk (depth=3 walk) BEFORE \`discover()\`, computes \`skipped = on_disk.saturating_sub(discovered.len())\`
- **AppState** grows \`skipped_iso_count: usize\` + \`with_skipped_iso_count()\` builder (defaults 0 — all existing tests unchanged)
- **render.rs**'s \`draw_list\` gets a new \`split_list_chrome()\` helper that inserts a \`Length(1)\` error band at the top of the layout only when \`skipped > 0\`. Keeps \`draw_list\` under the workspace-wide 100-line cap (mandatory refactor — clippy's \`too-many-lines\` denies at 100).

## Epic #85 closure state

- Tier 1: all 7 children — shipped v0.8.0
- Tier 2 children:
  - [x] Filter (\`/\`) — shipped v0.8.0
  - [x] Sort cycle (\`s\`) — shipped v0.8.0
  - [x] Empty-state explanation — shipped #172
  - [x] **Inline error band — this PR**
- Tier 3:
  - [x] Verify now (\`v\`) — shipped v0.10.0
  - [x] Rescue shell entry — shipped v0.10.0
  - [ ] Distro submenus — author-deferred per #91

## Test plan

- [x] \`cargo test --workspace\` — 262 pass (+2 new)
  - \`list_inline_band_appears_when_some_isos_skipped\` — yellow band + correct count
  - \`list_no_inline_band_when_nothing_skipped\` — zero-count doesn't add chrome
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean under the new \`unwrap_used = deny\` from #180
- [x] \`cargo fmt\` — clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)