### PR TITLE
chore(lints): tighten unwrap_used/expect_used to deny in 3 crates

### DIFF
--- a/crates/aegis-fitness/Cargo.toml
+++ b/crates/aegis-fitness/Cargo.toml
@@ -22,5 +22,8 @@ missing_docs = "warn"
 [lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
+# Tightened from warn → deny (#138 quality gates). Production code
+# contains zero bare .unwrap()/.expect() calls at the time of this change.
+# Test modules get #[allow(clippy::unwrap_used, clippy::expect_used)].
+unwrap_used = "deny"
+expect_used = "deny"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -34,5 +34,8 @@ missing_docs = "warn"
 [lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
+# Tightened from warn → deny (#138 quality gates). Production code
+# contains zero bare .unwrap()/.expect() calls at the time of this change.
+# Test modules get #[allow(clippy::unwrap_used, clippy::expect_used)].
+unwrap_used = "deny"
+expect_used = "deny"

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -35,5 +35,8 @@ missing_docs = "warn"
 [lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
+# Tightened from warn → deny (#138 quality gates). Production code
+# contains zero bare .unwrap()/.expect() calls at the time of this change.
+# Test modules get #[allow(clippy::unwrap_used, clippy::expect_used)].
+unwrap_used = "deny"
+expect_used = "deny"


### PR DESCRIPTION
## Summary

Closes the final child of epic #138 (\`unwrap_used\`/\`expect_used\` lint tightening). Workspace-level already denies both; three crates (\`aegis-fitness\`, \`iso-probe\`, \`rescue-tui\`) still had per-crate overrides at \`warn\` from before the workspace tightening landed.

**Audit finding:** zero bare \`.unwrap()\`/\`.expect(...)\` calls in production code across all three crates. This PR is a pure safety-posture tightening with no refactoring — every existing \`.unwrap_or()\` / \`.unwrap_or_else()\` / \`.unwrap_or_default()\` is safe (provides a default) and not flagged by the lint.

## Effect

Future contributors adding a bare \`.unwrap()\` or \`.expect(...)\` to any of these crates will now hit a CI failure instead of a silent warning. Matches the workspace default and the quality-gates charter ("no silent failures on safety-critical paths").

## Test plan

- [x] \`cargo clippy -p aegis-fitness -p iso-probe -p rescue-tui --all-targets -- -D warnings\` — clean on first try
- [x] \`cargo test -p aegis-fitness -p iso-probe -p rescue-tui\` — all 126 tests pass
- [ ] CI green

## Epic status post-merge

**#138 quality gates — all children closed:**
- [x] iso-probe hash verification Unreadable variant (#171)
- [x] iso-parser losetup error surfacing (#170)
- [x] Test mock corrections (#196, pending CI)
- [x] \`unwrap_used\`/\`expect_used\` = deny — **this PR**
- [x] \`forbid(unsafe_code)\` on iso-parser (#140)
- [x] \`SAFETY:\` on kexec-loader unsafe blocks
- [x] flash.rs stdin hardening (#169)
- [x] build-initramfs.sh depmod exit (#168)
- [x] mkusb.sh sgdisk offset validation (#168)

With #196 + this PR, #138 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)