### PR TITLE
docs: document all 5 theme names + a11y recipes (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Full developer loop: [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md).
 | Variable | Default | Purpose |
 |---|---|---|
 | `AEGIS_ISO_ROOTS` | `/run/media:/mnt` | Colon-separated dirs to scan for `.iso` files |
-| `AEGIS_THEME` | (built-in) | Override theme name (e.g. `high-contrast`) |
+| `AEGIS_THEME` | default | Theme: `default`, `monochrome` (serial/screen-reader), `high-contrast` (low-contrast framebuffers), `okabe-ito` (colorblind-safe, aliases: `cb`, `colorblind`), or `aegis` (brand). Also readable as `aegis.theme=<name>` on kernel cmdline. |
 | `AEGIS_AUTO_KEXEC` | unset | Substring; first matching ISO is kexec'd without operator confirmation |
 | `AEGIS_A11Y` | unset | `1` enables text-only mode (also auto-enabled when `TERM=dumb`) |
 | `AEGIS_LOG_JSON` | unset | `1` switches `tracing` output to JSON for `journalctl --output=json` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -130,6 +130,34 @@ Probably not. The handoff banner ([#127](https://github.com/williamzujkowski/aeg
 
 ---
 
+## Accessibility
+
+### Colors are unreadable (low contrast / framebuffer / HDMI capture)
+
+Set `AEGIS_THEME=high-contrast` (kernel cmdline: `aegis.theme=high-contrast`). Uses the bright ANSI variants only.
+
+### Red/green verdicts are indistinguishable (color vision)
+
+Set `AEGIS_THEME=okabe-ito` (aliases `cb` / `colorblind`). Swaps the verdict trio to the Okabe-Ito colorblind-safe palette: bluish-green for success, orange for warning, vermillion for error. Distinguishable under deuteranopia and protanopia.
+
+### Serial console or screen reader strips color
+
+Set `AEGIS_THEME=monochrome` (aliases `mono` / `none`) so verdicts render as the default terminal foreground. Combine with `AEGIS_A11Y=text` (or `TERM=dumb`, which auto-enables it) to skip the ratatui alt-screen and get a numbered-menu text renderer.
+
+Every state transition also emits an `ANN: {human text}` line on stderr — a parallel stream readers can consume without parsing ratatui's draw buffer.
+
+### Available themes
+
+| Name            | Aliases                                     | Use case                                 |
+| --------------- | ------------------------------------------- | ---------------------------------------- |
+| `default`       | (unknown names fall back here)              | Standard VT100 16-color console          |
+| `monochrome`    | `mono`, `none`                              | Serial / screen-reader / unreliable ANSI |
+| `high-contrast` | `hc`, `high_contrast`                       | Low-contrast framebuffers, HDMI capture  |
+| `okabe-ito`     | `cb`, `colorblind`, `okabe_ito`, `okabeito` | Colorblind-safe verdict trio             |
+| `aegis`         | `brand`                                     | Project brand palette                    |
+
+---
+
 ## When in doubt
 
 Drop to the rescue shell from the List screen (navigate to the `[#] rescue shell` entry, press Enter). You're in a busybox shell with the full initramfs around you. Useful commands:


### PR DESCRIPTION
## Summary

The codebase has shipped **five** themes since v0.11.0 + #76 (\`default\`, \`monochrome\`, \`high-contrast\`, \`okabe-ito\`, \`aegis\`), but operator docs only mentioned \"high-contrast\" as an example. Colorblind operators had no pointer at all.

This PR closes the discoverability half; the theme code + tests are already in \`crates/rescue-tui/src/theme.rs\`.

## Changes

- **README.md** — \`AEGIS_THEME\` row now lists all five names plus the kernel-cmdline alias form (\`aegis.theme=<name>\`).
- **docs/TROUBLESHOOTING.md** — new \"Accessibility\" section pairs each symptom (low-contrast framebuffer, color vision, serial/screen-reader) with the appropriate theme + \`AEGIS_A11Y\` flag. Followed by a complete theme-alias table.

## Why this matters for #93

Okabe-Ito was listed as an \"open P2\" in #93, but the code has been shipped since #76. The real gap was operator-facing docs. With this PR, a colorblind operator who hits the README can set \`AEGIS_THEME=colorblind\` without knowing that the canonical name is \`okabe-ito\`.

## Test plan

- [x] Docs-only, no code.
- [x] Verified theme names against \`crates/rescue-tui/src/theme.rs:86-94\` (\`Theme::from_name\`).
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)