### PR TITLE
docs(audit-log): record 2026-04-17 audit run against v0.13.x

### DIFF
--- a/docs/content-audit.md
+++ b/docs/content-audit.md
@@ -4,7 +4,8 @@ Per [#78](https://github.com/williamzujkowski/aegis-boot/issues/78), this file r
 
 | Date       | Reviewing | Files audited | Findings filed | PRs |
 |------------|-----------|---------------|----------------|-----|
-| 2026-04-16 | v0.12.0   | README, CONTRIBUTING, ROADMAP, CHANGELOG, SECURITY, THREAT_MODEL, BUILDING, all docs/* (incl. UNSIGNED_KERNEL, USB_LAYOUT, LOCAL_TESTING, content-audit), .github/CODEOWNERS, all crate Cargo.toml + crate-level rustdoc, scripts/mkusb.sh env vars | inline fixes in this PR; new docs (INSTALL, TROUBLESHOOTING, ARCHITECTURE, CLI); .github/ISSUE_TEMPLATE + pull_request_template added | (this PR) |
+| 2026-04-17 | v0.13.x   | docs/CLI.md, docs/HARDWARE_COMPAT.md, README.md, docs/TROUBLESHOOTING.md | STALE: CLI.md missing `compat`/`update`/`verify` subcommand sections + `--json` mode across 7 subcommands. STALE: `AEGIS_THEME` row named only `high-contrast`, no pointer to colorblind-safe `okabe-ito` despite code shipped since #76. #93 epic P1 (SysRq cheatsheet) listed as open but both halves shipped (initramfs + help overlay). | #199 (CLI.md), #200 (theme names + a11y), #93 comment (SysRq reclassified shipped) |
+| 2026-04-16 | v0.12.0   | README, CONTRIBUTING, ROADMAP, CHANGELOG, SECURITY, THREAT_MODEL, BUILDING, all docs/* (incl. UNSIGNED_KERNEL, USB_LAYOUT, LOCAL_TESTING, content-audit), .github/CODEOWNERS, all crate Cargo.toml + crate-level rustdoc, scripts/mkusb.sh env vars | inline fixes in that PR; new docs (INSTALL, TROUBLESHOOTING, ARCHITECTURE, CLI); .github/ISSUE_TEMPLATE + pull_request_template added | #135 |
 | 2026-04-15 | v0.7.0    | README, BUILDING, SECURITY, THREAT_MODEL, CHANGELOG, USB_LAYOUT, LOCAL_TESTING, all ADRs, all compatibility/, all crate Cargo.toml + top-level rustdoc | #76, #77, #78 (epics); inline fixes in this PR | #79 |
 | 2026-04-15 | v0.6.0    | CHANGELOG (partial) | #52 | #58 |
 


### PR DESCRIPTION
## Summary

Per the cadence documented in \`docs/content-audit.md\` (part of the #78 process), log today's audit work so the next re-audit has a starting point.

### Row recorded

- **Date:** 2026-04-17
- **Reviewing:** v0.13.x
- **Files audited:** docs/CLI.md, docs/HARDWARE_COMPAT.md, README.md, docs/TROUBLESHOOTING.md
- **Findings:**
  - STALE: CLI.md missing three shipped subcommand sections + \`--json\` on seven
  - STALE: \`AEGIS_THEME\` row mentioned only \"high-contrast\" despite 5 shipped themes including colorblind-safe \`okabe-ito\`
  - STALE: #93 epic's P1 SysRq child listed open; both halves shipped
- **PRs:** #199 (CLI.md), #200 (theme names + a11y), #93 comment (SysRq reclassified)

Also corrected the 2026-04-16 row which had a placeholder \`(this PR)\` value — the actual PR was #135.

## Test plan

Doc-only; single-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)