### PR TITLE
feat(cli): --version --json emits schema_version=1 envelope

### DIFF
--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -62,7 +62,18 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("--version" | "version") => {
-            println!("aegis-boot v{}", env!("CARGO_PKG_VERSION"));
+            // `--json` can appear anywhere after the `--version` /
+            // `version` subcommand. Consistent with the rest of the
+            // --json sweep, the envelope carries schema_version + the
+            // full semver so tools can match against a registry.
+            if args.iter().skip(1).any(|a| a == "--json") {
+                println!(
+                    "{{ \"schema_version\": 1, \"tool\": \"aegis-boot\", \"version\": \"{}\" }}",
+                    env!("CARGO_PKG_VERSION")
+                );
+            } else {
+                println!("aegis-boot v{}", env!("CARGO_PKG_VERSION"));
+            }
             ExitCode::SUCCESS
         }
         Some(other) => {
@@ -89,7 +100,7 @@ fn print_help() {
     println!("  aegis-boot update <device>    Check eligibility for in-place update");
     println!("  aegis-boot verify [device]    Re-verify every ISO's sha256 against its sidecar");
     println!("  aegis-boot compat [query]     Hardware compatibility lookup");
-    println!("  aegis-boot --version          Print version");
+    println!("  aegis-boot --version [--json] Print version (--json emits schema_version=1)");
     println!("  aegis-boot --help             This message");
     println!();
     println!("EXAMPLES:");

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,7 +18,7 @@ USAGE:
   aegis-boot update <device>    Check eligibility for in-place signed-chain update
   aegis-boot verify [device]    Re-verify every ISO's sha256 against its sidecar
   aegis-boot compat [query]     Hardware compatibility lookup (verified reports only)
-  aegis-boot --version          Print version
+  aegis-boot --version [--json] Print version (--json emits schema_version=1)
   aegis-boot --help             This message
 ```
 
@@ -38,6 +38,7 @@ The read-mostly subcommands emit a stable machine-readable document when given `
 | `recommend --json`  | Full catalog (or single entry with `recommend --json <slug>`)                |
 | `update --json`     | Eligibility envelope + host-chain (sha256 per slot) or reason-for-ineligible |
 | `compat --json`     | Compat DB entries (or single entry with `compat --json <query>`)             |
+| `--version --json`  | `{ schema_version, tool, version }` — scriptable semver lookup               |
 
 Every `--json` output carries `schema_version: 1` at the root so downstream tooling can detect future breaking changes.
 
@@ -638,6 +639,8 @@ aegis-boot compat --help
 ## Versioning
 
 `aegis-boot --version` reports the workspace version (currently `0.13.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+
+`aegis-boot --version --json` emits the same info as a stable envelope — `{ "schema_version": 1, "tool": "aegis-boot", "version": "0.13.0" }` — for scripted install verification or Homebrew-style version matching.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Completes the \`--json\` sweep across every CLI output path. Scripted consumers (install one-liner, Homebrew formula assertions, homelab-ansible verification) can now parse the tool version without regex'ing the human-readable string.

\`\`\`
\$ aegis-boot --version
aegis-boot v0.13.0

\$ aegis-boot --version --json
{ \"schema_version\": 1, \"tool\": \"aegis-boot\", \"version\": \"0.13.0\" }
\`\`\`

## Scope

- \`crates/aegis-cli/src/main.rs\` — match arm for \`--version\`/\`version\` now inspects remaining args for \`--json\`; emits the envelope or the human string accordingly.
- Help text updated: \`aegis-boot --version [--json] Print version (--json emits schema_version=1)\`.
- \`docs/CLI.md\` — added row to the \`--json\` mode table + appended to the Versioning section with an example.

No new dependencies. Reuses the existing \`env!(CARGO_PKG_VERSION)\` path.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-cli\` — 117 tests pass
- [x] Manual smoke: \`--version\`, \`--version --json\`, \`--version --json | python3 -m json.tool\` all produce expected output
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)