### PR TITLE
fix(completions): refresh static bash + zsh for today's new subcommands

### DIFF
--- a/completions/_aegis-boot
+++ b/completions/_aegis-boot
@@ -24,6 +24,10 @@ _aegis-boot() {
         'fetch:Download + verify a catalog ISO'
         'attest:Attestation receipts for past flashes'
         'eject:Safely power-off a stick before removal'
+        'update:Check eligibility for in-place signed-chain update'
+        'verify:Re-verify every ISO on the stick against its sidecar'
+        'compat:Hardware compatibility lookup (verified reports only)'
+        'completions:Emit bash/zsh completion script'
     )
 
     _arguments -C \
@@ -66,13 +70,21 @@ _aegis-boot() {
                     ;;
                 list|eject)
                     _arguments \
+                        '--json[machine-readable output (schema_version=1)]' \
                         '--help[show help]' \
                         '*:device:_files -g "/dev/sd*"'
                     ;;
                 doctor)
                     _arguments \
                         '--stick[stick device]:device:_files -g "/dev/sd*"' \
+                        '--json[machine-readable output (schema_version=1)]' \
                         '--help[show help]'
+                    ;;
+                update|verify)
+                    _arguments \
+                        '--json[machine-readable output (schema_version=1)]' \
+                        '--help[show help]' \
+                        '*:device:_files -g "/dev/sd*"'
                     ;;
                 recommend|fetch)
                     local -a slugs
@@ -81,17 +93,36 @@ _aegis-boot() {
                         _arguments \
                             '--out[destination directory]:dir:_directories' \
                             '--no-gpg[skip GPG verification]' \
+                            '--dry-run[print plan without downloading]' \
                             '--help[show help]' \
                             "*:ISO slug:($slugs)"
                     else
                         _arguments \
                             '--slugs-only[machine-readable slug list]' \
+                            '--json[machine-readable output (schema_version=1)]' \
                             '--help[show help]' \
                             "*:ISO slug:($slugs)"
                     fi
                     ;;
                 attest)
+                    _arguments \
+                        '--json[machine-readable output (schema_version=1)]'
                     _values 'attest action' list show --help
+                    ;;
+                compat)
+                    local -a vendors
+                    if (( $+commands[jq] )); then
+                        vendors=(${(f)"$(aegis-boot compat --json 2>/dev/null \
+                            | jq -r '.entries[]?.vendor' 2>/dev/null | sort -u)"})
+                    fi
+                    _arguments \
+                        '--my-machine[auto-lookup from DMI]' \
+                        '--json[machine-readable output (schema_version=1)]' \
+                        '--help[show help]' \
+                        "*:vendor:($vendors)"
+                    ;;
+                completions)
+                    _values 'shell' bash zsh --help
                     ;;
             esac
             ;;

--- a/completions/aegis-boot.bash
+++ b/completions/aegis-boot.bash
@@ -17,7 +17,7 @@ _aegis_boot() {
     local cur prev words cword
     _init_completion || return
 
-    local subcommands="init flash list add doctor recommend fetch attest eject --help --version"
+    local subcommands="init flash list add doctor recommend fetch attest eject update verify compat completions --help --version"
     local attest_actions="list show"
 
     # Top-level subcommand or global flag.
@@ -29,7 +29,7 @@ _aegis_boot() {
     # First arg after a subcommand.
     local sub="${words[1]}"
     case "$sub" in
-        init|flash|add|list|doctor|eject)
+        init|flash|add|list|doctor|eject|update|verify)
             # Device arg — complete block device paths + typical flags.
             case "$prev" in
                 --profile)
@@ -45,12 +45,14 @@ _aegis_boot() {
             esac
             if [[ "$cur" == --* ]]; then
                 case "$sub" in
-                    init)  COMPREPLY=($(compgen -W "--profile --yes --no-doctor --no-gpg --help" -- "$cur")) ;;
-                    flash) COMPREPLY=($(compgen -W "--yes --help" -- "$cur")) ;;
-                    doctor) COMPREPLY=($(compgen -W "--stick --help" -- "$cur")) ;;
-                    add)   COMPREPLY=($(compgen -W "--help" -- "$cur")) ;;
-                    list)  COMPREPLY=($(compgen -W "--help" -- "$cur")) ;;
-                    eject) COMPREPLY=($(compgen -W "--help" -- "$cur")) ;;
+                    init)   COMPREPLY=($(compgen -W "--profile --yes --no-doctor --no-gpg --help" -- "$cur")) ;;
+                    flash)  COMPREPLY=($(compgen -W "--yes --help" -- "$cur")) ;;
+                    doctor) COMPREPLY=($(compgen -W "--stick --json --help" -- "$cur")) ;;
+                    add)    COMPREPLY=($(compgen -W "--help" -- "$cur")) ;;
+                    list)   COMPREPLY=($(compgen -W "--json --help" -- "$cur")) ;;
+                    eject)  COMPREPLY=($(compgen -W "--help" -- "$cur")) ;;
+                    update) COMPREPLY=($(compgen -W "--json --help" -- "$cur")) ;;
+                    verify) COMPREPLY=($(compgen -W "--json --help" -- "$cur")) ;;
                 esac
                 return 0
             fi
@@ -66,8 +68,8 @@ _aegis_boot() {
         recommend|fetch)
             if [[ "$cur" == --* ]]; then
                 case "$sub" in
-                    recommend) COMPREPLY=($(compgen -W "--slugs-only --help" -- "$cur")) ;;
-                    fetch)     COMPREPLY=($(compgen -W "--out --no-gpg --help" -- "$cur")) ;;
+                    recommend) COMPREPLY=($(compgen -W "--slugs-only --json --help" -- "$cur")) ;;
+                    fetch)     COMPREPLY=($(compgen -W "--out --no-gpg --dry-run --help" -- "$cur")) ;;
                 esac
                 return 0
             fi
@@ -82,10 +84,30 @@ _aegis_boot() {
             ;;
         attest)
             if [[ $cword -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "$attest_actions --help" -- "$cur"))
+                COMPREPLY=($(compgen -W "$attest_actions --json --help" -- "$cur"))
                 return 0
             fi
             _filedir json
+            return 0
+            ;;
+        compat)
+            if [[ "$cur" == --* ]]; then
+                COMPREPLY=($(compgen -W "--my-machine --json --help" -- "$cur"))
+                return 0
+            fi
+            # Vendor tokens when `jq` is installed; silently skipped otherwise.
+            if command -v jq >/dev/null 2>&1; then
+                local vendors
+                vendors="$(aegis-boot compat --json 2>/dev/null \
+                    | jq -r '.entries[]?.vendor' 2>/dev/null | sort -u)"
+                if [[ -n "$vendors" ]]; then
+                    COMPREPLY=($(compgen -W "$vendors" -- "$cur"))
+                fi
+            fi
+            return 0
+            ;;
+        completions)
+            COMPREPLY=($(compgen -W "bash zsh --help" -- "$cur"))
             return 0
             ;;
     esac


### PR DESCRIPTION
## Summary

Follow-up to #207. The static completion files at \`completions/aegis-boot.bash\` and \`completions/_aegis-boot\` — what \`scripts/install.sh\` ships via \`curl -sSL … | sh\` — were missing four subcommands shipped today (\`update\`, \`verify\`, \`compat\`, \`completions\`) plus every \`--json\` / \`--my-machine\` / \`--dry-run\` flag added in #191/#205/#206/#207.

An operator who installed via \`install.sh\` before this PR would get tab-completion for only 9 of 13 subcommands and none of the \`--json\` surfaces.

## Why two completion sources?

#207 added an \`aegis-boot completions bash|zsh\` **runtime generator**. This PR refreshes the **pre-installed static files**. Genuine split:

- **Generator** — for operators who lack the repo (future Cargo-from-crates.io install, or who forgot where they cloned).
- **Static files** — shipped by \`install.sh\` *before* the binary is on disk, so tab-complete works the moment \`which aegis-boot\` resolves.

They produce different output (generator simpler; static files have \`_init_completion\` / \`_arguments\` + descriptions). Unification is a future concern; not blocking.

## Additions

**Bash (\`completions/aegis-boot.bash\`):**
- Subcommand list: \`+update\`, \`+verify\`, \`+compat\`, \`+completions\`
- \`doctor\` / \`list\` / \`update\` / \`verify\` / \`recommend\` / \`attest\`: \`+--json\`
- \`fetch\`: \`+--dry-run\`
- \`compat\` branch: \`--my-machine\` + vendor-token completion via \`jq\` with graceful fallback
- \`completions\` branch: \`bash\` / \`zsh\`

**Zsh (\`completions/_aegis-boot\`):**
- Subcommand descriptions extended with four new subcommands
- Per-subcommand \`_arguments\` blocks for \`update\`, \`verify\`, \`compat\`, \`completions\` mirroring bash logic
- \`--json\` threaded through \`doctor\`/\`list\`/\`update\`/\`verify\`/\`recommend\`/\`attest\`

## Test plan

- [x] \`bash -n completions/aegis-boot.bash\` — syntax clean
- [x] \`source completions/aegis-boot.bash\` — \`_aegis_boot\` defined as function, \`complete -p aegis-boot\` returns expected binding
- [x] Zsh file follows existing \`_arguments\` style (no local zsh for functional test; CI covers it)
- [x] Pure completion-script drift; zero code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)