### PR TITLE
fix(iso-parser): surface mount failure when mount_point empty

### DIFF
--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -490,13 +490,40 @@ impl IsoEnvironment for OsIsoEnvironment {
             }
         }
 
+        // Terminal dispatch. Attempt 1 may have reported status=success
+        // but left the mount_point empty (busybox loop-mode silently
+        // no-ops, or the filesystem type list didn't match the ISO's
+        // actual layout). In that case we previously returned
+        // Ok(empty mount_point) — callers then saw NoBootEntries
+        // instead of the real "mount didn't take" diagnostic. Re-verify
+        // the mount point has entries before accepting status.success.
+        let mount_point_populated = || {
+            std::fs::read_dir(&mount_point)
+                .ok()
+                .and_then(|mut entries| entries.next())
+                .is_some()
+        };
         match output {
-            Ok(out) if out.status.success() => {
+            Ok(out) if out.status.success() && mount_point_populated() => {
                 debug!("Mounted {} to {:?}", iso_path.display(), mount_point);
                 Ok(mount_point)
             }
             Ok(out) => {
                 let stderr = String::from_utf8_lossy(&out.stderr);
+                // Explicit hint when mount claimed success but wrote
+                // nothing: typically a filesystem-type mismatch
+                // (Windows/macOS ISOs against older mount defaults).
+                let reason = if out.status.success() {
+                    format!(
+                        "mount claimed success but {} is empty — \
+                         filesystem type likely not auto-detected \
+                         (stderr: {})",
+                        mount_point.display(),
+                        stderr.trim()
+                    )
+                } else {
+                    stderr.to_string()
+                };
                 // Try fallback with fuseiso
                 let fuse_output = Command::new("fuseiso")
                     .arg(iso_path.to_string_lossy().as_ref())
@@ -504,14 +531,14 @@ impl IsoEnvironment for OsIsoEnvironment {
                     .output();
 
                 match fuse_output {
-                    Ok(fuse_out) if fuse_out.status.success() => {
+                    Ok(fuse_out) if fuse_out.status.success() && mount_point_populated() => {
                         debug!("Mounted {} via fuseiso", iso_path.display());
                         Ok(mount_point)
                     }
                     _ => {
-                        // Cleanup mount point on failure
+                        // Cleanup mount point on failure.
                         let _ = std::fs::remove_dir(&mount_point);
-                        Err(IsoError::MountFailed(stderr.to_string()))
+                        Err(IsoError::MountFailed(reason))
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Companion to #214. While debugging the Win11 UDF detection I noticed a broader silent-failure path: if attempt 1 (\`mount -o loop,ro\`) returns status=success AND the losetup fallback later fails, the terminal \`match output\` branch still returns \`Ok(mount_point)\` even when the mount_point is empty.

The mount_point can be empty because:

1. **Busybox loop-mode is a no-op on some builds** — the mount command reports success but nothing is actually mounted (the existing code comments document this).
2. **Filesystem type list doesn't match** — same class of bug that hid Win11 UDF ISOs until #214's \`-t udf,iso9660\` fix. A theoretical future HFS+/exFAT ISO would hit this.

Silent success → caller sees \`NoBootEntries\` → operator is told the ISO is malformed when the real problem is \"mount didn't take\". Misdiagnosis wastes operator time.

## Fix

After claiming \`status=success\`, re-verify the mount_point has entries. If empty, emit a specific diagnostic:

\`\`\`
MountFailed(\"mount claimed success but <path> is empty — filesystem type likely not auto-detected (stderr: ...)\")
\`\`\`

Same check applied to the \`fuseiso\` fallback.

## Alignment

Epic #138 closed last week with the charter \"no silent failures on safety-critical paths.\" Mount failures are exactly the kind of path that should fail loud — and operators deserve the real diagnostic, not a misleading \`NoBootEntries\` error.

## Test plan

- [x] \`cargo clippy -p iso-parser --all-targets -- -D warnings\` clean
- [x] \`cargo test -p iso-parser\` — 35 tests pass (existing mock covers happy path; the empty-mount case is difficult to unit-test because it requires real filesystem interaction, the diagnostic text improvement is the meaningful win)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)