### PR TITLE
docs: ext4 flash recipe + Windows ISO behavior (Win11 testing follow-up)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -40,7 +40,33 @@ You're trying to add an ISO larger than what's free on `AEGIS_ISOS`. Either:
 
 - Free space: `rm` something via the host mount, or use `aegis-boot list` to see what's there and decide.
 - Reflash with a larger image: `DISK_SIZE_MB=8192 sudo aegis-boot flash` (or set the env on `mkusb.sh` if you build manually).
-- For ISOs > 4 GB on FAT32: rebuild with `DATA_FS=ext4 ./scripts/mkusb.sh`. Trade-off: ext4 isn't natively writable from macOS / Windows.
+
+### ISO too large for FAT32
+
+You hit an error like:
+
+```
+aegis-boot add: Win11_25H2_English_x64_v2.iso is 7.4 GiB — exceeds
+  FAT32's 4 GiB per-file ceiling.
+  The AEGIS_ISOS partition is formatted as vfat, which cannot store
+  files at or above 4 GiB. Reflash with ext4 to lift the ceiling:
+
+      DATA_FS=ext4 sudo aegis-boot flash /dev/sdX
+```
+
+FAT32 caps individual files at 4 GiB minus one byte — this affects Ubuntu LTS Desktop (~5.8 GB), Rocky 9 DVD (~10 GB), Windows 10 installer (~5.5 GB), and Windows 11 installer (~7.9 GB). Rebuild the stick with ext4:
+
+```bash
+DATA_FS=ext4 sudo aegis-boot flash /dev/sdX
+```
+
+The destructive reflash will wipe existing ISOs — back up first with `aegis-boot list /dev/sdX` to see what's there. Trade-off: ext4 isn't natively writable from macOS / Windows (Linux-only "drop files on the host" workflow, or use `ext4fuse` on macOS / `Ext2Fsd` on Windows).
+
+### Windows installer ISO on the stick doesn't boot
+
+Expected. Windows installers use `bootmgr.efi` + the NT loader, not a Linux kernel — they can't be kexec-booted through aegis-boot's signed chain. rescue-tui surfaces them with an `[X] not kexec-bootable` glyph for exactly this reason (rather than silently hiding them).
+
+To install Windows on a target machine, write the Windows ISO directly to a separate stick using `dd` or Rufus. aegis-boot's signed-chain model is specific to Linux kernels that participate in Secure Boot's PE signature check.
 
 ---
 

--- a/docs/USB_LAYOUT.md
+++ b/docs/USB_LAYOUT.md
@@ -40,20 +40,30 @@ FAT32 caps individual files at **4 GB minus 1 byte**. Typical distro ISOs:
 
 | ISO | Size | Fits on FAT32? |
 |---|---|---|
-| Ubuntu LTS desktop | ~5.8 GB | ❌ exceeds |
-| Fedora Workstation | ~2.3 GB | ✅ |
-| Debian netinst / live standard | ~1 GB | ✅ |
-| Arch | ~1.2 GB | ✅ |
 | Alpine standard | ~200 MB | ✅ |
 | NixOS minimal | ~900 MB | ✅ |
+| Debian netinst / live standard | ~1 GB | ✅ |
+| Arch | ~1.2 GB | ✅ |
+| Fedora Workstation | ~2.3 GB | ✅ |
+| Ubuntu Server LTS | ~2.6 GB | ✅ |
+| Ubuntu LTS Desktop | ~5.8 GB | ❌ exceeds |
+| Windows 10 installer | ~5.5 GB | ❌ exceeds |
+| Windows 11 installer | ~7.9 GB | ❌ exceeds |
+| Rocky 9 DVD | ~10 GB | ❌ exceeds |
 
-If you need to ship the full Ubuntu LTS desktop image: rebuild with:
+`aegis-boot add` refuses oversized ISOs on FAT32 before the copy starts, with a message naming the ext4 rebuild path. See [TROUBLESHOOTING.md § "ISO too large for FAT32"](./TROUBLESHOOTING.md#iso-too-large-for-fat32) for the exact error text.
+
+If you need to ship a >4 GB image, reflash the stick with ext4:
 
 ```bash
+DATA_FS=ext4 sudo aegis-boot flash /dev/sdX
+# or via mkusb.sh directly:
 DATA_FS=ext4 ./scripts/mkusb.sh
 ```
 
 Trade-off: ext4 isn't natively writable from macOS or Windows, so the "drop files on the host" workflow requires Linux (or FUSE drivers like `ext4fuse` on macOS, `Ext2Fsd`/`Paragon` on Windows). Pick based on where you're dropping ISOs onto the stick.
+
+**Windows installer caveat.** Win10/Win11 ISOs now get past `aegis-boot add` (on ext4 sticks) and surface in rescue-tui's list with the `[X] not kexec-bootable` glyph. They cannot actually be kexec-booted — Windows uses `bootmgr.efi` + the NT loader, not a Linux kernel. aegis-boot surfaces them as a specific diagnostic rather than silently hiding them so the operator isn't left wondering where their ISO went.
 
 The data-partition GUID changes with the filesystem: FAT32 gets `0700` (Microsoft Basic Data, cross-OS friendly) and ext4 gets `8300` (Linux filesystem). Both mount fine from Linux; the type only matters for auto-mount behavior on other OSes.
 


### PR DESCRIPTION
## Summary

Doc follow-up to the Win11 testing arc (#214 UDF detection → #215 mount-empty diagnostic → #216 FAT32 preflight). Operators hitting the FAT32 preflight error deserve good breadcrumbs both to **find** the fix (via search on the error text) and to **anticipate** the constraint (via USB_LAYOUT.md size table).

## USB_LAYOUT.md changes

- Expanded the FAT32 file-size table with Windows 10/11 and Rocky 9 DVD rows (all exceed); added Ubuntu Server for comparison
- Reordered small-to-large so the pattern is immediately visible
- Forward link to \`TROUBLESHOOTING.md#iso-too-large-for-fat32\`
- Windows caveat: ISOs now reach rescue-tui with \`[X] not kexec-bootable\` (per #214) but can't kexec-boot (NT loader)

## TROUBLESHOOTING.md changes

- New **\"ISO too large for FAT32\"** section with the exact #216 preflight error text — operators pasting the error into a search box will find the fix directly
- New **\"Windows installer ISO doesn't boot\"** section: explains the architectural constraint (Windows uses \`bootmgr.efi\` + NT loader) and points at \`dd\`/Rufus for actual Windows installation

## Test plan

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)