### PR TITLE
refactor(cli): consolidate /proc/mounts + disk-path helpers

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -208,8 +208,8 @@ fn locate_attestation_for_mount(
         return Err(format!("no attestation files in {}", dir.display()));
     }
 
-    if let Some(guid) = device_for_mount(mount_path)
-        .and_then(|p| disk_for_partition(&p))
+    if let Some(guid) = crate::mounts::device_for_mount(mount_path)
+        .and_then(|p| crate::mounts::parent_disk(&p))
         .and_then(|d| read_disk_guid(&d))
     {
         let lower = guid.to_lowercase();
@@ -237,76 +237,9 @@ fn locate_attestation_for_mount(
         .ok_or_else(|| "no attestation files found".to_string())
 }
 
-/// Read /proc/mounts and find the device backing the given mount path.
-/// Returns the longest-prefix-matching mount source (so /run/media/X
-/// resolves to /dev/sdc2 rather than the underlying / mount).
-fn device_for_mount(target: &Path) -> Option<PathBuf> {
-    let mounts = fs::read_to_string("/proc/mounts").ok()?;
-    let target_s = target
-        .canonicalize()
-        .ok()
-        .unwrap_or_else(|| target.to_path_buf());
-    let target_str = target_s.to_string_lossy();
-    let mut best: Option<(usize, PathBuf)> = None;
-    for line in mounts.lines() {
-        let f: Vec<&str> = line.split_whitespace().collect();
-        if f.len() < 2 {
-            continue;
-        }
-        let dev = f[0];
-        let mp = f[1];
-        if !dev.starts_with("/dev/") {
-            continue;
-        }
-        if target_str == mp || target_str.starts_with(&format!("{mp}/")) {
-            let len = mp.len();
-            if best.as_ref().is_none_or(|(b, _)| len > *b) {
-                best = Some((len, PathBuf::from(dev)));
-            }
-        }
-    }
-    best.map(|(_, dev)| dev)
-}
-
-/// Strip a partition suffix from a block device path so /dev/sdc2 →
-/// /dev/sdc, /dev/nvme0n1p3 → /dev/nvme0n1, /dev/mmcblk0p1 →
-/// /dev/mmcblk0. Returns None for paths that don't match a known
-/// pattern (we don't want to over-aggressively strip digits from
-/// something like /dev/loop12 — pass that through unchanged via None).
-fn disk_for_partition(part: &Path) -> Option<PathBuf> {
-    let name = part.file_name()?.to_str()?;
-    let stripped = if name.starts_with("sd") || name.starts_with("vd") || name.starts_with("hd") {
-        // /dev/sda1 → sda
-        name.trim_end_matches(|c: char| c.is_ascii_digit())
-    } else if name.starts_with("nvme") || name.starts_with("mmcblk") || name.starts_with("loop") {
-        // /dev/nvme0n1p3 → nvme0n1, /dev/mmcblk0p1 → mmcblk0,
-        // /dev/loop12p1 → loop12. The 'p' must be preceded by a digit
-        // (the disk number) — otherwise "loop12" would mis-strip as
-        // "loo" because the 'p' inside "loop" itself looks like a
-        // separator. Loop devices without partitions return None
-        // (caller passed a whole disk).
-        if let Some(idx) = name.rfind('p') {
-            let prev_is_digit = idx > 0 && name.as_bytes()[idx - 1].is_ascii_digit();
-            let suffix = &name[idx + 1..];
-            let suffix_all_digits =
-                !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit());
-            if prev_is_digit && suffix_all_digits {
-                &name[..idx]
-            } else {
-                return None;
-            }
-        } else {
-            return None;
-        }
-    } else {
-        return None;
-    };
-    if stripped == name {
-        // No partition suffix to strip — caller passed a whole disk.
-        return None;
-    }
-    Some(PathBuf::from(format!("/dev/{stripped}")))
-}
+// device_for_mount + disk_for_partition moved to `mounts.rs` (as
+// `mounts::device_for_mount` and `mounts::parent_disk`) so inventory.rs
+// can share the implementation. See mounts.rs for the canonical docs.
 
 /// Record a flash operation and return the path of the saved manifest.
 /// On any failure, returns Err — the caller (`flash::flash`) prints
@@ -913,51 +846,9 @@ mod tests {
         assert!(long.ends_with('\u{2026}'));
     }
 
-    #[test]
-    fn disk_for_partition_strips_sda_digit() {
-        assert_eq!(
-            disk_for_partition(&PathBuf::from("/dev/sda1")),
-            Some(PathBuf::from("/dev/sda"))
-        );
-        assert_eq!(
-            disk_for_partition(&PathBuf::from("/dev/sdc12")),
-            Some(PathBuf::from("/dev/sdc"))
-        );
-    }
-
-    #[test]
-    fn disk_for_partition_strips_nvme_p_suffix() {
-        assert_eq!(
-            disk_for_partition(&PathBuf::from("/dev/nvme0n1p3")),
-            Some(PathBuf::from("/dev/nvme0n1"))
-        );
-        assert_eq!(
-            disk_for_partition(&PathBuf::from("/dev/mmcblk0p1")),
-            Some(PathBuf::from("/dev/mmcblk0"))
-        );
-    }
-
-    #[test]
-    fn disk_for_partition_returns_none_for_whole_disk() {
-        // Whole disks don't have a partition suffix; we want Some(None)
-        // not "infinite recursion" or wrong stripping.
-        assert_eq!(disk_for_partition(&PathBuf::from("/dev/sda")), None);
-        assert_eq!(disk_for_partition(&PathBuf::from("/dev/nvme0n1")), None);
-    }
-
-    #[test]
-    fn disk_for_partition_does_not_overstrip_loop() {
-        // /dev/loop12 is a whole loop device; we shouldn't strip "12"
-        // off and yield "/dev/loop". The loop branch only matches when
-        // there's a 'p' separator, which loop devices never have.
-        assert_eq!(disk_for_partition(&PathBuf::from("/dev/loop12")), None);
-    }
-
-    #[test]
-    fn disk_for_partition_unknown_kind_returns_none() {
-        assert_eq!(disk_for_partition(&PathBuf::from("/dev/whatever3")), None);
-        assert_eq!(disk_for_partition(&PathBuf::from("not/a/dev/path")), None);
-    }
+    // disk_for_partition tests moved to mounts.rs (the canonical
+    // home); kept the smoke-test for the attest-specific call path
+    // via the summary_for_mount → device_for_mount → parent_disk chain.
 
     #[test]
     fn iso_record_appends_to_isos_vec() {

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -288,7 +288,7 @@ pub(crate) fn resolve_mount(arg: Option<&str>) -> Result<Mount, String> {
             // Reverse-lookup the backing device via /proc/mounts so
             // later error messages (FAT32 preflight) can name the
             // specific disk to reflash instead of a generic /dev/sdX.
-            let device = device_for_mount_path(&p);
+            let device = crate::mounts::device_for_mount(&p);
             return Ok(Mount {
                 path: p,
                 temporary: false,
@@ -458,59 +458,6 @@ fn free_bytes(path: &Path) -> Option<u64> {
 /// `DATA_FS=ext4` in mkusb.sh to lift the ceiling.
 const FAT32_MAX_FILE_SIZE: u64 = (4 * 1024 * 1024 * 1024) - 1;
 
-/// Read `/proc/mounts` and return the filesystem type for the
-/// best-matching mount point. Returns `None` when the path isn't a
-/// mount point or /proc/mounts can't be read (non-Linux host, or a
-/// mount path that's a subdir of the actual mount). Pure-string lookup;
-/// no kernel syscalls.
-fn filesystem_type(path: &Path) -> Option<String> {
-    let mounts = std::fs::read_to_string("/proc/mounts").ok()?;
-    let target = path.to_string_lossy();
-    let mut best_match: Option<(&str, usize)> = None;
-    for line in mounts.lines() {
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() < 3 {
-            continue;
-        }
-        let mount_path = fields[1];
-        let fs_type = fields[2];
-        if target == mount_path || target.starts_with(&format!("{mount_path}/")) {
-            // Prefer the longest matching mount path (handles nested
-            // mounts correctly).
-            let mp_len = mount_path.len();
-            if best_match.is_none_or(|(_, prev)| mp_len > prev) {
-                best_match = Some((fs_type, mp_len));
-            }
-        }
-    }
-    best_match.map(|(fs, _)| fs.to_string())
-}
-
-/// Reverse-lookup the backing device for a mount path via /proc/mounts.
-/// Returns the longest-matching mount entry's device field, which is
-/// the partition path (`/dev/sda2`, `/dev/nvme0n1p2`) — callers can
-/// strip the partition suffix via `parent_disk_path` when they need
-/// the whole-disk form.
-fn device_for_mount_path(path: &Path) -> Option<PathBuf> {
-    let mounts = std::fs::read_to_string("/proc/mounts").ok()?;
-    let target = path.to_string_lossy();
-    let mut best: Option<(&str, usize)> = None;
-    for line in mounts.lines() {
-        let fields: Vec<&str> = line.split_whitespace().collect();
-        if fields.len() < 2 {
-            continue;
-        }
-        let dev = fields[0];
-        let mp = fields[1];
-        if (target == mp || target.starts_with(&format!("{mp}/")))
-            && best.is_none_or(|(_, prev)| mp.len() > prev)
-        {
-            best = Some((dev, mp.len()));
-        }
-    }
-    best.map(|(d, _)| PathBuf::from(d))
-}
-
 /// True when the filesystem type reported by /proc/mounts indicates a
 /// FAT32-family layout with the 4 GiB per-file ceiling.
 fn is_fat32_family(fs_type: &str) -> bool {
@@ -526,7 +473,7 @@ fn is_fat32_family(fs_type: &str) -> bool {
 /// (~10 GiB). Unmounts the temporary mount on refusal so the caller
 /// doesn't have to.
 fn check_fat32_ceiling(mount: &Mount, iso_filename: &str, iso_size: u64) -> Result<(), u8> {
-    let Some(fs_type) = filesystem_type(&mount.path) else {
+    let Some(fs_type) = crate::mounts::filesystem_type(&mount.path) else {
         return Ok(());
     };
     if !is_fat32_family(&fs_type) || iso_size <= FAT32_MAX_FILE_SIZE {
@@ -540,8 +487,8 @@ fn check_fat32_ceiling(mount: &Mount, iso_filename: &str, iso_size: u64) -> Resu
     let flash_target = mount
         .device
         .as_deref()
-        .and_then(parent_disk_path)
-        .unwrap_or_else(|| "/dev/sdX".to_string());
+        .and_then(crate::mounts::parent_disk)
+        .map_or_else(|| "/dev/sdX".to_string(), |p| p.display().to_string());
     eprintln!(
         "aegis-boot add: {} is {} — exceeds FAT32's 4 GiB per-file ceiling.",
         iso_filename,
@@ -557,63 +504,6 @@ fn check_fat32_ceiling(mount: &Mount, iso_filename: &str, iso_size: u64) -> Resu
         unmount_temp(mount);
     }
     Err(1)
-}
-
-/// Strip the trailing partition suffix from a device path so operators
-/// see the disk path `aegis-boot flash` wants, not the partition path.
-/// Two naming conventions to handle:
-///
-///   * **sata / virtio / etc.** — whole disk ends in a letter (`sda`);
-///     partition appends digits directly (`sda2`, `sdb15`).
-///   * **nvme / mmcblk / loop** — whole disk ends in a digit
-///     (`nvme0n1`); partition uses a `p` separator (`nvme0n1p2`,
-///     `mmcblk0p1`, `loop0p1`).
-///
-/// Returns `None` when the input is already a whole-disk path or the
-/// name doesn't match either convention. Keeping the placeholder is
-/// safer than emitting a wrong disk — the operator corrects the hint
-/// instead of scripting a destructive reflash of the wrong drive.
-fn parent_disk_path(partition: &Path) -> Option<String> {
-    let s = partition.to_str()?;
-    let stem = s.strip_prefix("/dev/")?;
-    let bytes = stem.as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-    // Find the length of the trailing digit run.
-    let mut digits_start = bytes.len();
-    while digits_start > 0 && bytes[digits_start - 1].is_ascii_digit() {
-        digits_start -= 1;
-    }
-    if digits_start == bytes.len() || digits_start == 0 {
-        // No trailing digits, or the whole name is digits.
-        return None;
-    }
-    let char_before_digits = bytes[digits_start - 1];
-
-    // nvme / mmcblk / loop convention: "stem_ending_in_digit" + "p" +
-    // "partition_digits". Strip the `p<digits>` suffix to recover the
-    // whole-disk stem.
-    if char_before_digits == b'p' && digits_start >= 2 && bytes[digits_start - 2].is_ascii_digit() {
-        let parent = &stem[..digits_start - 1];
-        return Some(format!("/dev/{parent}"));
-    }
-
-    // sata-style: alpha + digits. But nvme whole disks like `nvme0n1`
-    // also end in "alpha + digit" (the `n` is the namespace letter).
-    // Discriminate via a tighter check: sata partitions have at least
-    // TWO alpha chars before the digits (sd-a, vd-a, hd-a, xvd-a) —
-    // which nvme/mmcblk/loop whole-disk names *don't* have between the
-    // namespace letter and the trailing namespace digit.
-    if char_before_digits.is_ascii_alphabetic()
-        && digits_start >= 2
-        && bytes[digits_start - 2].is_ascii_alphabetic()
-    {
-        let parent = &stem[..digits_start];
-        return Some(format!("/dev/{parent}"));
-    }
-
-    None
 }
 
 #[allow(clippy::cast_precision_loss)]
@@ -679,65 +569,6 @@ mod tests {
         // catches a real-world operator input, not a compile-time truism.
         let size = std::hint::black_box(7_900_000_000u64);
         assert!(size > FAT32_MAX_FILE_SIZE);
-    }
-
-    #[test]
-    fn parent_disk_path_strips_sata_partition_digit() {
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/sda2")).as_deref(),
-            Some("/dev/sda")
-        );
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/sdc1")).as_deref(),
-            Some("/dev/sdc")
-        );
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/sdb15")).as_deref(),
-            Some("/dev/sdb")
-        );
-        // Three-letter device path (vd, hd, etc.)
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/vda3")).as_deref(),
-            Some("/dev/vda")
-        );
-    }
-
-    #[test]
-    fn parent_disk_path_strips_nvme_p_partition() {
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/nvme0n1p2")).as_deref(),
-            Some("/dev/nvme0n1")
-        );
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/nvme1n1p15")).as_deref(),
-            Some("/dev/nvme1n1")
-        );
-        // mmcblk same convention
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/mmcblk0p1")).as_deref(),
-            Some("/dev/mmcblk0")
-        );
-        // loop devices
-        assert_eq!(
-            parent_disk_path(Path::new("/dev/loop0p1")).as_deref(),
-            Some("/dev/loop0")
-        );
-    }
-
-    #[test]
-    fn parent_disk_path_declines_whole_disk_input() {
-        // When the operator (or mount resolver) already passed a whole
-        // disk, don't mangle it — return None so the caller keeps the
-        // generic placeholder rather than emitting the wrong path.
-        assert_eq!(parent_disk_path(Path::new("/dev/sda")), None);
-        assert_eq!(parent_disk_path(Path::new("/dev/nvme0n1")), None);
-    }
-
-    #[test]
-    fn parent_disk_path_declines_non_dev_paths() {
-        assert_eq!(parent_disk_path(Path::new("/tmp/fake-stick2")), None);
-        assert_eq!(parent_disk_path(Path::new("sda2")), None); // no /dev/ prefix
-        assert_eq!(parent_disk_path(Path::new("")), None);
     }
 
     #[test]

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -32,6 +32,7 @@ mod flash;
 mod init;
 mod inventory;
 mod man;
+mod mounts;
 mod update;
 mod verify;
 

--- a/crates/aegis-cli/src/mounts.rs
+++ b/crates/aegis-cli/src/mounts.rs
@@ -1,0 +1,204 @@
+//! Shared helpers for reading `/proc/mounts` and deriving
+//! block-device paths. Consolidates three near-identical implementations
+//! that lived in `inventory.rs` and `attest.rs` (each doing their own
+//! longest-prefix match + disk suffix stripper).
+//!
+//! All helpers are side-effect-free (except reading `/proc/mounts`)
+//! and panic-free by construction. `None` returns are the canonical
+//! "I couldn't determine this" signal — callers must have a graceful
+//! fallback.
+
+use std::path::{Path, PathBuf};
+
+/// Reverse-lookup the backing device for a mount path via `/proc/mounts`.
+/// Returns the longest-prefix-matching device field (e.g. `/dev/sda2`
+/// for a mount at `/media/william/AEGIS_ISOS`). Filters out non-block
+/// mounts (tmpfs, cgroup, proc, etc.) by requiring the device path to
+/// begin with `/dev/`.
+///
+/// Longest-prefix matching matters: `/run/media/operator/AEGIS_ISOS`
+/// would otherwise match both `/` (root) and the actual stick mount —
+/// we want the stick.
+#[allow(dead_code)] // used by attest.rs and inventory.rs (cross-module reuse)
+pub(crate) fn device_for_mount(target: &Path) -> Option<PathBuf> {
+    let mounts = std::fs::read_to_string("/proc/mounts").ok()?;
+    let canonical = target
+        .canonicalize()
+        .ok()
+        .unwrap_or_else(|| target.to_path_buf());
+    let target_s = canonical.to_string_lossy();
+    let mut best: Option<(usize, PathBuf)> = None;
+    for line in mounts.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 2 {
+            continue;
+        }
+        let dev = fields[0];
+        let mp = fields[1];
+        if !dev.starts_with("/dev/") {
+            continue;
+        }
+        if (target_s == mp || target_s.starts_with(&format!("{mp}/")))
+            && best.as_ref().is_none_or(|(prev, _)| mp.len() > *prev)
+        {
+            best = Some((mp.len(), PathBuf::from(dev)));
+        }
+    }
+    best.map(|(_, dev)| dev)
+}
+
+/// Return the filesystem type reported by `/proc/mounts` for the
+/// best-matching mount point. Unlike `device_for_mount`, this accepts
+/// any mount source (including tmpfs and overlayfs) so the caller
+/// can distinguish a vfat-mounted `AEGIS_ISOS` from, say, an operator
+/// who accidentally pointed us at a tmpfs directory.
+#[allow(dead_code)]
+pub(crate) fn filesystem_type(path: &Path) -> Option<String> {
+    let mounts = std::fs::read_to_string("/proc/mounts").ok()?;
+    let target = path.to_string_lossy();
+    let mut best: Option<(&str, usize)> = None;
+    for line in mounts.lines() {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() < 3 {
+            continue;
+        }
+        let mp = fields[1];
+        let fs = fields[2];
+        if (target == mp || target.starts_with(&format!("{mp}/")))
+            && best.is_none_or(|(_, prev)| mp.len() > prev)
+        {
+            best = Some((fs, mp.len()));
+        }
+    }
+    best.map(|(f, _)| f.to_string())
+}
+
+/// Strip the trailing partition suffix from a block device path so
+/// callers that need the whole-disk form (e.g. `aegis-boot flash`
+/// which refuses partition devices) get it directly.
+///
+/// Handles two Linux naming conventions:
+///
+/// * **sata / virtio / xen / hd** — whole disk ends in a letter (`sda`);
+///   partition appends digits directly (`sda2`, `sdb15`, `vda1`).
+/// * **nvme / mmcblk / loop** — whole disk ends in a digit (`nvme0n1`,
+///   `mmcblk0`); partition uses a `p` separator (`nvme0n1p2`,
+///   `mmcblk0p1`, `loop0p1`).
+///
+/// Returns `None` when the input is already a whole-disk path or
+/// doesn't match either convention — safer than emitting a wrong disk
+/// and risking a destructive operation on the wrong device.
+#[allow(dead_code)]
+pub(crate) fn parent_disk(partition: &Path) -> Option<PathBuf> {
+    let s = partition.to_str()?;
+    let stem = s.strip_prefix("/dev/")?;
+    let bytes = stem.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    // Find the length of the trailing digit run.
+    let mut digits_start = bytes.len();
+    while digits_start > 0 && bytes[digits_start - 1].is_ascii_digit() {
+        digits_start -= 1;
+    }
+    if digits_start == bytes.len() || digits_start == 0 {
+        // No trailing digits, or the whole name is digits.
+        return None;
+    }
+    let char_before_digits = bytes[digits_start - 1];
+
+    // nvme / mmcblk / loop convention: stem ends in a digit, partition
+    // inserts `p` before its own digit run. Strip the `p<digits>`.
+    if char_before_digits == b'p' && digits_start >= 2 && bytes[digits_start - 2].is_ascii_digit() {
+        let parent = &stem[..digits_start - 1];
+        return Some(PathBuf::from(format!("/dev/{parent}")));
+    }
+
+    // sata-style — constrain by known prefix so mmcblk0/nvme0n1
+    // (whole disks that happen to end in digit+after-alpha) don't get
+    // mis-stripped. The kernel's block-device naming for sata/virtio/
+    // xen/hd uses `sd<a..z>[a..z]*<N>` where the stem is an alpha run.
+    // Anything outside these prefixes and not matching the `pN` rule
+    // above is either a whole disk or an unrecognized naming scheme.
+    let sata_prefix = ["sd", "vd", "hd", "xvd"]
+        .iter()
+        .any(|p| stem.starts_with(p));
+    if sata_prefix && char_before_digits.is_ascii_alphabetic() {
+        let parent = &stem[..digits_start];
+        return Some(PathBuf::from(format!("/dev/{parent}")));
+    }
+
+    None
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parent_disk_strips_sata_partition_digits() {
+        assert_eq!(
+            parent_disk(Path::new("/dev/sda2")).as_deref(),
+            Some(Path::new("/dev/sda"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/sdc1")).as_deref(),
+            Some(Path::new("/dev/sdc"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/sdb15")).as_deref(),
+            Some(Path::new("/dev/sdb"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/vda3")).as_deref(),
+            Some(Path::new("/dev/vda"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/hda1")).as_deref(),
+            Some(Path::new("/dev/hda"))
+        );
+    }
+
+    #[test]
+    fn parent_disk_strips_nvme_p_partition() {
+        assert_eq!(
+            parent_disk(Path::new("/dev/nvme0n1p2")).as_deref(),
+            Some(Path::new("/dev/nvme0n1"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/nvme1n1p15")).as_deref(),
+            Some(Path::new("/dev/nvme1n1"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/mmcblk0p1")).as_deref(),
+            Some(Path::new("/dev/mmcblk0"))
+        );
+        assert_eq!(
+            parent_disk(Path::new("/dev/loop0p1")).as_deref(),
+            Some(Path::new("/dev/loop0"))
+        );
+    }
+
+    #[test]
+    fn parent_disk_declines_whole_disk_input() {
+        // Must not mangle a disk path — callers keep their placeholder.
+        assert_eq!(parent_disk(Path::new("/dev/sda")), None);
+        assert_eq!(parent_disk(Path::new("/dev/nvme0n1")), None);
+        assert_eq!(parent_disk(Path::new("/dev/mmcblk0")), None);
+        // /dev/loop0 is a whole loop device, not a partition.
+        assert_eq!(parent_disk(Path::new("/dev/loop0")), None);
+    }
+
+    #[test]
+    fn parent_disk_declines_non_dev_paths() {
+        assert_eq!(parent_disk(Path::new("/tmp/fake2")), None);
+        assert_eq!(parent_disk(Path::new("sda2")), None);
+        assert_eq!(parent_disk(Path::new("")), None);
+    }
+}


### PR DESCRIPTION
## Summary

\`attest.rs\` and \`inventory.rs\` had grown nearly-identical implementations during the Win11 arc — #219 added inventory-side copies of what #147 already had in attest. Three duplicated helpers across ~180 lines:

| Helper | Purpose | Previously in |
|---|---|---|
| \`device_for_mount\` | \`/proc/mounts\` reverse lookup | attest.rs + inventory.rs |
| \`disk_for_partition\` / \`parent_disk_path\` | strip partition suffix | attest.rs + inventory.rs |
| \`filesystem_type\` | mount's fs type | inventory.rs only |

New \`crates/aegis-cli/src/mounts.rs\` consolidates all three as \`pub(crate)\` helpers: \`mounts::device_for_mount\`, \`mounts::filesystem_type\`, \`mounts::parent_disk\`.

## Parser bug fixed as a side-effect

My earlier \`parent_disk_path\` (shipped in #219) used \"two alpha chars before trailing digits\" to discriminate sata from nvme. That matched \`mmcblk0\` (the \`lk\` in \`mmcblk\`) and stripped the trailing \`0\`, yielding \`/dev/mmcblk\`. Subtle because test coverage didn't include mmcblk whole-disk until now.

The consolidated \`mounts::parent_disk\` uses an explicit prefix allowlist for sata-style (\`sd\`/\`vd\`/\`hd\`/\`xvd\`). nvme/mmcblk/loop definitively require the \`p<N>\` suffix. Whole-disk paths (\`/dev/mmcblk0\`, \`/dev/nvme0n1\`, \`/dev/loop0\`) all correctly return \`None\`.

## Net diff

- 4 call-site updates (inventory.rs + attest.rs pointing at \`crate::mounts::*\`)
- 3 dedup'd functions
- 1 parser bug fixed (mmcblk whole-disk mis-strip)
- 4 shared tests replacing 9 duplicated tests

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-cli\` — 137 tests pass
- [x] Real-hardware smoke: \`aegis-boot add win11.iso /media/…/AEGIS_ISOS\` still emits \`/dev/sda\` correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)