### PR TITLE
feat(doctor): point at `compat --submit` instead of raw report URL

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -521,15 +521,14 @@ fn check_compat_db_coverage(report: &mut Report, vendor: &str, product: &str) {
         );
     } else {
         // Warn (not Fail): missing coverage is informational — aegis-boot
-        // still works on undocumented machines. We inline the guidance
-        // into `detail` because `next_action` only surfaces on Fail.
+        // still works on undocumented machines. Point at the one-command
+        // draft-report path (`compat --submit`) rather than the raw URL;
+        // the URL is long and operators running on a terminal can't
+        // click it, whereas they can copy-paste the subcommand.
         report.add(
             Verdict::Warn,
             "compat DB coverage",
-            format!(
-                "not yet in compat DB — file a report at {}",
-                crate::compat::REPORT_URL,
-            ),
+            "not yet in compat DB — run `aegis-boot compat --submit` to draft a report",
         );
     }
 }


### PR DESCRIPTION
## Summary

After #222 (\`compat --submit\`), operators have a one-command path to draft a hardware report. doctor's compat-DB-miss WARN row was still emitting the raw GitHub URL, which is:

- **Not clickable** in many terminal emulators (serial, tmux, minimal tty)
- **Long** (~80 chars) — breaks line wrapping
- **Incomplete** — the URL alone skips the DMI auto-fill that \`--submit\` does

### Before

\`\`\`
[! WARN] compat DB coverage   not yet in compat DB — file a report at https://github.com/williamzujkowski/aegis-boot/issues/new?template=hardware-report.yml
\`\`\`

### After

\`\`\`
[! WARN] compat DB coverage   not yet in compat DB — run \`aegis-boot compat --submit\` to draft a report
\`\`\`

Short, copy-pasteable, and the command does more than the URL (auto-fills vendor/model/firmware/version).

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-cli\` — 146 tests pass (existing Warn-verdict assertions hold)
- [x] Real-hardware smoke: \`aegis-boot doctor\` on Framework Laptop emits the new message
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)