### PR TITLE
docs(install): mention compat --my-machine + --submit in sanity-check

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -43,6 +43,14 @@ aegis-boot doctor          # 0–100 health score for host + stick
 
 If `aegis-boot doctor` reports anything FAIL, fix that first — its NEXT ACTION line tells you exactly what.
 
+Check whether your machine is in the hardware-compatibility database:
+
+```bash
+aegis-boot compat --my-machine   # DMI auto-lookup, Linux only
+```
+
+If it's not (common until the database grows), the Warn row from `doctor` will already tell you to run `aegis-boot compat --submit`, which gathers the same DMI values and generates a pre-filled GitHub issue URL — one click, four fields already populated. See [HARDWARE_COMPAT.md](./HARDWARE_COMPAT.md) for the criteria the database uses.
+
 Optional — install shell completions for tab-complete on subcommands, catalog slugs, and compat-DB vendors:
 
 ```bash


### PR DESCRIPTION
## Summary

\`INSTALL.md\` walked operators through \`aegis-boot --version\` and \`aegis-boot doctor\` but never mentioned the hardware-compatibility flow (#206 / #222 / #223) that shipped this week. New users had to discover it via \`doctor\`'s WARN row output.

Three-line addition after the sanity-check section:

\`\`\`bash
aegis-boot compat --my-machine   # DMI auto-lookup, Linux only
\`\`\`

With a pointer explaining that if the machine isn't documented yet, \`doctor\`'s WARN row already names \`aegis-boot compat --submit\` for the pre-filled GitHub issue URL. Links to \`HARDWARE_COMPAT.md\` for the DB criteria.

Placed BEFORE the shell-completions optional so operators see the hardware flow early in the post-install sequence.

## Test plan

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)