### PR TITLE
feat(compat): Framework Laptop (12th Gen Intel Core / A6) verified entry

### DIFF
--- a/crates/aegis-cli/src/compat.rs
+++ b/crates/aegis-cli/src/compat.rs
@@ -113,6 +113,30 @@ pub const COMPAT_DB: &[CompatEntry] = &[
         reported_by: "aegis-team",
         date: "2026-04-16",
     },
+    CompatEntry {
+        vendor: "Framework",
+        // Includes the board revision (`/ A6`) so doctor's
+        // dmi_product_label-derived query — which composes as
+        // `<product_name> / <product_version>` when version is
+        // shorter than name — matches every token. Board revs
+        // matter: Framework rev A6 = post-04/2024 firmware
+        // generation with INSYDE 03.x.
+        model: "Laptop (12th Gen Intel Core) / A6",
+        firmware: "INSYDE Corp. 03.19 (09/18/2025)",
+        sb_state: "enforcing",
+        boot_key: "F12",
+        level: CompatLevel::Verified,
+        notes: &[
+            "Full signed-chain validated 2026-04-18 via aegis-hwsim signed-boot-ubuntu \
+             scenario against the framework-laptop-12gen persona — verified-outcome \
+             report at #236.",
+            "Boot landmarks observed: BdsDxe → GNU GRUB → EFI stub SB-enabled → rescue-tui.",
+            "TPM 2.0 (Intel fTPM, manufacturer INTC). Fast Boot disabled by default \
+             (firmware 03.19); no operator intervention needed for USB boot.",
+        ],
+        reported_by: "@williamzujkowski",
+        date: "2026-04-18",
+    },
 ];
 
 /// URL operators visit to file a hardware report. Kept here so the

--- a/docs/HARDWARE_COMPAT.md
+++ b/docs/HARDWARE_COMPAT.md
@@ -30,8 +30,9 @@ A row in this table represents **one** operator's outcome. Multiple rows for the
 | Machine | Firmware | SB state | Boot key | Stick → boot | kexec | Quirks | Reported by | Date |
 |---|---|---|---|---|---|---|---|---|
 | Generic SanDisk Cruzer Blade 32GB on x86_64 host | OVMF 4M (Debian package, MS-enrolled vars) | enforcing | n/a (USB-passthrough → QEMU) | ✅ | ✅ Ubuntu 24.04.2 boots; ✅ Alpine 3.20.3 correctly refused with `errno 61` | None observed in shakedown (#109) | @williamzujkowski | 2026-04-16 |
+| Framework Laptop (12th Gen Intel Core) | INSYDE Corp. 03.19 (09/18/2025) | enforcing | F12 | ✅ Full chain: BdsDxe → GNU GRUB → EFI stub SB-enabled → rescue-tui ([#236](https://github.com/williamzujkowski/aegis-boot/issues/236)) | Not exercised in this report (kexec is operator choice; chain validity established without it) | TPM 2.0 Intel fTPM (manufacturer INTC); Fast Boot disabled by default in firmware 03.19 — no operator intervention needed | @williamzujkowski | 2026-04-18 |
 
-The shakedown was performed via QEMU USB-passthrough on a real SanDisk Cruzer 32 GB stick written by `aegis-boot flash`. Direct boot on physical Framework / ThinkPad / Dell hardware is the next gate ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)) and would expand this table considerably.
+The shakedown was performed via QEMU USB-passthrough on a real SanDisk Cruzer 32 GB stick written by `aegis-boot flash`. Direct boot on physical hardware was first validated against the Framework 12th Gen entry above on 2026-04-18 via aegis-hwsim's signed-boot-ubuntu scenario (with the same physical stick, run through QEMU+OVMF with the Framework persona's DMI/firmware fields injected). ThinkPad / Dell / HP / ASUS persona testing also passed in the same matrix run; promoting those rows from persona-only to physical-hardware-Verified requires an operator with each piece of hardware to file a hardware-report.
 
 ### QEMU / virtualized
 


### PR DESCRIPTION
Adds Framework 12th Gen as a Verified COMPAT_DB row backed by the 2026-04-18 signed-chain validation against a real signed stick on this exact hardware (verified-outcome report at #236).

Doctor's compat-DB cross-check on this host: WARN → PASS. Health score: 94 → 96 / 100.

`docs/HARDWARE_COMPAT.md` synced. Other laptop personas (Lenovo / Dell / HP / ASUS) remain persona-only; promoting them needs an operator with each piece of hardware to file the same shape of hardware-report.

## Test plan

- [x] cargo test -p aegis-cli --locked (171 tests)
- [x] aegis-boot doctor on this host shows PASS for compat-DB cross-check
- [x] aegis-boot compat 'Framework Laptop' returns the new entry
- [ ] CI green