### PR TITLE
fix(attest+update): respect SUDO_USER + clearer no-sudo update message

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -595,11 +595,89 @@ fn read_attestation(path: &Path) -> Result<Attestation, String> {
 }
 
 fn data_dir() -> PathBuf {
+    // When running under sudo, prefer the original user's data dir
+    // rather than root's (/root/.local/share/...). Otherwise `aegis-
+    // boot flash` (run via sudo for dd) would write attestations to
+    // root's home, but `aegis-boot attest list` (run as the operator)
+    // would look under their own home and find nothing — see the
+    // companion `sudo_aware_data_dir` in update.rs::attestation_dir.
+    if let Some(sudo_data) = sudo_aware_data_dir() {
+        return sudo_data.join("aegis-boot");
+    }
     let base = std::env::var_os("XDG_DATA_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
         .unwrap_or_else(|| PathBuf::from("/tmp"));
     base.join("aegis-boot")
+}
+
+/// When the process runs under `sudo`, the kernel preserves
+/// `SUDO_USER` (and usually `SUDO_UID`); HOME has already been
+/// rewritten to root's. Look up `SUDO_USER`'s home from `/etc/passwd`
+/// and prefer it over root's so attestations + cached state land
+/// in the operator's actual home dir.
+///
+/// Returns `Some(<user>/.local/share)` only when:
+/// - Effective UID is 0 AND
+/// - `SUDO_USER` is set AND
+/// - `getent passwd <user>` returns a valid home dir
+///
+/// Otherwise returns `None`, signaling the caller to fall back to
+/// the standard XDG/HOME resolution. Pure: shells out to `getent`
+/// (a glibc tool present on every system aegis-boot supports).
+pub(crate) fn sudo_aware_data_dir() -> Option<PathBuf> {
+    if !is_running_as_root() {
+        return None;
+    }
+    let sudo_user = std::env::var_os("SUDO_USER")?;
+    let sudo_user = sudo_user.to_str()?;
+    if sudo_user == "root" {
+        return None;
+    }
+    let home = lookup_home_via_getent(sudo_user)?;
+    Some(home.join(".local/share"))
+}
+
+fn is_running_as_root() -> bool {
+    // Read /proc/self/status to avoid an unsafe libc::geteuid() call.
+    // `Uid:` line format: "Uid:\t<real>\t<effective>\t<saved>\t<fs>".
+    // Effective UID is column 2 (0-indexed: index 2 after splitwhitespace
+    // including the Uid: prefix... actually 2 if we skip "Uid:" first).
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("Uid:") {
+            let mut tokens = rest.split_whitespace();
+            // tokens: <real> <effective> <saved> <fs>
+            tokens.next(); // real
+            if let Some(euid) = tokens.next() {
+                return euid == "0";
+            }
+        }
+    }
+    false
+}
+
+fn lookup_home_via_getent(user: &str) -> Option<PathBuf> {
+    // getent passwd <user> output: "<user>:<x>:<uid>:<gid>:<gecos>:<home>:<shell>"
+    // 6th field (index 5) is the home dir.
+    let out = Command::new("getent")
+        .args(["passwd", user])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&out.stdout);
+    let line = line.trim();
+    let fields: Vec<&str> = line.split(':').collect();
+    if fields.len() < 6 {
+        return None;
+    }
+    let home = fields[5];
+    if home.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(home))
 }
 
 fn current_iso_timestamp() -> String {

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -375,10 +375,28 @@ pub(crate) fn check_eligibility(dev: &Path) -> Eligibility {
     let sgdisk = match Command::new("sgdisk").args(["-p"]).arg(dev).output() {
         Ok(o) if o.status.success() => o,
         Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            // Sniff for the permission-denied case. sgdisk surfaces it
+            // as "Problem opening /dev/sdX for reading! Error is 13."
+            // (errno 13 = EACCES) plus "You must run this program as
+            // root or use sudo!". Detecting this lets us tell the
+            // operator to retry with sudo instead of leaving them
+            // confused that their stick is "NOT ELIGIBLE".
+            if stderr.contains("must run this program as root")
+                || stderr.contains("Error is 13")
+                || stderr.contains("Permission denied")
+            {
+                return Eligibility::Ineligible(format!(
+                    "permission denied reading {} (need root for raw block-device read). \
+                     Re-run with sudo: `sudo aegis-boot update {}`.",
+                    dev.display(),
+                    dev.display()
+                ));
+            }
             return Eligibility::Ineligible(format!(
                 "`sgdisk -p {}` exited non-zero: {}",
                 dev.display(),
-                String::from_utf8_lossy(&o.stderr).trim()
+                stderr.trim()
             ));
         }
         Err(e) => {
@@ -527,7 +545,18 @@ pub(crate) fn body_contains_guid(body: &str, target_guid: &str) -> bool {
 /// Same resolution rules as `attest::attestation_dir()` — duplicated here
 /// to avoid exporting a new pub surface in attest.rs this PR. Kept
 /// `pub(crate)` so a future `mv` into attest.rs is a mechanical rename.
+///
+/// Sudo handling: when running as root with `SUDO_USER` set (the
+/// typical `sudo aegis-boot update` flow — sudo needed to read the
+/// raw block device), prefer the original user's data dir rather
+/// than root's. Otherwise update-via-sudo would never find the
+/// attestations that flash-via-sudo wrote under the same user's
+/// home — that's the exact bug this fix closes (caught 2026-04-18
+/// during real-stick testing of #181).
 pub(crate) fn attestation_dir() -> Option<PathBuf> {
+    if let Some(sudo_data) = crate::attest::sudo_aware_data_dir() {
+        return Some(sudo_data.join("aegis-boot").join("attestations"));
+    }
     let base = std::env::var_os("XDG_DATA_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))?;


### PR DESCRIPTION
Two real bugs caught while live-testing #181 against the user's signed stick.

## Bug 1: `sudo aegis-boot update` never finds attestations

`flash` runs as the operator → writes attestations under `$HOME/.local/share/aegis-boot/`. `update` needs sudo for raw block-device read → HOME is rewritten to `/root` → looks for attestations under `/root/.local/share/...` → finds nothing → reports NOT ELIGIBLE for a stick that flash JUST attested.

Fix: new `attest::sudo_aware_data_dir()` that, when running as root with SUDO_USER set, resolves the original user's home via `getent passwd $SUDO_USER` and prefixes attestations under that user's data dir. Both `attest::data_dir()` and `update::attestation_dir()` route through it.

EUID detection reads `/proc/self/status` rather than calling `geteuid()` to avoid pulling `unsafe`/libc.

## Bug 2: no-sudo `update` conflates 'permission denied' with 'not eligible'

Without sudo, sgdisk fails with errno 13. update surfaced this as 'NOT ELIGIBLE: sgdisk exited non-zero ...' — diagnostic told operator their stick was bad when really they just needed sudo. Fix: sniff stderr for permission-denied phrases and surface 'permission denied ... Re-run with sudo: sudo aegis-boot update <device>'.

## Verified live

```
$ sudo aegis-boot update /dev/sda
Status: ELIGIBLE for in-place update.
  disk GUID:   e47213e8-4921-4eb3-b335-88e006700292
  attestation: /home/william/.local/share/aegis-boot/attestations/...
  AEGIS_ISOS:  will be preserved byte-for-byte
```

(Same flow that returned NOT ELIGIBLE before this PR.)

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy -p aegis-cli --all-targets -- -D warnings
- [x] cargo test -p aegis-cli --locked (171 tests)
- [x] cargo check --target x86_64-apple-darwin under -D warnings
- [x] Live-tested both UX paths (sudo + no-sudo) against a real signed stick
- [ ] CI green