### PR TITLE
style: cargo fmt drift on mutex.lock chain

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -879,7 +879,9 @@ mod tests {
 
     #[test]
     fn data_dir_uses_xdg_data_home_when_set() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var_os("XDG_DATA_HOME");
         std::env::set_var("XDG_DATA_HOME", "/tmp/aegis-test-xdg-data");
         let p = data_dir();
@@ -892,7 +894,9 @@ mod tests {
 
     #[test]
     fn data_dir_falls_back_to_home_local_share() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_xdg = std::env::var_os("XDG_DATA_HOME");
         let prev_home = std::env::var_os("HOME");
         std::env::remove_var("XDG_DATA_HOME");


### PR DESCRIPTION
Local stable rustfmt left the mutex.lock chain on one line; CI's nightly wraps it. Same family pattern. Doc-only.