### PR TITLE
feat(direct-install): stage_esp + grub.cfg render + combine_initrd (#274 PR2)

### DIFF
--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -567,27 +567,23 @@ mod tests {
 
     #[test]
     fn render_grub_cfg_writes_expected_body_to_disk() {
-        let tmp = std::env::temp_dir().join(format!(
-            "aegis-direct-install-grub-cfg-{}.cfg",
-            std::process::id()
-        ));
-        render_grub_cfg(&tmp).expect("render_grub_cfg");
-        let written = std::fs::read_to_string(&tmp).expect("read back grub.cfg");
+        // tempfile::TempDir rather than std::env::temp_dir so the
+        // test fs ops happen inside a private, auto-cleaned 0700 dir
+        // (semgrep rust.lang.security.temp-dir flags the latter).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("grub.cfg");
+        render_grub_cfg(&path).expect("render_grub_cfg");
+        let written = std::fs::read_to_string(&path).expect("read back grub.cfg");
         let expected = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
         assert_eq!(written, expected);
-        let _ = std::fs::remove_file(&tmp);
     }
 
     #[test]
     fn combine_initrd_concats_distro_then_aegis() {
-        let dir = std::env::temp_dir().join(format!(
-            "aegis-direct-install-combine-{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir tmp");
-        let distro = dir.join("distro.img");
-        let aegis = dir.join("aegis.img");
-        let out = dir.join("combined.img");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let distro = tmp.path().join("distro.img");
+        let aegis = tmp.path().join("aegis.img");
+        let out = tmp.path().join("combined.img");
 
         std::fs::write(&distro, b"DISTRO_PAYLOAD").expect("write distro");
         std::fs::write(&aegis, b"AEGIS_PAYLOAD").expect("write aegis");
@@ -595,26 +591,18 @@ mod tests {
 
         let got = std::fs::read(&out).expect("read combined");
         assert_eq!(got, b"DISTRO_PAYLOADAEGIS_PAYLOAD");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn combine_initrd_rejects_missing_input() {
-        let dir = std::env::temp_dir().join(format!(
-            "aegis-direct-install-combine-miss-{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).expect("mkdir tmp");
-        let distro = dir.join("does-not-exist.img");
-        let aegis = dir.join("aegis.img");
-        let out = dir.join("combined.img");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let distro = tmp.path().join("does-not-exist.img");
+        let aegis = tmp.path().join("aegis.img");
+        let out = tmp.path().join("combined.img");
 
         std::fs::write(&aegis, b"aegis").expect("write aegis");
         let err = combine_initrd(&distro, &aegis, &out).expect_err("should fail");
         assert!(err.contains("does-not-exist.img"), "err: {err}");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -9,9 +9,11 @@
 //!     fresh one with ESP (EF00, 400 MB) + `AEGIS_ISOS` (0700, rest).
 //!   * [`format_esp`] — mkfs.fat on partition 1.
 //!   * [`format_data_partition`] — mkfs.exfat on partition 2.
+//!   * [`render_grub_cfg`] — emit the 3-entry rescue-tui menu.
+//!   * [`combine_initrd`] — concat distro initrd + aegis-boot initramfs.
+//!   * [`stage_esp`] — mmd + mcopy the signed chain onto partition 1.
 //!
-//! ESP staging (mcopy of shim / grub / kernel / initrd) and the
-//! signed-manifest attestation land in follow-up PRs under #274 —
+//! The signed-manifest attestation lands in Phase 2c under #274 —
 //! see the epic for the phased rollout.
 //!
 //! **No caller wired up yet.** This is the foundation slice — the
@@ -23,6 +25,7 @@
 #![cfg(target_os = "linux")]
 #![allow(dead_code)]
 
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -131,6 +134,186 @@ pub(crate) fn format_esp(part1_path: &Path) -> Result<(), String> {
 pub(crate) fn format_data_partition(part2_path: &Path) -> Result<(), String> {
     let p = part2_path.display().to_string();
     run_sudo(&["mkfs.exfat", "-L", AEGIS_ISOS_LABEL, &p]).map_err(|e| format!("mkfs.exfat: {e}"))
+}
+
+/// Default grub timeout (seconds). Matches `scripts/mkusb.sh:146`.
+pub(crate) const GRUB_TIMEOUT_SECS: u32 = 3;
+
+/// Default menuentry selected on boot. 0 = tty0-primary rescue (the
+/// right choice for a local-monitor operator). Matches mkusb.sh's
+/// `MKUSB_GRUB_DEFAULT:-0` fallback; direct-install does not expose
+/// the override env var because it's a CLI-driven path and the
+/// equivalent knob will be a `flash --serial-default` flag in Phase 3.
+pub(crate) const GRUB_DEFAULT_ENTRY: u32 = 0;
+
+/// Render the 3-entry rescue-tui grub menu to `out`. Matches the
+/// literal text produced by `scripts/mkusb.sh:145-178` with the
+/// `MKUSB_GRUB_DEFAULT` override defaulted to 0 (the tty0-primary
+/// rescue menuentry).
+///
+/// Kept as a standalone text render rather than a template file so
+/// direct-install stays buildable without an asset directory and the
+/// output is unit-testable on content invariants without file fs.
+pub(crate) fn render_grub_cfg(out: &Path) -> Result<(), String> {
+    let body = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
+    fs::write(out, body).map_err(|e| format!("grub.cfg write {}: {e}", out.display()))
+}
+
+/// Pure builder: returns the grub.cfg body string for the given
+/// timeout + default entry. Split out from [`render_grub_cfg`] so the
+/// content can be asserted in unit tests without touching the fs.
+pub(crate) fn build_grub_cfg_body(timeout_secs: u32, default_entry: u32) -> String {
+    format!(
+        "set timeout={timeout_secs}
+set default={default_entry}
+
+# Normal boot — concise kernel logs.
+# console= order MATTERS: last one wins as /dev/console for userspace.
+menuentry \"aegis-boot rescue\" {{
+    linux /vmlinuz console=ttyS0,115200 console=tty0 panic=5 loglevel=4
+    initrd /initrd.img
+}}
+
+# Serial-primary variant — for operators using a serial console.
+menuentry \"aegis-boot rescue (serial-primary)\" {{
+    linux /vmlinuz console=tty0 console=ttyS0,115200 panic=5 loglevel=4
+    initrd /initrd.img
+}}
+
+# Verbose boot — loglevel=7 + earlyprintk + aegis.verbose=1.
+menuentry \"aegis-boot rescue (verbose — first-boot debug)\" {{
+    linux /vmlinuz console=ttyS0,115200 console=tty0 panic=30 loglevel=7 earlyprintk=efi ignore_loglevel aegis.verbose=1
+    initrd /initrd.img
+}}
+"
+    )
+}
+
+/// Concatenate `distro_initrd || aegis_initrd` into `out`. The kernel
+/// unpacks concatenated cpio archives in order, so the distro's
+/// driver payload is live before the aegis-boot `/init` runs — matches
+/// `scripts/mkusb.sh:114-115`.
+pub(crate) fn combine_initrd(
+    distro_initrd: &Path,
+    aegis_initrd: &Path,
+    out: &Path,
+) -> Result<(), String> {
+    let distro =
+        fs::read(distro_initrd).map_err(|e| format!("read {}: {e}", distro_initrd.display()))?;
+    let aegis =
+        fs::read(aegis_initrd).map_err(|e| format!("read {}: {e}", aegis_initrd.display()))?;
+    let mut combined = Vec::with_capacity(distro.len() + aegis.len());
+    combined.extend_from_slice(&distro);
+    combined.extend_from_slice(&aegis);
+    fs::write(out, &combined).map_err(|e| format!("write {}: {e}", out.display()))?;
+    Ok(())
+}
+
+/// Sources for the signed chain staged onto an ESP partition. Bundled
+/// into a struct rather than passed as 6 positional args so call sites
+/// read as `sources.shim` / `sources.kernel` (and to stay inside the
+/// clippy `too_many_arguments` budget).
+#[derive(Debug, Clone)]
+pub(crate) struct EspStagingSources<'a> {
+    pub shim: &'a Path,
+    pub grub: &'a Path,
+    pub kernel: &'a Path,
+    pub combined_initrd: &'a Path,
+    pub grub_cfg: &'a Path,
+}
+
+/// Canonical ESP destination paths (as mcopy `::/` targets).
+/// Exported as constants so both `stage_esp` and the attestation
+/// manifest in Phase 2c can key off the same closed-list ordering.
+pub(crate) const ESP_DEST_SHIM: &str = "::/EFI/BOOT/BOOTX64.EFI";
+pub(crate) const ESP_DEST_GRUB: &str = "::/EFI/BOOT/grubx64.efi";
+pub(crate) const ESP_DEST_GRUB_CFG_BOOT: &str = "::/EFI/BOOT/grub.cfg";
+pub(crate) const ESP_DEST_GRUB_CFG_UBUNTU: &str = "::/EFI/ubuntu/grub.cfg";
+pub(crate) const ESP_DEST_KERNEL: &str = "::/vmlinuz";
+pub(crate) const ESP_DEST_INITRD: &str = "::/initrd.img";
+
+/// Build the argv for a single mcopy invocation that writes `src` to
+/// `dest` on the FAT32 image or block device at `image_or_dev`.
+///
+/// `--` is inserted before the positional args so that a path
+/// beginning with `-` can't be misread by mcopy as an option flag.
+/// `-D o` means "overwrite destination if it exists" (mkusb.sh relies
+/// on freshly-formatted ESP so there's nothing to overwrite, but
+/// direct-install's idempotent replay path needs this).
+pub(crate) fn build_mcopy_argv(image_or_dev: &str, src: &Path, dest: &str) -> Vec<String> {
+    vec![
+        "mcopy".to_string(),
+        "-i".to_string(),
+        image_or_dev.to_string(),
+        "-D".to_string(),
+        "o".to_string(),
+        "--".to_string(),
+        src.display().to_string(),
+        dest.to_string(),
+    ]
+}
+
+/// Build the argv for `mmd` — creates directories on a FAT image
+/// without failing if they already exist (via `-D s` = skip existing).
+pub(crate) fn build_mmd_argv(image_or_dev: &str, dirs: &[&str]) -> Vec<String> {
+    let mut argv = vec![
+        "mmd".to_string(),
+        "-i".to_string(),
+        image_or_dev.to_string(),
+        "-D".to_string(),
+        "s".to_string(),
+        "--".to_string(),
+    ];
+    for d in dirs {
+        argv.push((*d).to_string());
+    }
+    argv
+}
+
+/// Stage the signed chain onto partition 1 of the target stick.
+///
+/// Calls `mmd` once to create `::/EFI ::/EFI/BOOT ::/EFI/ubuntu`, then
+/// six `mcopy` invocations laying the signed chain down in the layout
+/// required by the firmware + shim + grub:
+///
+/// | destination                | source                         |
+/// | -------------------------- | ------------------------------ |
+/// | `::/EFI/BOOT/BOOTX64.EFI`  | `sources.shim`                 |
+/// | `::/EFI/BOOT/grubx64.efi`  | `sources.grub`                 |
+/// | `::/EFI/BOOT/grub.cfg`     | `sources.grub_cfg`             |
+/// | `::/EFI/ubuntu/grub.cfg`   | `sources.grub_cfg`             |
+/// | `::/vmlinuz`               | `sources.kernel`               |
+/// | `::/initrd.img`            | `sources.combined_initrd`      |
+///
+/// Matches `scripts/mkusb.sh:185-191`.
+///
+/// `part1_dev` is the ESP partition path (e.g. `/dev/sda1`) or, for
+/// test fixtures, a path to a FAT32 image file. mcopy acts on either
+/// transparently. Caller is responsible for having released any
+/// desktop auto-mounts on the device — see the #273 pattern.
+pub(crate) fn stage_esp(part1_dev: &Path, sources: &EspStagingSources<'_>) -> Result<(), String> {
+    let dev = part1_dev.display().to_string();
+
+    // Create ESP directory skeleton (idempotent).
+    let mmd = build_mmd_argv(&dev, &["::/EFI", "::/EFI/BOOT", "::/EFI/ubuntu"]);
+    let mmd_refs: Vec<&str> = mmd.iter().map(String::as_str).collect();
+    run_sudo(&mmd_refs).map_err(|e| format!("mmd: {e}"))?;
+
+    // Six mcopy writes in a fixed order matching mkusb.sh.
+    for (src, dest) in [
+        (sources.shim, ESP_DEST_SHIM),
+        (sources.grub, ESP_DEST_GRUB),
+        (sources.grub_cfg, ESP_DEST_GRUB_CFG_BOOT),
+        (sources.grub_cfg, ESP_DEST_GRUB_CFG_UBUNTU),
+        (sources.kernel, ESP_DEST_KERNEL),
+        (sources.combined_initrd, ESP_DEST_INITRD),
+    ] {
+        let argv = build_mcopy_argv(&dev, src, dest);
+        let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+        run_sudo(&argv_refs).map_err(|e| format!("mcopy {dest}: {e}"))?;
+    }
+
+    Ok(())
 }
 
 /// Run `sudo <argv>` and return Ok if the exit status is success.
@@ -273,5 +456,183 @@ mod tests {
         let argv = build_partition_argv("/dev/sda");
         let n_flags = argv.iter().filter(|a| a.as_str() == "-n").count();
         assert_eq!(n_flags, 2, "expected exactly two -n flags: {argv:?}");
+    }
+
+    // ---- Phase 2b: stage_esp helpers ---------------------------------------
+
+    #[test]
+    fn build_mcopy_argv_starts_with_mcopy_and_minus_i() {
+        let argv = build_mcopy_argv("/dev/sda1", Path::new("/tmp/shim.efi"), ESP_DEST_SHIM);
+        assert_eq!(argv.first().map(String::as_str), Some("mcopy"));
+        assert_eq!(argv.get(1).map(String::as_str), Some("-i"));
+        assert_eq!(argv.get(2).map(String::as_str), Some("/dev/sda1"));
+    }
+
+    #[test]
+    fn build_mcopy_argv_inserts_double_dash_before_positional_args() {
+        // `--` stops mcopy from interpreting a path that starts with
+        // `-` as a flag. Defense against argv-injection on paths we
+        // don't fully control in downstream phases (e.g. a user-named
+        // ISO subfolder in a future direct-install layout).
+        let argv = build_mcopy_argv("/dev/sda1", Path::new("-rogue"), ESP_DEST_SHIM);
+        let dd_idx = argv.iter().position(|a| a == "--").expect("-- delimiter");
+        let src_idx = argv.iter().position(|a| a == "-rogue").expect("src");
+        assert!(dd_idx < src_idx, "`--` must precede the src path: {argv:?}");
+    }
+
+    #[test]
+    fn build_mcopy_argv_uses_overwrite_mode() {
+        // `-D o` = overwrite destination. Idempotent replay requires
+        // this; mkusb.sh doesn't need it because it formats first,
+        // but direct-install's re-stage-on-retry path would otherwise
+        // fail on an existing file.
+        let argv = build_mcopy_argv("/dev/sda1", Path::new("/tmp/x"), "::/x");
+        let d_idx = argv.iter().position(|a| a == "-D").expect("-D flag");
+        assert_eq!(argv.get(d_idx + 1).map(String::as_str), Some("o"));
+    }
+
+    #[test]
+    fn build_mmd_argv_creates_all_requested_dirs() {
+        let argv = build_mmd_argv("/dev/sda1", &["::/EFI", "::/EFI/BOOT", "::/EFI/ubuntu"]);
+        assert_eq!(argv.first().map(String::as_str), Some("mmd"));
+        // `-D s` = skip existing directories so a replay on a
+        // partial-stage doesn't fail on the first `mmd`.
+        let d_idx = argv.iter().position(|a| a == "-D").expect("-D flag");
+        assert_eq!(argv.get(d_idx + 1).map(String::as_str), Some("s"));
+        assert!(argv.iter().any(|a| a == "::/EFI"));
+        assert!(argv.iter().any(|a| a == "::/EFI/BOOT"));
+        assert!(argv.iter().any(|a| a == "::/EFI/ubuntu"));
+    }
+
+    #[test]
+    fn esp_destination_paths_match_mkusb_layout() {
+        // Drift guard — these six paths are the contract between the
+        // ESP staging layer and the firmware + shim + grub chain.
+        // mkusb.sh:186-191 writes to these exact paths. Any change
+        // here without a corresponding change to mkusb.sh (or vice
+        // versa) would produce a stick that doesn't boot.
+        assert_eq!(ESP_DEST_SHIM, "::/EFI/BOOT/BOOTX64.EFI");
+        assert_eq!(ESP_DEST_GRUB, "::/EFI/BOOT/grubx64.efi");
+        assert_eq!(ESP_DEST_GRUB_CFG_BOOT, "::/EFI/BOOT/grub.cfg");
+        assert_eq!(ESP_DEST_GRUB_CFG_UBUNTU, "::/EFI/ubuntu/grub.cfg");
+        assert_eq!(ESP_DEST_KERNEL, "::/vmlinuz");
+        assert_eq!(ESP_DEST_INITRD, "::/initrd.img");
+    }
+
+    #[test]
+    fn build_grub_cfg_body_contains_three_menuentries() {
+        let body = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
+        let count = body.matches("menuentry ").count();
+        assert_eq!(count, 3, "expected exactly 3 menuentries in grub.cfg");
+    }
+
+    #[test]
+    fn build_grub_cfg_body_sets_timeout_and_default() {
+        let body = build_grub_cfg_body(7, 2);
+        assert!(body.starts_with("set timeout=7\n"), "body: {body}");
+        assert!(body.contains("\nset default=2\n"), "body: {body}");
+    }
+
+    #[test]
+    fn build_grub_cfg_body_references_kernel_and_initrd_by_mkusb_paths() {
+        // The kernel and initrd are written to `::/vmlinuz` and
+        // `::/initrd.img` — grub sees them as `/vmlinuz` + `/initrd.img`.
+        // Drift between these paths and the mcopy destinations
+        // (ESP_DEST_KERNEL / ESP_DEST_INITRD) would silently break boot.
+        let body = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
+        assert!(body.contains("linux /vmlinuz"), "body: {body}");
+        assert!(body.contains("initrd /initrd.img"), "body: {body}");
+    }
+
+    #[test]
+    fn build_grub_cfg_body_includes_serial_and_verbose_variants() {
+        // The rescue-tui's screen layout assumes both console orders
+        // are bootable so operators on a serial-only KVM can flip
+        // into the serial-primary entry. The verbose entry is #109's
+        // first-boot debug path. Missing either is a UX regression.
+        let body = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
+        assert!(
+            body.contains("serial-primary"),
+            "missing serial-primary menuentry: {body}"
+        );
+        assert!(
+            body.contains("verbose"),
+            "missing verbose menuentry: {body}"
+        );
+        assert!(
+            body.contains("aegis.verbose=1"),
+            "missing aegis.verbose flag on verbose entry: {body}"
+        );
+    }
+
+    #[test]
+    fn render_grub_cfg_writes_expected_body_to_disk() {
+        let tmp = std::env::temp_dir().join(format!(
+            "aegis-direct-install-grub-cfg-{}.cfg",
+            std::process::id()
+        ));
+        render_grub_cfg(&tmp).expect("render_grub_cfg");
+        let written = std::fs::read_to_string(&tmp).expect("read back grub.cfg");
+        let expected = build_grub_cfg_body(GRUB_TIMEOUT_SECS, GRUB_DEFAULT_ENTRY);
+        assert_eq!(written, expected);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn combine_initrd_concats_distro_then_aegis() {
+        let dir = std::env::temp_dir().join(format!(
+            "aegis-direct-install-combine-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir tmp");
+        let distro = dir.join("distro.img");
+        let aegis = dir.join("aegis.img");
+        let out = dir.join("combined.img");
+
+        std::fs::write(&distro, b"DISTRO_PAYLOAD").expect("write distro");
+        std::fs::write(&aegis, b"AEGIS_PAYLOAD").expect("write aegis");
+        combine_initrd(&distro, &aegis, &out).expect("combine_initrd");
+
+        let got = std::fs::read(&out).expect("read combined");
+        assert_eq!(got, b"DISTRO_PAYLOADAEGIS_PAYLOAD");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn combine_initrd_rejects_missing_input() {
+        let dir = std::env::temp_dir().join(format!(
+            "aegis-direct-install-combine-miss-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir tmp");
+        let distro = dir.join("does-not-exist.img");
+        let aegis = dir.join("aegis.img");
+        let out = dir.join("combined.img");
+
+        std::fs::write(&aegis, b"aegis").expect("write aegis");
+        let err = combine_initrd(&distro, &aegis, &out).expect_err("should fail");
+        assert!(err.contains("does-not-exist.img"), "err: {err}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn esp_staging_sources_is_debug_and_clone() {
+        // The struct is Debug+Clone because Phase 2c's attestation
+        // helpers will capture the staging sources by value; easier
+        // to pass a clone than force lifetime gymnastics through the
+        // signing layer.
+        let p = Path::new("/tmp/x");
+        let s = EspStagingSources {
+            shim: p,
+            grub: p,
+            kernel: p,
+            combined_initrd: p,
+            grub_cfg: p,
+        };
+        let cloned = s.clone();
+        let debug = format!("{cloned:?}");
+        assert!(debug.contains("EspStagingSources"));
     }
 }


### PR DESCRIPTION
## Summary

Phase 2b of epic [#274](https://github.com/williamzujkowski/aegis-boot/issues/274). Continues the Phase 2a foundation (#275) with ESP-staging helpers. **No behaviour change in this PR.** \`#[allow(dead_code)]\` stays at the module level until Phase 3 wires a \`--direct-install\` flag; the flash command still goes through \`mkusb.sh + dd\`.

## What's here

| Helper | Purpose |
|---|---|
| \`build_mcopy_argv\` | pure argv builder; \`--\` delimiter hardens against argv-injection on \`-\`-prefix paths; \`-D o\` makes replay idempotent |
| \`build_mmd_argv\` | pure argv builder; \`-D s\` skips existing dirs so partial-stage replay doesn't fail |
| \`EspStagingSources\` | struct bundling the 6 signed-chain paths — keeps \`stage_esp\` inside clippy's arg budget, lets Phase 2c attestation capture sources by value |
| \`render_grub_cfg\` + \`build_grub_cfg_body\` | 3-menuentry rescue-tui menu (tty0-primary, serial-primary, verbose); content matches \`scripts/mkusb.sh:145-178\` |
| \`combine_initrd\` | concat \`distro_initrd \|\| aegis_initrd\`; the kernel unpacks concatenated cpio archives in order, matching \`mkusb.sh:114-115\` |
| \`stage_esp\` | mmd the EFI skeleton, then 6 mcopy writes in fixed mkusb.sh:186-191 order |

## Drift tests (13 new, 23 total in module)

- 6 assertions pinning the \`::/\` destination paths (firmware + shim + grub chain)
- mcopy / mmd argv shape + \`-D\` replay modes + \`--\` delimiter
- grub.cfg content invariants (3 menuentries, timeout/default, vmlinuz + initrd.img paths, serial-primary + verbose + \`aegis.verbose=1\`)
- \`combine_initrd\` concat ordering + missing-input rejection
- \`EspStagingSources\` Debug + Clone (for Phase 2c capture)

Invariants rather than sha256 on grub.cfg (per reviewer feedback — sha256 is noisy on whitespace churn without catching semantic drift).

## Consensus

Nexus-agents higher_order vote 2026-04-19: **80% approve** (4/5 real votes, supermajority threshold). Reviewer refinements all incorporated:
- PM/architect — content invariants over sha256 pin on grub.cfg
- Contrarian — \`--\` argv delimiter against path-starts-with-\`-\` injection
- Contrarian — bundle 6 stage_esp args into struct (clippy-friendly, Phase 2c capture)

## Test plan

- [x] \`cargo test -p aegis-cli\`: 313 passed (+13)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt --all -- --check\`: clean
- [ ] CI green

## #274 phase map

| Phase | Scope | Status |
|-------|-------|--------|
| 1 | RFC + consensus | ✅ #274 |
| 2a | partition + format foundation | ✅ #275 |
| **2b (this PR)** | **mcopy/mmd argv + grub.cfg render + combine_initrd + stage_esp** | **in review** |
| 2c | signed attestation manifest (per-file sha256 + partition-table hash + closed-list, minisign-signed) | next |
| 3 | \`--direct-install\` flag + OVMF SecBoot E2E + byte-parity diff vs mkusb.sh | after 2a-c |
| 4 | default flip | after E2E green-streak ≥ 10 |
| 5 | deprecate mkusb.sh as flash's image-builder | after default-flip confidence |

Part of [#274](https://github.com/williamzujkowski/aegis-boot/issues/274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)