### PR TITLE
chore(ci): pin semgrep image to 1.160.0 (#253)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,10 @@ jobs:
     name: SAST (semgrep p/rust)
     runs-on: ubuntu-22.04
     container:
-      image: returntocorp/semgrep:latest
+      # Pinned per #253. Latest release known-good as of 2026-04-19; refresh
+      # this pin when a newer semgrep drops the pkg_resources import (the
+      # setuptools 81+ removal leaves `latest` exposed to a sudden break).
+      image: returntocorp/semgrep:1.160.0
     steps:
       - uses: actions/checkout@v5
       - run: semgrep scan --config=p/rust --config=p/security-audit --error --sarif --output semgrep.sarif .


### PR DESCRIPTION
## Summary

Pins \`returntocorp/semgrep:latest\` → \`returntocorp/semgrep:1.160.0\` in the SAST job. Closes the \"pin semgrep version in CI\" bullet of [#253](https://github.com/williamzujkowski/aegis-boot/issues/253).

## Why

\`pkg_resources\` is slated for removal in setuptools 81+ (deadline was 2025-11-30). Semgrep transitively imports it via \`opentelemetry/instrumentation/dependencies.py\`. If the GitHub-hosted runner bumps setuptools past 81 before semgrep ships a clean build, \`:latest\` fails to start and the SAST gate turns into a hard failure or a silent no-op.

## Why 1.160.0

- Released 2026-04-16 (3 days ago)
- What \`:latest\` resolved to on our last 3 green main CI runs (#275 / #276 / #268)
- \`-nonroot\` variant exists for future hardening, but changing container user at the same time as pinning is two changes in one PR — deferred

## Test plan

- [x] \`.github/workflows/ci.yml\` YAML parses (Python \`yaml.safe_load\`)
- [ ] CI green — effectively validates that 1.160.0 still accepts our current rule sets + p/rust + p/security-audit

## Not in this PR

- **Monitoring**: subscribing to semgrep upstream's pkg_resources tracking issue (non-code action)
- **Refresh cadence**: next semgrep version that drops pkg_resources — swap the pin and close #253
- **Other Python CI tools**: \`check-jsonschema\` via \`pipx\` is pure-stdlib per #253, so no exposure there

Keeps #253 open until upstream drops the transitive import and we refresh the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)