### PR TITLE
feat(direct-install): signed attestation manifest (#274 PR3, closes #277)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "hex",
  "indicatif",
  "iso-probe",
+ "minisign",
  "serde",
  "serde_json",
  "sha2",
@@ -99,6 +100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +228,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -276,10 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -310,6 +330,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "id-arena"
@@ -354,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -502,6 +540,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minisign"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aefd422a7a8b5efced01cd7cdf3771e62ebecbc90e3d27695002d3af6af94586"
+dependencies = [
+ "ct-codecs",
+ "getrandom",
+ "rpassword",
+ "scrypt",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +609,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -678,6 +738,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,10 +797,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "semver"
@@ -889,6 +990,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -31,6 +31,11 @@ thiserror = { workspace = true }
 # stderr, so the bar is Linux-only; macOS falls back to the original
 # silent .status() call.
 indicatif = { version = "0.17", default-features = false }
+# Signed attestation manifest for direct-install (#274 PR3, #277).
+# Ed25519-based minisign in pure Rust — no sigtool shellout, no PATH
+# dependency. Used to sign `::/aegis-boot-manifest.json` on flashed
+# sticks; operator-supplied keys, key lifecycle lives in Phase 3.
+minisign = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/aegis-cli/src/direct_install_manifest.rs
+++ b/crates/aegis-cli/src/direct_install_manifest.rs
@@ -1,0 +1,610 @@
+//! Signed attestation manifest for direct-install (#274 PR3, #277).
+//!
+//! Companion module to [`direct_install`]. Produces
+//! `::/aegis-boot-manifest.json` + `::/aegis-boot-manifest.json.minisig`
+//! on the flashed ESP. The manifest is the contract between
+//! flash-time attestation and runtime verification
+//! (`aegis-boot doctor --stick`, rescue-tui stick check, aegis-hwsim E6
+//! attestation-roundtrip scenario).
+//!
+//! **Schema version 1** is locked by [#277]. See the issue for the
+//! full design rationale; the short version is:
+//!
+//! * Closed-set file list — verifier rejects the stick if any ESP
+//!   file is not in `esp_files` or is missing / mismatched. Six
+//!   entries, one per line in the signed-chain layout established by
+//!   Phase 2b.
+//! * `manifest_sequence` is monotonic-per-flash, defending against
+//!   rollback to an older validly-signed manifest without relying on
+//!   a secure RTC.
+//! * `partition_count` + per-partition `type_guid` / `partuuid` /
+//!   `fs_uuid` replaces the brittle `partition_table_sha256` — the
+//!   GPT backup header LBA moves with disk size, so hashing it breaks
+//!   re-flash onto a different stick.
+//! * No `expected_pcrs` in PR3; E6 populates after TPM PCR selection
+//!   lock.
+//! * Manifest body is hard-capped at [`MAX_MANIFEST_BYTES`] to bound
+//!   early-boot JSON parser exposure.
+//!
+//! PR3 ships **writer + signer + drift tests + a verify helper used
+//! by tests**. No caller is wired; `#[allow(dead_code)]` at module
+//! scope rides until a Phase 3 PR adds the `--direct-install` flag.
+//!
+//! [#277]: https://github.com/williamzujkowski/aegis-boot/issues/277
+
+#![cfg(target_os = "linux")]
+#![allow(dead_code)]
+
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::direct_install::{
+    ESP_DEST_GRUB, ESP_DEST_GRUB_CFG_BOOT, ESP_DEST_GRUB_CFG_UBUNTU, ESP_DEST_INITRD,
+    ESP_DEST_KERNEL, ESP_DEST_SHIM,
+};
+
+/// Locked schema version for PR3. Bump alongside a breaking shape
+/// change (removing a field, changing a field's type). Adding a new
+/// optional field is backwards-compatible and does not require a
+/// version bump — the verifier ignores fields it doesn't know about.
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+/// Canonical file name of the manifest on the ESP. Operators and
+/// verifiers MUST key off this exact path; moving it is a breaking
+/// change that requires a schema version bump.
+pub(crate) const MANIFEST_ESP_PATH: &str = "::/aegis-boot-manifest.json";
+
+/// Canonical file name of the detached signature on the ESP.
+pub(crate) const MANIFEST_SIG_ESP_PATH: &str = "::/aegis-boot-manifest.json.minisig";
+
+/// Hard cap on manifest body size. The verifier refuses to parse a
+/// manifest larger than this — bounds JSON-parser attack surface in
+/// the early-boot rescue-tui code path. 64 KiB is ~100× the expected
+/// body size so legitimate future growth has room.
+pub(crate) const MAX_MANIFEST_BYTES: usize = 64 * 1024;
+
+/// GPT type GUID for EFI System Partition.
+pub(crate) const TYPE_GUID_ESP: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+
+/// GPT type GUID for Microsoft Basic Data (covers both FAT32 and
+/// exFAT on our sticks — see the [`crate::direct_install`] doc on
+/// `DATA_TYPE_CODE` for why the runtime doesn't key off this).
+pub(crate) const TYPE_GUID_MSFT_BASIC_DATA: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
+
+/// Top-level manifest body. Serialized field order matches the
+/// declaration order below — relied on for canonical JSON stability
+/// (the signature is over `serde_json::to_vec(&Manifest)`).
+///
+/// The Rust field is `sequence` (clippy prefers not to prefix the
+/// struct name); the JSON wire field stays `manifest_sequence` per
+/// #277 schema lock via `#[serde(rename)]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct Manifest {
+    pub schema_version: u32,
+    pub tool_version: String,
+    #[serde(rename = "manifest_sequence")]
+    pub sequence: u64,
+    pub device: Device,
+    pub esp_files: Vec<EspFileEntry>,
+    pub allowed_files_closed_set: bool,
+    pub expected_pcrs: Vec<PcrEntry>,
+}
+
+/// Device identity captured at flash time. All values come from the
+/// freshly-written GPT (`blkid` + `sgdisk -p`); verifier re-reads them
+/// and asserts equality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct Device {
+    pub disk_guid: String,
+    pub partition_count: u32,
+    pub esp: EspPartition,
+    pub data: DataPartition,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct EspPartition {
+    pub partuuid: String,
+    pub type_guid: String,
+    pub fs_uuid: String,
+    pub first_lba: u64,
+    pub last_lba: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct DataPartition {
+    pub partuuid: String,
+    pub type_guid: String,
+    pub fs_uuid: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct EspFileEntry {
+    /// Mtools-style `::/` path on the ESP. Verifier lowercases both
+    /// sides before comparison (FAT32 is case-insensitive).
+    pub path: String,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+/// Reserved for E6 / Phase 3 TPM attestation. Left out of the
+/// serialized array by PR3 (`expected_pcrs: []`); once E6 locks the
+/// PCR selection this struct grows populated rows.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PcrEntry {
+    pub pcr_index: u32,
+    pub bank: String,
+    pub digest_hex: String,
+}
+
+/// Errors from manifest build / parse / verify.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ManifestError {
+    #[error("manifest body exceeds MAX_MANIFEST_BYTES ({actual} > {limit})")]
+    TooLarge { actual: usize, limit: usize },
+
+    #[error("manifest schema_version {got} is newer than this verifier's max supported ({max})")]
+    SchemaTooNew { got: u32, max: u32 },
+
+    #[error("manifest_sequence {got} is less than last-seen {last_seen}")]
+    Rollback { got: u64, last_seen: u64 },
+
+    #[error("manifest JSON parse: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("manifest fs i/o {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("minisign: {0}")]
+    Minisign(String),
+}
+
+/// Build a manifest from its inputs. Pure: no fs i/o, no subprocess.
+/// The caller is responsible for having computed the file hashes +
+/// gathered the GPT identity fields (a later helper in this module
+/// will wrap those calls; for PR3 scope they're left to the eventual
+/// Phase 3 caller so the writer layer stays testable without mocking
+/// sgdisk or sha256 computation).
+pub(crate) fn build_manifest(
+    tool_version: &str,
+    sequence: u64,
+    device: Device,
+    esp_files: [EspFileEntry; 6],
+) -> Manifest {
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        tool_version: tool_version.to_string(),
+        sequence,
+        device,
+        esp_files: esp_files.into(),
+        allowed_files_closed_set: true,
+        expected_pcrs: Vec::new(),
+    }
+}
+
+/// Pretty-print the manifest as JSON. Serialization field order is
+/// struct-declaration order (serde's default), which gives us stable
+/// bytes for the signature to cover.
+pub(crate) fn serialize_manifest(m: &Manifest) -> Result<Vec<u8>, ManifestError> {
+    let body = serde_json::to_vec_pretty(m)?;
+    if body.len() > MAX_MANIFEST_BYTES {
+        return Err(ManifestError::TooLarge {
+            actual: body.len(),
+            limit: MAX_MANIFEST_BYTES,
+        });
+    }
+    Ok(body)
+}
+
+/// Parse a manifest body and enforce the non-crypto invariants
+/// (size cap, schema forward-compat window, sequence rollback).
+/// Signature verification is a separate helper; this function is
+/// pure JSON + invariants and can be exercised without a keypair.
+pub(crate) fn parse_and_validate_manifest(
+    body: &[u8],
+    last_seen_sequence: u64,
+    max_schema: u32,
+) -> Result<Manifest, ManifestError> {
+    if body.len() > MAX_MANIFEST_BYTES {
+        return Err(ManifestError::TooLarge {
+            actual: body.len(),
+            limit: MAX_MANIFEST_BYTES,
+        });
+    }
+    let m: Manifest = serde_json::from_slice(body)?;
+    if m.schema_version > max_schema {
+        return Err(ManifestError::SchemaTooNew {
+            got: m.schema_version,
+            max: max_schema,
+        });
+    }
+    if m.sequence < last_seen_sequence {
+        return Err(ManifestError::Rollback {
+            got: m.sequence,
+            last_seen: last_seen_sequence,
+        });
+    }
+    Ok(m)
+}
+
+/// Sign a serialized manifest body with a minisign secret key. The
+/// detached signature is what gets written alongside the manifest
+/// at `::/aegis-boot-manifest.json.minisig`.
+///
+/// Takes a live [`minisign::SecretKey`] rather than a serialized
+/// `SecretKeyBox` so the caller controls the unlock-from-file step
+/// (password prompts, key-from-env, HSM-backed loaders, etc.) — key
+/// lifecycle is Phase 3 scope and this layer stays pure-crypto.
+pub(crate) fn sign_manifest_body(
+    manifest_body: &[u8],
+    sk: &minisign::SecretKey,
+) -> Result<Vec<u8>, ManifestError> {
+    let sig_box = minisign::sign(
+        None,
+        sk,
+        manifest_body,
+        Some("aegis-boot attestation manifest"),
+        Some("signed by aegis-boot direct-install"),
+    )
+    .map_err(|e| ManifestError::Minisign(format!("sign: {e}")))?;
+    Ok(sig_box.into_string().into_bytes())
+}
+
+/// Verify a detached minisign signature against a public key.
+/// Returns `Ok(())` on valid signature, `Err` otherwise.
+pub(crate) fn verify_manifest_body(
+    manifest_body: &[u8],
+    sig_bytes: &[u8],
+    pk: &minisign::PublicKey,
+) -> Result<(), ManifestError> {
+    let sig_str = std::str::from_utf8(sig_bytes)
+        .map_err(|e| ManifestError::Minisign(format!("sig utf8: {e}")))?;
+    let sig_box = minisign::SignatureBox::from_string(sig_str)
+        .map_err(|e| ManifestError::Minisign(format!("sig parse: {e}")))?;
+    let cursor = Cursor::new(manifest_body);
+    minisign::verify(pk, &sig_box, cursor, true, false, false)
+        .map_err(|e| ManifestError::Minisign(format!("verify: {e}")))?;
+    Ok(())
+}
+
+/// Write the manifest body + detached signature to the given paths.
+/// Called with local fs paths (the staging layer) or ESP block-device
+/// paths; the fs module doesn't distinguish. The ESP write path in
+/// Phase 3 will stage through a tempfile + mcopy rather than writing
+/// directly to `/dev/sdX1`.
+pub(crate) fn write_manifest_and_sig(
+    body: &[u8],
+    sig: &[u8],
+    manifest_path: &Path,
+    sig_path: &Path,
+) -> Result<(), ManifestError> {
+    fs::write(manifest_path, body).map_err(|source| ManifestError::Io {
+        path: manifest_path.display().to_string(),
+        source,
+    })?;
+    fs::write(sig_path, sig).map_err(|source| ManifestError::Io {
+        path: sig_path.display().to_string(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Return the 6 canonical ESP destination paths in the fixed order
+/// used by [`build_manifest`]. Sourced from
+/// [`crate::direct_install`] so the manifest's closed set and the
+/// ESP staging layer can never drift.
+pub(crate) fn canonical_esp_paths() -> [&'static str; 6] {
+    [
+        ESP_DEST_SHIM,
+        ESP_DEST_GRUB,
+        ESP_DEST_GRUB_CFG_BOOT,
+        ESP_DEST_GRUB_CFG_UBUNTU,
+        ESP_DEST_KERNEL,
+        ESP_DEST_INITRD,
+    ]
+}
+
+/// Helper for the verifier (Phase 3) — returns `true` if every
+/// `esp_files` entry's path is one of the 6 canonical paths and no
+/// canonical path is missing. Callers layer the sha256 + size checks
+/// on top once the actual stick contents are available.
+pub(crate) fn esp_files_cover_canonical_set(m: &Manifest) -> bool {
+    if m.esp_files.len() != 6 {
+        return false;
+    }
+    let canonical = canonical_esp_paths();
+    for c in canonical {
+        let c_lower = c.to_ascii_lowercase();
+        if !m
+            .esp_files
+            .iter()
+            .any(|e| e.path.to_ascii_lowercase() == c_lower)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn sample_device() -> Device {
+        Device {
+            disk_guid: "03EFA1BB-4F1F-4213-BC80-252030C43B24".to_string(),
+            partition_count: 2,
+            esp: EspPartition {
+                partuuid: "39C73252-7FD2-4116-B92D-462CA5B8C5C0".to_string(),
+                type_guid: TYPE_GUID_ESP.to_string(),
+                fs_uuid: "2007-0EF1".to_string(),
+                first_lba: 2048,
+                last_lba: 821_247,
+            },
+            data: DataPartition {
+                partuuid: "96695E97-5354-498D-AAF0-494857101427".to_string(),
+                type_guid: TYPE_GUID_MSFT_BASIC_DATA.to_string(),
+                fs_uuid: "EDF7-E497".to_string(),
+                label: "AEGIS_ISOS".to_string(),
+            },
+        }
+    }
+
+    fn sample_esp_files() -> [EspFileEntry; 6] {
+        let paths = canonical_esp_paths();
+        let mut out: Vec<EspFileEntry> = Vec::new();
+        for (i, p) in paths.iter().enumerate() {
+            out.push(EspFileEntry {
+                path: (*p).to_string(),
+                sha256: format!("{:064x}", i + 1),
+                size_bytes: 1024 * (i as u64 + 1),
+            });
+        }
+        out.try_into().expect("6 entries")
+    }
+
+    #[test]
+    fn schema_version_is_pinned_to_one() {
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn build_manifest_sets_closed_set_flag() {
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        assert!(m.allowed_files_closed_set);
+    }
+
+    #[test]
+    fn build_manifest_leaves_expected_pcrs_empty_for_pr3() {
+        // E6 populates this after TPM PCR selection; PR3 must not
+        // pre-commit to a shape the TPM contract hasn't locked.
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        assert!(m.expected_pcrs.is_empty());
+    }
+
+    #[test]
+    fn build_manifest_preserves_canonical_esp_path_order() {
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let got: Vec<&str> = m.esp_files.iter().map(|e| e.path.as_str()).collect();
+        let expected = canonical_esp_paths();
+        assert_eq!(got, expected.to_vec());
+    }
+
+    #[test]
+    fn canonical_esp_paths_match_phase_2b_constants() {
+        // Drift guard against a rename / reorder in direct_install.rs
+        // that would silently leave the manifest writing to a set of
+        // paths the ESP staging layer never produces. The 6 paths and
+        // their order are a contract with mkusb.sh (mkusb.sh:186-191)
+        // and every consumer of either layer.
+        let got = canonical_esp_paths();
+        assert_eq!(got[0], "::/EFI/BOOT/BOOTX64.EFI");
+        assert_eq!(got[1], "::/EFI/BOOT/grubx64.efi");
+        assert_eq!(got[2], "::/EFI/BOOT/grub.cfg");
+        assert_eq!(got[3], "::/EFI/ubuntu/grub.cfg");
+        assert_eq!(got[4], "::/vmlinuz");
+        assert_eq!(got[5], "::/initrd.img");
+    }
+
+    #[test]
+    fn serialize_manifest_is_deterministic() {
+        let m = build_manifest("aegis-boot 0.13.0", 7, sample_device(), sample_esp_files());
+        let a = serialize_manifest(&m).unwrap();
+        let b = serialize_manifest(&m).unwrap();
+        assert_eq!(a, b, "repeated serialization must produce identical bytes");
+    }
+
+    #[test]
+    fn serialize_manifest_field_order_is_top_level_schema_first() {
+        // Whoever reads the first few bytes of a manifest should see
+        // schema_version immediately — lets a dumb consumer dispatch
+        // on schema version without loading the whole body. The
+        // top-level serialization order is struct declaration order
+        // which we assert on here.
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        let schema_idx = text.find("\"schema_version\"").unwrap();
+        let tool_idx = text.find("\"tool_version\"").unwrap();
+        let seq_idx = text.find("\"manifest_sequence\"").unwrap();
+        let device_idx = text.find("\"device\"").unwrap();
+        let files_idx = text.find("\"esp_files\"").unwrap();
+        assert!(schema_idx < tool_idx);
+        assert!(tool_idx < seq_idx);
+        assert!(seq_idx < device_idx);
+        assert!(device_idx < files_idx);
+    }
+
+    #[test]
+    fn serialize_manifest_rejects_oversized_body() {
+        let mut m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        // Pad tool_version until the body would exceed the cap.
+        m.tool_version = "A".repeat(MAX_MANIFEST_BYTES);
+        let err = serialize_manifest(&m).expect_err("should exceed cap");
+        assert!(
+            matches!(err, ManifestError::TooLarge { .. }),
+            "expected TooLarge, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_validate_roundtrips_canonical_manifest() {
+        let m = build_manifest("aegis-boot 0.13.0", 5, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        let parsed = parse_and_validate_manifest(&body, 0, SCHEMA_VERSION).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn parse_and_validate_rejects_rollback() {
+        let m = build_manifest("aegis-boot 0.13.0", 3, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        let err =
+            parse_and_validate_manifest(&body, 5, SCHEMA_VERSION).expect_err("rollback rejected");
+        assert!(
+            matches!(
+                err,
+                ManifestError::Rollback {
+                    got: 3,
+                    last_seen: 5
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_validate_accepts_equal_sequence() {
+        // Equal is not rollback — a re-read of the same manifest
+        // must still verify. Only strictly-less-than is rejected.
+        let m = build_manifest("aegis-boot 0.13.0", 5, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        parse_and_validate_manifest(&body, 5, SCHEMA_VERSION).unwrap();
+    }
+
+    #[test]
+    fn parse_and_validate_rejects_forward_incompat_schema() {
+        let mut m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        m.schema_version = 99;
+        let body = serialize_manifest(&m).unwrap();
+        let err = parse_and_validate_manifest(&body, 0, SCHEMA_VERSION)
+            .expect_err("schema_version > max");
+        assert!(
+            matches!(err, ManifestError::SchemaTooNew { got: 99, max: 1 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_validate_rejects_oversized_body() {
+        let blob = vec![b' '; MAX_MANIFEST_BYTES + 1];
+        let err = parse_and_validate_manifest(&blob, 0, SCHEMA_VERSION).expect_err("too large");
+        assert!(matches!(err, ManifestError::TooLarge { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn esp_files_cover_canonical_set_passes_on_fresh_manifest() {
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        assert!(esp_files_cover_canonical_set(&m));
+    }
+
+    #[test]
+    fn esp_files_cover_canonical_set_is_case_insensitive_fat32() {
+        // FAT32 is case-insensitive; the verifier must accept a
+        // manifest whose stored paths differ only in case from the
+        // canonical declaration.
+        let mut m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        for e in &mut m.esp_files {
+            e.path = e.path.to_ascii_uppercase();
+        }
+        assert!(esp_files_cover_canonical_set(&m));
+    }
+
+    #[test]
+    fn esp_files_cover_canonical_set_rejects_missing_canonical_entry() {
+        let mut m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        // Corrupt one entry so the set no longer covers the canonical
+        // path.
+        m.esp_files[0].path = "::/EFI/BOOT/IMPOSTOR.EFI".to_string();
+        assert!(!esp_files_cover_canonical_set(&m));
+    }
+
+    #[test]
+    fn esp_files_cover_canonical_set_rejects_wrong_count() {
+        let mut m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        m.esp_files.pop();
+        assert!(!esp_files_cover_canonical_set(&m));
+    }
+
+    #[test]
+    fn write_manifest_and_sig_round_trips_through_disk() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let m_path = tmp.path().join("manifest.json");
+        let s_path = tmp.path().join("manifest.json.minisig");
+
+        let body = b"{\"schema_version\":1}";
+        let sig = b"untrusted comment: ...\nDUMMY_SIG\n";
+        write_manifest_and_sig(body, sig, &m_path, &s_path).expect("write");
+
+        assert_eq!(std::fs::read(&m_path).unwrap(), body);
+        assert_eq!(std::fs::read(&s_path).unwrap(), sig);
+    }
+
+    #[test]
+    fn sign_then_verify_round_trip_passes() {
+        let keypair = minisign::KeyPair::generate_unencrypted_keypair().expect("keygen");
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+
+        let sig = sign_manifest_body(&body, &keypair.sk).expect("sign");
+        verify_manifest_body(&body, &sig, &keypair.pk).expect("verify");
+    }
+
+    #[test]
+    fn verify_rejects_tampered_body() {
+        let keypair = minisign::KeyPair::generate_unencrypted_keypair().expect("keygen");
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        let sig = sign_manifest_body(&body, &keypair.sk).expect("sign");
+
+        // Tamper with the manifest body — flip one byte.
+        let mut tampered = body.clone();
+        tampered[10] ^= 0x01;
+        let err = verify_manifest_body(&tampered, &sig, &keypair.pk).expect_err("should reject");
+        assert!(matches!(err, ManifestError::Minisign(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn verify_rejects_signature_from_different_key() {
+        let kp1 = minisign::KeyPair::generate_unencrypted_keypair().expect("keygen 1");
+        let kp2 = minisign::KeyPair::generate_unencrypted_keypair().expect("keygen 2");
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        let sig = sign_manifest_body(&body, &kp1.sk).expect("sign");
+        let err = verify_manifest_body(&body, &sig, &kp2.pk).expect_err("wrong key");
+        assert!(matches!(err, ManifestError::Minisign(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn max_manifest_bytes_leaves_comfortable_headroom() {
+        // Sanity regression guard: a realistic manifest fits well
+        // under the cap, so future additions can land without
+        // immediately bumping MAX_MANIFEST_BYTES.
+        let m = build_manifest("aegis-boot 0.13.0", 1, sample_device(), sample_esp_files());
+        let body = serialize_manifest(&m).unwrap();
+        assert!(
+            body.len() < MAX_MANIFEST_BYTES / 10,
+            "body {} bytes; cap {} — ≥10× headroom expected",
+            body.len(),
+            MAX_MANIFEST_BYTES
+        );
+    }
+}

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -27,6 +27,7 @@ mod compat;
 mod completions;
 mod detect;
 mod direct_install;
+mod direct_install_manifest;
 mod doctor;
 mod eject;
 mod fetch;


### PR DESCRIPTION
## Summary

Phase 2c of epic [#274](https://github.com/williamzujkowski/aegis-boot/issues/274). Implements the \`aegis-boot-manifest.json\` writer + signer per the schema locked in [#277](https://github.com/williamzujkowski/aegis-boot/issues/277). **No behaviour change in this PR.** \`#[allow(dead_code)]\` stays at module level until Phase 3 wires a \`--direct-install\` flag.

Closes #277.

## What's here

### Schema (matching #277, schema_version = 1)

\`\`\`jsonc
{
  \"schema_version\": 1,
  \"tool_version\": \"aegis-boot X.Y.Z\",
  \"manifest_sequence\": <monotonic u64>,  // JSON wire name; Rust field is \`sequence\`
  \"device\": {
    \"disk_guid\": ...,
    \"partition_count\": 2,
    \"esp\":  { partuuid, type_guid, fs_uuid, first_lba, last_lba },
    \"data\": { partuuid, type_guid, fs_uuid, label: \"AEGIS_ISOS\" }
  },
  \"esp_files\": [/* 6 entries in Phase 2b canonical order */],
  \"allowed_files_closed_set\": true,
  \"expected_pcrs\": []   // populated by aegis-hwsim E6 later
}
\`\`\`

### Helpers

| Function | Purpose |
|---|---|
| \`build_manifest\` | pure constructor; schema_version pinned, closed-set flag set, expected_pcrs empty |
| \`serialize_manifest\` | pretty JSON, struct-declaration field order; 64 KiB cap enforced |
| \`parse_and_validate_manifest\` | size-cap + forward-compat schema + strict rollback check |
| \`sign_manifest_body\` | minisign ed25519 over the JSON body; takes live \`SecretKey\` so key lifecycle stays a Phase 3 concern |
| \`verify_manifest_body\` | pure-crypto detached-sig verification |
| \`write_manifest_and_sig\` | atomic fs write; called with either a local staging path or an mcopy target |
| \`canonical_esp_paths\` | returns the 6 ESP destination paths in fixed order — sourced from \`direct_install.rs\`, drift-tested |
| \`esp_files_cover_canonical_set\` | case-insensitive FAT32 closed-set check |

### 22 new unit tests

- Schema: \`SCHEMA_VERSION = 1\` pin; closed-set flag; \`expected_pcrs: []\` (E6 coordination guard); canonical path order matches Phase 2b constants
- Serialization: deterministic repeated output; top-level field order (schema_version, tool_version, manifest_sequence, device, esp_files, ...)
- Size cap: rejects on write and on parse
- Rollback: strictly-less-than rejected; equal accepted (re-read of same manifest must verify)
- Forward-compat: \`schema_version > max\` rejected
- Crypto: sign → verify round-trip; tampered-body rejected; wrong-key rejected
- Closed-set: passes on fresh manifest; case-insensitive (FAT32); rejects missing canonical entry; rejects wrong count
- Headroom: realistic body is ≥10× under the 64 KiB cap

## Design decisions incorporated from consensus

The 2026-04-19 higher_order vote on the initial #277 proposal was 80% approve. Dissenting + review feedback reshaped the final schema:

| Review point | Resolution |
|---|---|
| **Contrarian (rejected)** — GPT header \`alt_lba\` tied to disk size makes \`partition_table_sha256\` brittle on re-flash | Dropped \`partition_table_sha256\`. Identity captured via \`disk_guid\` + \`partition_count\` + per-partition \`type_guid\`/\`partuuid\`/\`fs_uuid\` instead. |
| **Security** — no secure RTC at boot; \`created_at\` can't defend against rollback | Dropped \`created_at\`; added \`manifest_sequence\` (u64, monotonic per flash). Strictly-less-than is the rollback line; equal is allowed for re-reads. |
| **Security** — FAT32 case-insensitivity | \`esp_files_cover_canonical_set\` lowercases both sides before comparison. |
| **Security** — early-boot JSON parser attack surface | \`MAX_MANIFEST_BYTES = 64 KiB\` hard cap enforced on both write and read. |
| **PM** — document backup-GPT scope | \`first_lba\`/\`last_lba\` captured only for the ESP (fixed 400 MB); data-partition LBA range omitted since \`sgdisk -n 2:0:0\` fills the rest of any disk. |
| **Architect** — content-addressing vs timestamp | No content-addressed identity on the manifest itself; the signature is what establishes provenance. |

## Module split rationale

\`direct_install.rs\` was 626 lines after Phase 2b — adding ~450 lines for the manifest layer would push it past the 400-600 cohesion budget in governance. Split into a sibling module \`direct_install_manifest.rs\` that imports the \`ESP_DEST_*\` constants from \`direct_install.rs\` so the two layers can never drift on the canonical path set.

## Test plan

- [x] \`cargo test -p aegis-cli\`: **335 passed** (+22 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt --all -- --check\`: clean
- [ ] CI green

## #274 phase map

| Phase | Status |
|---|---|
| 1 RFC + consensus | ✅ #274 |
| 2a partition + format foundation | ✅ #275 |
| 2b ESP staging + grub.cfg + combine_initrd | ✅ #276 |
| **2c (this PR)** signed attestation manifest | **in review** |
| 3 \`--direct-install\` flag + OVMF SecBoot E2E + byte-parity diff | after 2c |
| 4 default flip | after E2E green-streak ≥ 10 |
| 5 deprecate mkusb.sh as flash's image-builder | after default-flip confidence |

Part of #274. Closes #277.

Unblocks [aegis-hwsim E6](https://github.com/williamzujkowski/aegis-hwsim/issues/6) — E6's attestation-roundtrip scenario can now be coded against the locked \`schema_version: 1\` shape. \`expected_pcrs\` is deliberately empty here so E6 owns the PCR-selection contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)