### PR TITLE
chore(release): v0.14.1 hotfix — release.yml asset cap + doc drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,17 +124,31 @@ jobs:
           cp crates/rescue-tui/rescue-tui.cdx.json out/sbom.cdx.json
 
       # ---------- Disk image (#235 PR2) ------------------------------
-      # Build the same signed-chain disk image mkusb.yml smoke-tests,
-      # but at mkusb.sh's default size (not the 1 GB CI override) so
-      # the published artifact is the one operators would produce
-      # locally. AEGIS_ISOS ships empty — the stick is ready to `add`
-      # ISOs, not pre-populated; keeps the asset small and avoids
-      # distribution-rights questions around bundling third-party ISOs.
-      # Operators who want `init --profile panic-room` run that step
-      # post-flash against the catalog.
+      # Build the signed-chain disk image as small as we can get away
+      # with. The .img contains GPT + ESP (400 MB signed chain: shim
+      # + grub + kernel + initrd + grub.cfg — real content ~56 MB,
+      # rest is headroom for future kernel growth) + an empty
+      # AEGIS_ISOS data partition. ISOs go onto AEGIS_ISOS POST-flash,
+      # and `flash` already auto-expands AEGIS_ISOS to fill any-size
+      # stick (closes #242) — so shipping a larger empty data
+      # partition in the release .img wastes download bandwidth for
+      # no operator-visible benefit.
+      #
+      # DISK_SIZE_MB=512 → AEGIS_ISOS ~108 MB (mkusb.sh floors at
+      # ESP_SIZE_MB + 32), total .img ~512 MB — ~4x smaller than
+      # the 1900 MB we'd need to stay under GitHub's 2 GiB asset cap
+      # (v0.14.0's first tag hit exactly 2 GiB and the upload
+      # failed with HTTP 422). Fetch time improves commensurately.
+      #
+      # AEGIS_ISOS ships empty — the stick is ready to `add` ISOs,
+      # not pre-populated; avoids distribution-rights questions
+      # around bundling third-party ISOs. Operators who want
+      # `init --profile panic-room` run that step post-flash
+      # against the catalog.
       - name: Build aegis-boot.img via mkusb.sh
         env:
           SOURCE_DATE_EPOCH: "1700000000"
+          DISK_SIZE_MB: "512"
         run: |
           ./scripts/mkusb.sh
           ls -lh out/aegis-boot.img out/aegis-boot.img.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-04-19
+
+### Bug fixes (release-workflow)
+
+- **`release.yml` hits GitHub's 2 GiB asset upload cap + ships a much smaller .img** — v0.14.0's publish step failed at the final asset upload with `HTTP 422 Validation Failed` on `aegis-boot.img`. Root cause: `mkusb.sh`'s default `DISK_SIZE_MB=2048` produces a file exactly at GitHub's 2 GiB release-asset cap (2,147,483,648 bytes). The build + cosign-sign steps succeeded, so the release gained orphaned `aegis-boot.img.sig` + `aegis-boot.img.sha256` assets whose target image wasn't uploaded. Fix: set `DISK_SIZE_MB=512` in `release.yml`. The .img only needs to carry the ESP's signed chain (~56 MB actual payload, 400 MB partition for headroom) + an empty AEGIS_ISOS data partition; operators add ISOs post-flash, and `flash` auto-expands AEGIS_ISOS to fill any-size stick (#242). The previous 2048 MB default shipped ~1644 MB of empty data partition that operators never saw — 512 MB is ~4× smaller, ~4× faster to fetch, same UX.
+
+### Documentation
+
+- **Doc version refs rolled to 0.14.1** — `README.md`, `docs/INSTALL.md`, `docs/CLI.md`, `man/aegis-boot.1`. Motivates the doc-automation tracking issue ([#286](https://github.com/williamzujkowski/aegis-boot/issues/286)) for workspace-level version single-source + CI drift-check.
+
+### Release workflow
+
+- v0.14.0 is left in place on GitHub as a partial release (all non-`.img` assets valid + signed); operators should use v0.14.1.
+
 ## [0.14.0] — 2026-04-19
 
 ### Bug fixes (operator-reported)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "hex",
  "indicatif",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "hex",
  "iso-parser",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "kexec-loader"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libc",
  "thiserror",
@@ -721,7 +721,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "crossterm",
  "hex",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.13.0 — best-in-class push: 5 new operator subcommands (`doctor`, `recommend`, `fetch`, `attest list/show`), cosign-signed prebuilt binaries, install one-liner, Homebrew tap, attestation receipts on every flash. Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.14.0 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-cli"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/aegis-fitness/Cargo.toml
+++ b/crates/aegis-fitness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-fitness"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-parser"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -466,7 +466,7 @@ Every other USB-imaging tool is silent after flash. The attestation receipt is t
 ```json
 {
   "schema_version": 1,
-  "tool_version": "0.13.0",
+  "tool_version": "0.14.1",
   "flashed_at": "2026-04-16T12:34:56Z",
   "operator": "william",
   "host": {
@@ -638,9 +638,9 @@ aegis-boot compat --help
 
 ## Versioning
 
-`aegis-boot --version` reports the workspace version (currently `0.13.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.14.1`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
-`aegis-boot --version --json` emits the same info as a stable envelope — `{ "schema_version": 1, "tool": "aegis-boot", "version": "0.13.0" }` — for scripted install verification or Homebrew-style version matching.
+`aegis-boot --version --json` emits the same info as a stable envelope — `{ "schema_version": 1, "tool": "aegis-boot", "version": "0.14.1" }` — for scripted install verification or Homebrew-style version matching.
 
 ## See also
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,7 +37,7 @@ Option B (Homebrew) auto-installs the Brew-tracked runtime deps (`curl`, `gnupg`
 Sanity check:
 
 ```bash
-aegis-boot --version       # → aegis-boot v0.13.0
+aegis-boot --version       # → aegis-boot v0.14.1
 aegis-boot doctor          # 0–100 health score for host + stick
 ```
 

--- a/man/aegis-boot.1
+++ b/man/aegis-boot.1
@@ -1,4 +1,4 @@
-.TH AEGIS-BOOT 1 "2026-04-17" "aegis-boot 0.13.0" "User Commands"
+.TH AEGIS-BOOT 1 "2026-04-19" "aegis-boot 0.14.1" "User Commands"
 .SH NAME
 aegis-boot \- signed-chain-preserving USB-boot-stick builder and operator CLI
 .SH SYNOPSIS


### PR DESCRIPTION
## Summary

Post-v0.14.0 surfaced a common pattern — 4 docs hardcoded \`v0.13.0\` while \`Cargo.toml\` shipped v0.14.0. Discovered by the nexus-agents doc-inventory subagent run 2026-04-19.

## Files

- \`README.md\` — Status header (prose updated to v0.14.0 headlines: signed \`.img\` release asset, installed-binary UX fix, direct-install foundation)
- \`docs/INSTALL.md\` — \`--version\` example output
- \`docs/CLI.md\` — 2× JSON envelope examples + inline prose
- \`man/aegis-boot.1\` — \`.TH\` header (bumped date too)

## Why it matters

Motivates the doc-automation follow-up — version strings shouldn't require manual sync. Plan to file a tracking issue for:
- Workspace-level version source via \`version.workspace = true\`
- Build-time injection into man page via \`env!(\"CARGO_PKG_VERSION\")\`
- CI drift-check that fails on any \`v[0-9]+\.[0-9]+\.[0-9]+\` in docs that doesn't match \`workspace.package.version\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)