### PR TITLE
feat(docs): workspace version single-source + CI drift-check (Phase 1a+1c of #286, closes #287)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,15 @@ jobs:
             experimental-features = nix-command flakes
       - run: nix flake check --no-build
       - run: nix develop --command cargo --version
+
+  # Doc version drift-check (Phase 1c of #287 / #286).
+  # Reads [workspace.package].version from Cargo.toml and verifies
+  # every aegis-boot-version reference in the user-facing doc
+  # allowlist matches. Prevents the v0.14.0 class of bug where a
+  # release cut shipped 4 docs still saying v0.13.0.
+  doc-version-drift:
+    name: Doc version drift-check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - run: ./scripts/check-doc-version.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ members = [
 exclude = ["crates/iso-parser/fuzz"]
 
 [workspace.package]
+# Single source of truth for the release version (Phase 1a of #286).
+# Each member crate references this via `version.workspace = true`.
+# Release-cut flow: bump this one line + amend CHANGELOG, tag.
+# CI's doc-version drift-check (Phase 1c) greps an allowlist of
+# user-facing doc files and fails if any version literal diverges.
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.14.0 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.14.1 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-cli"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/aegis-fitness/Cargo.toml
+++ b/crates/aegis-fitness/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-fitness"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-parser"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso-probe"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kexec-loader"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rescue-tui"
-version = "0.14.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/scripts/check-doc-version.sh
+++ b/scripts/check-doc-version.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# check-doc-version.sh — drift-guard for aegis-boot version literals in
+# user-facing docs.
+#
+# Single source of truth: `[workspace.package].version` in Cargo.toml.
+# This script reads that once, then checks a small set of **per-file
+# targeted patterns** — each pattern captures a literal that MUST be
+# the current aegis-boot version. Any mismatch is a drift and fails
+# the check.
+#
+# Why per-file patterns (not a broad repo-wide grep): a naive regex
+# like `v?\d+\.\d+\.\d+` flags Rust toolchain version (1.85.0),
+# Ubuntu ISO versions (24.04.2), kernel versions (6.17.0), historical
+# aegis-boot references ("--version v0.12.0"), and forward-looking
+# milestones ("gates v1.0.0"). All false positives.
+#
+# Each pattern below is anchored to text that is aegis-boot-specific
+# AND is expected to always carry the CURRENT version — so a mismatch
+# is always real drift.
+#
+# Exit codes: 0 all good, 1 drift detected, 2 tool error.
+#
+# Wired into CI by `.github/workflows/ci.yml`. Phase 1c of #287.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---- Parse the canonical version from [workspace.package] -------------------
+CANONICAL_VERSION="$(
+    awk '
+        /^\[workspace\.package\]/ { f=1; next }
+        f && /^\[/                 { exit }
+        f && /^version = /         {
+            gsub(/^version = "|"$/, "", $0)
+            print
+            exit
+        }
+    ' Cargo.toml
+)"
+
+if [[ -z "$CANONICAL_VERSION" ]]; then
+    echo "check-doc-version: ERROR — could not parse [workspace.package].version from Cargo.toml" >&2
+    exit 2
+fi
+
+if ! [[ "$CANONICAL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$ ]]; then
+    echo "check-doc-version: ERROR — canonical version '$CANONICAL_VERSION' doesn't match semver shape" >&2
+    exit 2
+fi
+
+echo "check-doc-version: canonical version = $CANONICAL_VERSION"
+
+# ---- Per-file targeted patterns --------------------------------------------
+#
+# Each row: FILE|PATTERN_WITH_@VERSION@|DESCRIPTION
+# The pattern is grep -E (extended regex) with `@VERSION@` substituted
+# to the canonical version at check time. The check succeeds if the
+# pattern (with the canonical version) matches — i.e., the file DOES
+# carry the current version at the expected location.
+#
+# If you add a new doc that references the aegis-boot version, add a
+# row here. If a doc drops a version reference, remove its row.
+#
+# Add with intent: each row should be a reference that MUST match, not
+# MAY match. Don't allowlist speculative patterns.
+PATTERNS=(
+    # README status header: **Status:** v<version> — description...
+    'README.md|\*\*Status:\*\* v@VERSION@|README status header'
+
+    # INSTALL.md --version example output
+    'docs/INSTALL.md|aegis-boot --version[^\n]*aegis-boot v@VERSION@|INSTALL.md --version example'
+
+    # CLI.md: JSON envelope examples use `"version": "X.Y.Z"` and
+    # `"tool_version": "X.Y.Z"` — both are expected to carry the
+    # CURRENT version because they're rendered by `aegis-boot` which
+    # always emits its own CARGO_PKG_VERSION. A follow-up phase will
+    # make these auto-generated; until then, drift-check them.
+    'docs/CLI.md|"version": "@VERSION@"|CLI.md --version JSON envelope'
+    'docs/CLI.md|"tool_version": "@VERSION@"|CLI.md tool_version JSON envelope'
+    'docs/CLI.md|reports the workspace version \(currently `@VERSION@`\)|CLI.md prose'
+
+    # man page .TH header must carry the current version. Phase 1b
+    # (#287 child) replaces this with a build.rs template + @VERSION@
+    # literal; until then, drift-check.
+    'man/aegis-boot.1|"aegis-boot @VERSION@"|man page .TH header'
+)
+
+drift_found=0
+
+for row in "${PATTERNS[@]}"; do
+    IFS='|' read -r file pattern_template description <<< "$row"
+
+    if [[ ! -f "$file" ]]; then
+        echo "check-doc-version: WARN — allowlisted file missing: $file ($description)" >&2
+        continue
+    fi
+
+    # Substitute @VERSION@ to the canonical version.
+    pattern="${pattern_template//@VERSION@/$CANONICAL_VERSION}"
+
+    if ! grep -qE "$pattern" "$file"; then
+        echo "check-doc-version: DRIFT in $file — expected $description to match current version '$CANONICAL_VERSION'" >&2
+        echo "    pattern (with @VERSION@ substituted): $pattern" >&2
+        drift_found=1
+    fi
+done
+
+if [[ "$drift_found" -eq 1 ]]; then
+    echo "check-doc-version: FAIL — doc version drift detected" >&2
+    echo "" >&2
+    echo "Fix: update each flagged file so the named reference matches '$CANONICAL_VERSION'." >&2
+    echo "The workspace version is managed in Cargo.toml [workspace.package] (Phase 1a of #286)." >&2
+    exit 1
+fi
+
+echo "check-doc-version: OK — ${#PATTERNS[@]} patterns checked, all reference $CANONICAL_VERSION"

--- a/scripts/check-doc-version.test.sh
+++ b/scripts/check-doc-version.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# check-doc-version.test.sh — smoke-test that `check-doc-version.sh`
+# (a) passes on the current green tree, and (b) correctly FAILS when
+# a synthetic drift is introduced.
+#
+# Not wired into CI automatically — this tests the tester. Run it
+# after modifying scripts/check-doc-version.sh or adding a new
+# file to its allowlist.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "check-doc-version.test: GREEN path — current tree should pass"
+if "$SCRIPT_DIR/check-doc-version.sh" > /dev/null; then
+    echo "  PASS — checker reports OK on current tree"
+else
+    echo "  FAIL — checker reports drift on current tree (fix that first before testing the tester)" >&2
+    exit 1
+fi
+
+echo "check-doc-version.test: RED path — synthetic drift must be caught"
+BACKUP="$(mktemp)"
+cp README.md "$BACKUP"
+# Append a fake Status line with a drifted version. Sed the existing
+# line rather than append so the test simulates the actual failure
+# mode (drift of an existing reference, not addition of a new one).
+sed -i 's|\*\*Status:\*\* v[0-9.]*|**Status:** v99.99.99|' README.md
+if "$SCRIPT_DIR/check-doc-version.sh" > /dev/null 2>&1; then
+    # Checker passed on a drifted tree — that's a bug in the checker.
+    echo "  FAIL — checker did NOT catch the synthetic drift to v99.99.99" >&2
+    cp "$BACKUP" README.md
+    rm "$BACKUP"
+    exit 1
+fi
+cp "$BACKUP" README.md
+rm "$BACKUP"
+echo "  PASS — checker caught the synthetic drift and exited non-zero"
+
+echo "check-doc-version.test: all tests passed"


### PR DESCRIPTION
## Summary

Two slices of [#286](https://github.com/williamzujkowski/aegis-boot/issues/286)'s doc-automation rollout, combined into one PR because they're tightly coupled — the drift-check reads the version from the workspace config.

Closes [#287](https://github.com/williamzujkowski/aegis-boot/issues/287).

## 1a — \`[workspace.package].version\`

- \`Cargo.toml\` top-level: \`[workspace.package]\` gains \`version = \"0.14.1\"\`
- Each of the 6 crates swaps \`version = \"0.14.1\"\` → \`version.workspace = true\`
- Same resolved version; release-cut bumps are now a **one-line edit** instead of six

## 1c — CI drift-check

### \`scripts/check-doc-version.sh\`

Parses \`[workspace.package].version\` from \`Cargo.toml\`, then checks **6 per-file targeted patterns** across 4 allowlisted docs. Each pattern captures a literal that MUST equal the current aegis-boot version.

| File | Pattern (with @VERSION@ → canonical) | Why |
|---|---|---|
| \`README.md\` | \`**Status:** v@VERSION@\` | Status header prose |
| \`docs/INSTALL.md\` | \`aegis-boot --version ... aegis-boot v@VERSION@\` | \`--version\` example output |
| \`docs/CLI.md\` | \`\"version\": \"@VERSION@\"\` | JSON envelope example |
| \`docs/CLI.md\` | \`\"tool_version\": \"@VERSION@\"\` | attestation JSON example |
| \`docs/CLI.md\` | \`reports the workspace version (currently \\\`@VERSION@\\\`)\` | prose |
| \`man/aegis-boot.1\` | \`\"aegis-boot @VERSION@\"\` | \`.TH\` header |

### Why per-file patterns

A naive repo-wide \`v?\\d+\\.\\d+\\.\\d+\` regex, run against the current tree, caught:
- Rust toolchain version (\`1.85.0\`)
- Ubuntu ISO version (\`24.04.2\`)
- Alpine ISO version (\`3.20.3\`)
- Linux kernel (\`6.17.0\`)
- Legitimate historical reference (\`install.sh --version v0.12.0\`)
- Future-milestone reference (\`gates v1.0.0\`)

All false positives. PM + contrarian flagged this class of issue in the #286 consensus review; per-file targeted patterns fix it.

### \`scripts/check-doc-version.test.sh\`

Tests the tester. Two paths:
1. **GREEN** — run checker on current tree, expect exit 0
2. **RED** — sed-inject a synthetic drift (\`**Status:** v99.99.99\`), expect checker to exit non-zero, then restore the backup

Not wired to CI; run after modifying the checker or adding to its allowlist.

### CI wiring

New job \`doc-version-drift\` in \`.github/workflows/ci.yml\`:
\`\`\`yaml
doc-version-drift:
  name: Doc version drift-check
  runs-on: ubuntu-22.04
  steps:
    - uses: actions/checkout@v5
    - run: ./scripts/check-doc-version.sh
\`\`\`

## Validated against the real failure mode

First run against the current tree caught **real drift** — \`README.md\` still said \`v0.14.0\` in the Status header after the v0.14.1 hotfix (my own miss in the earlier drift-fix). The checker's RED path is the best validation: it found the thing I missed.

## Test plan

- [x] \`cargo build\`: all 6 crates green with \`version.workspace = true\`
- [x] \`cargo test\`: all pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean
- [x] \`cargo fmt --all -- --check\`: clean
- [x] \`./scripts/check-doc-version.sh\`: passes
- [x] \`./scripts/check-doc-version.test.sh\`: both GREEN + RED paths verified
- [ ] CI green (includes the new drift-check job)

## Not in this PR

- **Phase 1b** (build.rs man-page templating) — follows as its own PR, tracked in #287 remaining scope
- **Phase 2** (constants registry) → #288
- **Phases 3–7** → #289 / #290 / #291 / #292 / #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)