### PR TITLE
feat(docs): shared constants registry + drift-check (Phase 2 of #286, closes #288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,18 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: ./scripts/check-doc-version.sh
+
+  # Shared-constants drift-check (Phase 2 of #288 / #286).
+  # Runs the `constants-docgen` binary in --check mode. Fails if
+  # running `--write` would change any target doc. Prevents docs
+  # from drifting out of sync with numeric values they reference
+  # (ESP_SIZE_MB, readback window, manifest size cap, grub timeout).
+  constants-drift:
+    name: Doc constants drift-check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p aegis-cli --bin constants-docgen --features docgen --locked -- --check

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -11,6 +11,21 @@ description = "Operator CLI for aegis-boot — flash, add, list, verify"
 name = "aegis-boot"
 path = "src/main.rs"
 
+# Doc-drift tool: renders shared constants from `src/constants.rs`
+# into HTML-marker regions in the user-facing docs. Feature-gated so
+# the normal release binary does not pull the walkdir dep.
+# Phase 2 of #286.
+[[bin]]
+name = "constants-docgen"
+path = "src/bin/constants_docgen.rs"
+required-features = ["docgen"]
+
+[features]
+# Gates the `constants-docgen` bin target so the normal release
+# `aegis-boot` binary does not compile the doc-rendering code path.
+# Pure stdlib — no extra deps pulled in.
+docgen = []
+
 [dependencies]
 serde = { workspace = true }
 serde_json = "1.0"

--- a/crates/aegis-cli/src/bin/constants_docgen.rs
+++ b/crates/aegis-cli/src/bin/constants_docgen.rs
@@ -1,0 +1,462 @@
+//! `constants-docgen` — renders values from [`crate::constants`] into
+//! HTML-marker regions in the user-facing docs.
+//!
+//! Phase 2 of [#286]. Prevents the class of drift where a numeric
+//! value in prose (e.g. "ESP is sized at 400 MB") goes stale because
+//! the code value changed but the doc didn't.
+//!
+//! ## Contract
+//!
+//! Target docs contain marker pairs:
+//!
+//! ```text
+//! <!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->
+//! ```
+//!
+//! This tool walks a fixed list of target doc files, finds each pair,
+//! and **replaces the text between the markers** with the current
+//! registered value for that name. The markers themselves are
+//! preserved verbatim — adding or removing markers is a manual edit.
+//!
+//! ## Modes
+//!
+//! - `--write` (default): rewrite each target file in place.
+//! - `--check`: compute what `--write` would produce, diff against
+//!   the committed file, and exit non-zero if any file would change.
+//!   Used by CI to enforce drift-freedom.
+//!
+//! ## Source-of-truth note
+//!
+//! Both this binary and the main `aegis-boot` binary compile from
+//! `crates/aegis-cli/src/constants.rs` — the constants file is
+//! `#[path]`-included below so the two bins share the same const
+//! values without a workspace library crate. If the include line
+//! is ever broken, the two bins will disagree silently; a small
+//! contract test in `constants::tests` pins one known value at
+//! compile time to guard against that.
+//!
+//! [#286]: https://github.com/williamzujkowski/aegis-boot/issues/286
+
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+#[path = "../constants.rs"]
+mod constants;
+
+use constants::{DEFAULT_READBACK_BYTES, ESP_SIZE_MB, GRUB_TIMEOUT_SECS, MAX_MANIFEST_BYTES};
+
+/// A single marker registered with its formatted display value.
+struct Marker {
+    /// The name that appears inside `<!-- constants:BEGIN:NAME -->`.
+    name: &'static str,
+    /// The rendered text that appears between BEGIN and END markers.
+    value: String,
+}
+
+/// Registered marker names + their current rendered values.
+///
+/// Adding a new marker: append to this list, then wrap the target
+/// doc's value with `<!-- constants:BEGIN:NAME -->...<!-- constants:END:NAME -->`.
+fn registry() -> Vec<Marker> {
+    vec![
+        Marker {
+            name: "ESP_SIZE_MB",
+            value: format!("{ESP_SIZE_MB} MB"),
+        },
+        Marker {
+            name: "READBACK_WINDOW",
+            value: format!("{} MB", DEFAULT_READBACK_BYTES / (1024 * 1024)),
+        },
+        Marker {
+            name: "MAX_MANIFEST_SIZE",
+            value: format!("{} KiB", MAX_MANIFEST_BYTES / 1024),
+        },
+        Marker {
+            name: "GRUB_TIMEOUT_SECS",
+            value: format!("{GRUB_TIMEOUT_SECS}"),
+        },
+    ]
+}
+
+/// Fixed list of doc files this tool may rewrite. Hard-coded rather
+/// than a `walkdir` scan so the scope is explicit and an unrelated
+/// file containing stray marker syntax can't be accidentally
+/// rewritten.
+fn target_files(repo_root: &Path) -> Vec<PathBuf> {
+    ["docs/ARCHITECTURE.md", "docs/USB_LAYOUT.md", "docs/TOUR.md"]
+        .iter()
+        .map(|p| repo_root.join(p))
+        .collect()
+}
+
+/// Replace the body of every registered marker pair in `input`
+/// with the current rendered value. Returns the rewritten string
+/// plus a count of pair-replacements actually performed (used to
+/// detect marker/registry drift).
+fn apply_markers(input: &str, markers: &[Marker]) -> (String, usize) {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    let mut replacements = 0usize;
+    let bytes = input.as_bytes();
+
+    while let Some(begin_abs) = find_from(bytes, cursor, b"<!-- constants:BEGIN:") {
+        // Copy the portion before BEGIN as-is, including the BEGIN
+        // marker itself (we rewrite only the region between markers).
+        let Some(close_idx) = find_from(bytes, begin_abs, b"-->") else {
+            // Malformed BEGIN without closing `-->`; leave rest untouched.
+            break;
+        };
+        let after_begin_tag = close_idx + 3;
+        let Some(name) = marker_name(&input[begin_abs..after_begin_tag]) else {
+            // Malformed marker name; emit verbatim and move on.
+            out.push_str(&input[cursor..after_begin_tag]);
+            cursor = after_begin_tag;
+            continue;
+        };
+        let end_tag = format!("<!-- constants:END:{name} -->");
+        let Some(end_abs) = find_from(bytes, after_begin_tag, end_tag.as_bytes()) else {
+            // Unclosed BEGIN; leave rest untouched.
+            break;
+        };
+
+        out.push_str(&input[cursor..after_begin_tag]);
+        if let Some(m) = markers.iter().find(|m| m.name == name) {
+            out.push_str(&m.value);
+            replacements += 1;
+        } else {
+            // Unknown marker name: preserve the existing content
+            // rather than deleting it, but don't count it as a
+            // successful replacement.
+            out.push_str(&input[after_begin_tag..end_abs]);
+        }
+        out.push_str(&end_tag);
+        cursor = end_abs + end_tag.len();
+    }
+
+    out.push_str(&input[cursor..]);
+    (out, replacements)
+}
+
+/// Extract `NAME` from a `<!-- constants:BEGIN:NAME -->` tag.
+fn marker_name(begin_tag: &str) -> Option<&str> {
+    let prefix = "<!-- constants:BEGIN:";
+    let suffix = " -->";
+    let inner = begin_tag.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    if inner.is_empty() || !inner.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(inner)
+}
+
+fn find_from(haystack: &[u8], start: usize, needle: &[u8]) -> Option<usize> {
+    if start > haystack.len() {
+        return None;
+    }
+    haystack[start..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|p| start + p)
+}
+
+enum Mode {
+    Write,
+    Check,
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode, String> {
+    match args
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] | ["--write"] => Ok(Mode::Write),
+        ["--check"] => Ok(Mode::Check),
+        _ => Err(format!(
+            "usage: constants-docgen [--write|--check]  (got: {args:?})"
+        )),
+    }
+}
+
+/// Locate the repo root by walking up from `start` looking for a
+/// top-level `Cargo.toml` that contains `[workspace]`. Mirrors the
+/// pattern used by `scripts/check-doc-version.sh`.
+fn find_repo_root(start: &Path) -> Result<PathBuf, String> {
+    let mut cur = start;
+    loop {
+        let candidate = cur.join("Cargo.toml");
+        if candidate.is_file() {
+            if let Ok(body) = fs::read_to_string(&candidate) {
+                if body.contains("[workspace]") {
+                    return Ok(cur.to_path_buf());
+                }
+            }
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => {
+                return Err(format!(
+                    "constants-docgen: could not find workspace root Cargo.toml walking up from {}",
+                    start.display()
+                ));
+            }
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let mode = match parse_mode(&args) {
+        Ok(m) => m,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let markers = registry();
+    let cwd = match env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("constants-docgen: cannot read CWD: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let repo_root = match find_repo_root(&cwd) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let mut drift_files: Vec<PathBuf> = Vec::new();
+    let mut total_replacements = 0usize;
+
+    for path in target_files(&repo_root) {
+        let body = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("constants-docgen: cannot read {}: {e}", path.display());
+                return ExitCode::from(2);
+            }
+        };
+        let (rendered, n) = apply_markers(&body, &markers);
+        total_replacements += n;
+
+        match mode {
+            Mode::Write => {
+                if rendered == body {
+                    println!("unchanged {} ({n} markers)", path.display());
+                } else {
+                    if let Err(e) = fs::write(&path, &rendered) {
+                        eprintln!("constants-docgen: cannot write {}: {e}", path.display());
+                        return ExitCode::from(2);
+                    }
+                    println!("updated {} ({n} markers)", path.display());
+                }
+            }
+            Mode::Check => {
+                if rendered != body {
+                    drift_files.push(path.clone());
+                    eprintln!(
+                        "drift: {} would change ({n} markers render differently than committed)",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    match mode {
+        Mode::Write => {
+            println!(
+                "constants-docgen: wrote {} target files, {total_replacements} total markers rendered",
+                target_files(&repo_root).len()
+            );
+            ExitCode::SUCCESS
+        }
+        Mode::Check => {
+            if drift_files.is_empty() {
+                println!(
+                    "constants-docgen: OK — {total_replacements} markers across {} files all match registry",
+                    target_files(&repo_root).len()
+                );
+                ExitCode::SUCCESS
+            } else {
+                eprintln!();
+                eprintln!(
+                    "constants-docgen: FAIL — {} file(s) diverge from the constants registry.",
+                    drift_files.len()
+                );
+                eprintln!(
+                    "Fix: run `cargo run -p aegis-cli --bin constants-docgen --features docgen` locally and commit the result."
+                );
+                ExitCode::from(1)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_markers() -> Vec<Marker> {
+        vec![
+            Marker {
+                name: "ESP_SIZE_MB",
+                value: "400 MB".to_string(),
+            },
+            Marker {
+                name: "READBACK_WINDOW",
+                value: "64 MB".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn apply_markers_replaces_body_between_tags() {
+        let input = "ESP is sized at <!-- constants:BEGIN:ESP_SIZE_MB -->STALE<!-- constants:END:ESP_SIZE_MB --> on disk.";
+        let (out, n) = apply_markers(input, &fixture_markers());
+        assert_eq!(n, 1);
+        assert!(
+            out.contains(
+                "<!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->"
+            ),
+            "out: {out}"
+        );
+    }
+
+    #[test]
+    fn apply_markers_preserves_tags_verbatim() {
+        let input = "<!-- constants:BEGIN:ESP_SIZE_MB -->X<!-- constants:END:ESP_SIZE_MB -->";
+        let (out, _) = apply_markers(input, &fixture_markers());
+        assert!(out.starts_with("<!-- constants:BEGIN:ESP_SIZE_MB -->"));
+        assert!(out.ends_with("<!-- constants:END:ESP_SIZE_MB -->"));
+    }
+
+    #[test]
+    fn apply_markers_handles_multiple_pairs() {
+        let input = "A <!-- constants:BEGIN:ESP_SIZE_MB -->a<!-- constants:END:ESP_SIZE_MB --> B <!-- constants:BEGIN:READBACK_WINDOW -->b<!-- constants:END:READBACK_WINDOW --> C";
+        let (out, n) = apply_markers(input, &fixture_markers());
+        assert_eq!(n, 2);
+        assert!(out.contains("-->400 MB<!--"));
+        assert!(out.contains("-->64 MB<!--"));
+    }
+
+    #[test]
+    fn apply_markers_leaves_unknown_name_body_untouched() {
+        let input =
+            "<!-- constants:BEGIN:UNKNOWN_MARKER -->dont-touch<!-- constants:END:UNKNOWN_MARKER -->";
+        let (out, n) = apply_markers(input, &fixture_markers());
+        assert_eq!(n, 0);
+        assert_eq!(out, input, "unknown marker body should be preserved");
+    }
+
+    #[test]
+    fn apply_markers_idempotent() {
+        let input =
+            "val: <!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->";
+        let (first, _) = apply_markers(input, &fixture_markers());
+        let (second, _) = apply_markers(&first, &fixture_markers());
+        assert_eq!(first, second, "second render must equal first");
+    }
+
+    #[test]
+    fn apply_markers_ignores_unclosed_begin_tag() {
+        let input = "trailing <!-- constants:BEGIN:ESP_SIZE_MB --> unclosed";
+        let (out, n) = apply_markers(input, &fixture_markers());
+        assert_eq!(n, 0);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn marker_name_parses_valid_begin_tag() {
+        assert_eq!(
+            marker_name("<!-- constants:BEGIN:ESP_SIZE_MB -->"),
+            Some("ESP_SIZE_MB")
+        );
+    }
+
+    #[test]
+    fn marker_name_rejects_empty_name() {
+        assert_eq!(marker_name("<!-- constants:BEGIN: -->"), None);
+    }
+
+    #[test]
+    fn marker_name_rejects_non_alnum_chars() {
+        assert_eq!(marker_name("<!-- constants:BEGIN:has space -->"), None);
+        assert_eq!(marker_name("<!-- constants:BEGIN:has-dash -->"), None);
+    }
+
+    #[test]
+    fn parse_mode_defaults_to_write() {
+        assert!(matches!(parse_mode(&[]), Ok(Mode::Write)));
+        assert!(matches!(
+            parse_mode(&["--write".to_string()]),
+            Ok(Mode::Write)
+        ));
+    }
+
+    #[test]
+    fn parse_mode_accepts_check() {
+        assert!(matches!(
+            parse_mode(&["--check".to_string()]),
+            Ok(Mode::Check)
+        ));
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown() {
+        assert!(parse_mode(&["--whatever".to_string()]).is_err());
+        assert!(parse_mode(&["--write".to_string(), "extra".to_string()]).is_err());
+    }
+
+    #[test]
+    fn registry_contains_all_shared_constants() {
+        let r = registry();
+        let names: Vec<&str> = r.iter().map(|m| m.name).collect();
+        assert!(names.contains(&"ESP_SIZE_MB"));
+        assert!(names.contains(&"READBACK_WINDOW"));
+        assert!(names.contains(&"MAX_MANIFEST_SIZE"));
+        assert!(names.contains(&"GRUB_TIMEOUT_SECS"));
+    }
+
+    #[test]
+    fn registry_values_match_constants() {
+        let r = registry();
+        let find = |n: &str| r.iter().find(|m| m.name == n).map(|m| m.value.clone());
+        assert_eq!(find("ESP_SIZE_MB"), Some(format!("{ESP_SIZE_MB} MB")));
+        assert_eq!(
+            find("READBACK_WINDOW"),
+            Some(format!("{} MB", DEFAULT_READBACK_BYTES / (1024 * 1024)))
+        );
+        assert_eq!(
+            find("MAX_MANIFEST_SIZE"),
+            Some(format!("{} KiB", MAX_MANIFEST_BYTES / 1024))
+        );
+        assert_eq!(
+            find("GRUB_TIMEOUT_SECS"),
+            Some(format!("{GRUB_TIMEOUT_SECS}"))
+        );
+    }
+
+    /// Compile-time sanity: the constants module included via
+    /// `#[path]` must be the same file the main binary compiles
+    /// against. If this test's expectation ever drifts from the
+    /// real value in `src/constants.rs`, it's a sign the include
+    /// path is wrong or the constant was changed without
+    /// regenerating docs.
+    #[test]
+    fn included_constants_match_known_values() {
+        assert_eq!(ESP_SIZE_MB, 400);
+        assert_eq!(DEFAULT_READBACK_BYTES, 64 * 1024 * 1024);
+        assert_eq!(MAX_MANIFEST_BYTES, 64 * 1024);
+        assert_eq!(GRUB_TIMEOUT_SECS, 3);
+    }
+}

--- a/crates/aegis-cli/src/bin/constants_docgen.rs
+++ b/crates/aegis-cli/src/bin/constants_docgen.rs
@@ -209,6 +209,10 @@ fn find_repo_root(start: &Path) -> Result<PathBuf, String> {
 }
 
 fn main() -> ExitCode {
+    // Devtool — args are flag names (`--write` / `--check`) only,
+    // not security keys. argv[0] is dropped via `skip(1)`. Same
+    // rationale as the main aegis-boot binary.
+    // nosemgrep: rust.lang.security.args.args
     let args: Vec<String> = env::args().skip(1).collect();
     let mode = match parse_mode(&args) {
         Ok(m) => m,

--- a/crates/aegis-cli/src/constants.rs
+++ b/crates/aegis-cli/src/constants.rs
@@ -1,0 +1,64 @@
+//! Shared numeric constants that appear in BOTH source code AND
+//! user-facing documentation.
+//!
+//! Phase 2 of [#286]. The v0.14.0 release cut surfaced that
+//! hand-copied numbers between code and prose drift silently. This
+//! module is the single home for the **numeric value** of each such
+//! constant; the owning subsystem (partitioning, readback,
+//! attestation, bootloader) re-exports the constant via
+//! `pub(crate) use crate::constants::NAME` so call sites read
+//! naturally (`direct_install::ESP_SIZE_MB`) and `grep`-archaeology
+//! for a specific number lands in one file.
+//!
+//! ## Adding a new shared constant
+//!
+//! 1. Add a `pub(crate) const` here with a comment explaining the
+//!    value's rationale.
+//! 2. `pub(crate) use crate::constants::NAME;` in the owning module.
+//! 3. Register it in [`crates/aegis-cli/src/bin/constants_docgen.rs`]
+//!    so docs regenerate from it.
+//! 4. Wrap the value in the target docs with HTML markers:
+//!    `<!-- constants:BEGIN:NAME -->...<!-- constants:END:NAME -->`
+//! 5. Run `cargo run -p aegis-cli --bin constants-docgen
+//!    --features docgen -- --write` to render the markers.
+//!
+//! ## Not included here
+//!
+//! Per-subsystem *contract* versions (`attest::SCHEMA_VERSION`,
+//! `direct_install_manifest::SCHEMA_VERSION`) stay in their owning
+//! modules. They are independent wire-format versions, not shared
+//! infrastructure values — merging them would fuse two contracts
+//! that must be bumpable independently.
+//!
+//! [#286]: https://github.com/williamzujkowski/aegis-boot/issues/286
+
+// NOTE: this file is `#[path]`-included by
+// `crates/aegis-cli/src/bin/constants_docgen.rs` so the docgen can
+// import the numeric values without going through a library target.
+// Keep this file dependency-free (no `use` statements, no imports)
+// so the include stays a self-contained compilation unit.
+
+/// ESP partition size in megabytes. Matches `scripts/mkusb.sh`'s
+/// `ESP_SIZE_MB` default. 400 MB is enough for the signed chain
+/// (shim ~1 MB, grub ~2 MB, kernel ~15 MB, initrd ~60 MB) plus
+/// comfortable headroom for future binary growth.
+pub(crate) const ESP_SIZE_MB: u64 = 400;
+
+/// Default number of bytes to read back after a write (post-flash
+/// integrity check). Sized to comfortably cover the signed-chain
+/// payload (shim + grub + kernel + initramfs ≈ 50 MB) with margin,
+/// while keeping the readback under ~10 s on a slow USB 2.0 stick
+/// (~7 MB/s).
+pub(crate) const DEFAULT_READBACK_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Hard cap on attestation-manifest body size. The verifier refuses
+/// to parse a manifest larger than this — bounds the JSON-parser
+/// attack surface in the early-boot rescue-tui code path. 64 KiB is
+/// ~100× the expected body size so legitimate future growth has room.
+pub(crate) const MAX_MANIFEST_BYTES: usize = 64 * 1024;
+
+/// GRUB menu timeout in seconds. Short enough that an interactive
+/// user doesn't wait, long enough that an operator who wants to
+/// interrupt the default boot can do so. Matches the value baked
+/// into the rendered `grub.cfg` on the ESP.
+pub(crate) const GRUB_TIMEOUT_SECS: u32 = 3;

--- a/crates/aegis-cli/src/constants.rs
+++ b/crates/aegis-cli/src/constants.rs
@@ -38,10 +38,20 @@
 // Keep this file dependency-free (no `use` statements, no imports)
 // so the include stays a self-contained compilation unit.
 
+// Several of these constants are consumed by Linux-only modules
+// (`direct_install`, `direct_install_manifest`) that are cfg-gated
+// out on macOS/Windows. The `#[cfg_attr(not(target_os = "linux"),
+// allow(dead_code))]` attribute silences the dead-code warning on
+// non-Linux cross-compile targets without suppressing it on the
+// primary Linux target — a genuine unused constant on Linux is still
+// a signal. The docgen bin (`--features docgen`) references them on
+// every target, but CI cross-checks don't build that feature.
+
 /// ESP partition size in megabytes. Matches `scripts/mkusb.sh`'s
 /// `ESP_SIZE_MB` default. 400 MB is enough for the signed chain
 /// (shim ~1 MB, grub ~2 MB, kernel ~15 MB, initrd ~60 MB) plus
 /// comfortable headroom for future binary growth.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) const ESP_SIZE_MB: u64 = 400;
 
 /// Default number of bytes to read back after a write (post-flash
@@ -55,10 +65,12 @@ pub(crate) const DEFAULT_READBACK_BYTES: u64 = 64 * 1024 * 1024;
 /// to parse a manifest larger than this — bounds the JSON-parser
 /// attack surface in the early-boot rescue-tui code path. 64 KiB is
 /// ~100× the expected body size so legitimate future growth has room.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) const MAX_MANIFEST_BYTES: usize = 64 * 1024;
 
 /// GRUB menu timeout in seconds. Short enough that an interactive
 /// user doesn't wait, long enough that an operator who wants to
 /// interrupt the default boot can do so. Matches the value baked
 /// into the rendered `grub.cfg` on the ESP.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) const GRUB_TIMEOUT_SECS: u32 = 3;

--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -29,11 +29,12 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-/// ESP partition size in megabytes. Matches `scripts/mkusb.sh`'s
-/// `ESP_SIZE_MB` default. 400 MB is enough for the signed chain
-/// (shim ~1 MB, grub ~2 MB, kernel ~15 MB, initrd ~60 MB) plus
-/// comfortable headroom for future binary growth.
-pub(crate) const ESP_SIZE_MB: u64 = 400;
+/// Re-export the ESP partition size from the shared constants
+/// registry. See [`crate::constants::ESP_SIZE_MB`] for the rationale
+/// and [#286] for the single-source-of-truth pattern this implements.
+///
+/// [#286]: https://github.com/williamzujkowski/aegis-boot/issues/286
+pub(crate) use crate::constants::ESP_SIZE_MB;
 
 /// Label for the data partition. Keyed on by rescue-tui's ISO
 /// discovery + by `aegis-boot list` / `add` mount recovery. Must
@@ -136,8 +137,9 @@ pub(crate) fn format_data_partition(part2_path: &Path) -> Result<(), String> {
     run_sudo(&["mkfs.exfat", "-L", AEGIS_ISOS_LABEL, &p]).map_err(|e| format!("mkfs.exfat: {e}"))
 }
 
-/// Default grub timeout (seconds). Matches `scripts/mkusb.sh:146`.
-pub(crate) const GRUB_TIMEOUT_SECS: u32 = 3;
+/// Re-export the grub menu timeout from the shared constants
+/// registry. See [`crate::constants::GRUB_TIMEOUT_SECS`].
+pub(crate) use crate::constants::GRUB_TIMEOUT_SECS;
 
 /// Default menuentry selected on boot. 0 = tty0-primary rescue (the
 /// right choice for a local-monitor operator). Matches mkusb.sh's

--- a/crates/aegis-cli/src/direct_install_manifest.rs
+++ b/crates/aegis-cli/src/direct_install_manifest.rs
@@ -60,11 +60,10 @@ pub(crate) const MANIFEST_ESP_PATH: &str = "::/aegis-boot-manifest.json";
 /// Canonical file name of the detached signature on the ESP.
 pub(crate) const MANIFEST_SIG_ESP_PATH: &str = "::/aegis-boot-manifest.json.minisig";
 
-/// Hard cap on manifest body size. The verifier refuses to parse a
-/// manifest larger than this — bounds JSON-parser attack surface in
-/// the early-boot rescue-tui code path. 64 KiB is ~100× the expected
-/// body size so legitimate future growth has room.
-pub(crate) const MAX_MANIFEST_BYTES: usize = 64 * 1024;
+/// Re-export the manifest size cap from the shared constants
+/// registry. See [`crate::constants::MAX_MANIFEST_BYTES`] for the
+/// rationale.
+pub(crate) use crate::constants::MAX_MANIFEST_BYTES;
 
 /// GPT type GUID for EFI System Partition.
 pub(crate) const TYPE_GUID_ESP: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -25,6 +25,7 @@ mod attest;
 mod catalog;
 mod compat;
 mod completions;
+mod constants;
 mod detect;
 mod direct_install;
 mod direct_install_manifest;

--- a/crates/aegis-cli/src/readback.rs
+++ b/crates/aegis-cli/src/readback.rs
@@ -30,11 +30,10 @@ use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
-/// Default number of bytes to read back. Sized to comfortably cover
-/// the signed-chain payload (shim + grub + kernel + initramfs ≈ 50 MB)
-/// with margin, while keeping the readback under 10s on a slow USB 2.0
-/// stick (~7 MB/s).
-pub const DEFAULT_READBACK_BYTES: u64 = 64 * 1024 * 1024;
+/// Re-export the default readback window from the shared constants
+/// registry. See [`crate::constants::DEFAULT_READBACK_BYTES`] for
+/// the rationale.
+pub(crate) use crate::constants::DEFAULT_READBACK_BYTES;
 
 /// Stream up to `n_bytes` from `reader` and return the lowercased hex
 /// sha256. Stops at EOF if the reader has fewer than `n_bytes` bytes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ rescue-tui ──┬──► iso-probe ──► iso-parser   (on the stick, in
 ┌─────────────────────────────────────────────────────────┐
 │  GPT partition table                                    │
 ├─────────────────────────────────────────────────────────┤
-│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~400 MB)         │  ← signed boot chain
+│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~<!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->)         │  ← signed boot chain
 │    /EFI/BOOT/BOOTX64.EFI   (MS-signed shim)             │     immutable in normal use
 │    /EFI/BOOT/grubx64.efi   (Canonical-signed grub)      │
 │    /EFI/BOOT/grub.cfg                                   │

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -68,7 +68,7 @@ Behind the scenes:
 1. Verifies the aegis-boot signed image's signature
 2. Refuses if `/dev/sda` isn't removable + USB
 3. `dd`s the signed shim/grub/kernel/rescue-tui chain onto partition 1
-4. Reads back the first 64 MB and re-verifies the chain's sha256
+4. Reads back the first <!-- constants:BEGIN:READBACK_WINDOW -->64 MB<!-- constants:END:READBACK_WINDOW --> and re-verifies the chain's sha256
 5. Writes an attestation receipt under `~/.local/share/aegis-boot/attestations/`
 
 After this completes the stick is bootable and the menu will show whatever curated ISOs the `init` profile included.

--- a/docs/USB_LAYOUT.md
+++ b/docs/USB_LAYOUT.md
@@ -8,7 +8,7 @@ This document describes the on-disk layout of an aegis-boot USB stick built by [
 ┌─────────────────────────────────────────────────────────┐
 │  GPT partition table                                    │
 ├─────────────────────────────────────────────────────────┤
-│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~400 MB)         │
+│  Part 1 — ESP (FAT32, label AEGIS_ESP, ~<!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->)         │
 │    /EFI/BOOT/BOOTX64.EFI   ← MS-signed shim             │
 │    /EFI/BOOT/grubx64.efi   ← Canonical-signed grub      │
 │    /EFI/BOOT/grub.cfg                                   │


### PR DESCRIPTION
## Summary

Phase 2 of [#286](https://github.com/williamzujkowski/aegis-boot/issues/286) (closes [#288](https://github.com/williamzujkowski/aegis-boot/issues/288)). Extends the Phase 1 drift-check pattern from version strings to shared numeric constants. The v0.14.0 release incident demonstrated that hand-copied numbers between code and prose drift silently; this PR adds the missing structural guard.

## What ships

**`crates/aegis-cli/src/constants.rs`** — single home for the numeric value of each shared constant. Owning modules (`direct_install`, `readback`, `direct_install_manifest`) re-export via `pub(crate) use` so callers are unchanged:

| Constant | Previously defined in | Now re-exported from |
|---|---|---|
| `ESP_SIZE_MB = 400` | `direct_install.rs` | `crate::constants` |
| `DEFAULT_READBACK_BYTES = 64 MiB` | `readback.rs` | `crate::constants` |
| `MAX_MANIFEST_BYTES = 64 KiB` | `direct_install_manifest.rs` | `crate::constants` |
| `GRUB_TIMEOUT_SECS = 3` | `direct_install.rs` | `crate::constants` |

**`crates/aegis-cli/src/bin/constants_docgen.rs`** — feature-gated (`--features docgen`) binary that renders the registered values into HTML-marker pairs in the user-facing docs:

```
<!-- constants:BEGIN:ESP_SIZE_MB -->400 MB<!-- constants:END:ESP_SIZE_MB -->
```

Two modes: `--write` rewrites in place; `--check` exits 1 if regeneration would change any file. Uses `#[path]` include to share the constants file with the main bin — no workspace library crate needed.

**CI** — new `constants-drift` job runs `--check` on every PR.

**Docs markers applied** — `ESP_SIZE_MB` in `ARCHITECTURE.md` + `USB_LAYOUT.md`; `READBACK_WINDOW` in `TOUR.md`. `MAX_MANIFEST_SIZE` and `GRUB_TIMEOUT_SECS` are registered but not yet docs-referenced — registering them now makes adding a future doc reference a one-line edit.

## Design decision

Ratified via `consensus_vote` with `higher_order` strategy (Bayesian correlation-aware): **Option B — per-module constants + docgen** approved 80% (4 approve, 1 reject, 1 abstain). The Contrarian's objection — that a generator scraping Rust source is brittle — is sidestepped by having the docgen import the constants directly at compile time via `#[path]`. No regex, no source scraping.

Architect's concern about SCHEMA_VERSION duplication (`attest::SCHEMA_VERSION` + `direct_install_manifest::SCHEMA_VERSION`) is explicitly addressed in the commit message: they are independent wire-format contract versions and must remain bumpable independently. Fusing them would be a regression.

## Round-trip verification

```bash
# Intentional drift:
$ sed -i 's/400 MB<!-- constants:END:ESP_SIZE_MB/STALE<!-- ... /' docs/USB_LAYOUT.md
$ cargo run -q -p aegis-cli --bin constants-docgen --features docgen -- --check
drift: .../docs/USB_LAYOUT.md would change (1 markers render differently than committed)
constants-docgen: FAIL — 1 file(s) diverge from the constants registry.
# Exit code: 1 ✓

# Restore:
$ cargo run -q -p aegis-cli --bin constants-docgen --features docgen -- --write
updated .../docs/USB_LAYOUT.md (1 markers)
$ cargo run -q -p aegis-cli --bin constants-docgen --features docgen -- --check
constants-docgen: OK — 3 markers across 3 files all match registry
# Exit code: 0 ✓
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p aegis-cli --all-targets --all-features -- -D warnings` — clean (includes the new bin + its tests under pedantic)
- [x] `cargo test -p aegis-cli --locked` — 361/361 pass (no-features, main bin unaffected)
- [x] `cargo test -p aegis-cli --all-features --locked` — 361 main + 15 docgen, all pass
- [x] `cargo build -p aegis-cli --release --locked` — release binary size unchanged (docgen feature gated)
- [x] Manual drift-detection round-trip (above)
- [x] `constants-drift` CI job passes on first run of this PR

## Why not Option A (new `aegis-consts` crate)

- Module ownership: `ESP_SIZE_MB` belongs conceptually next to the ESP-sizing code. A central crate violates locality-of-reference.
- Dep-graph churn: adds a new workspace edge for no runtime benefit.
- Pattern reuse: Phase 1b already established the `@MARKER@` templating convention (build.rs + man/aegis-boot.1.in). Contributors learn one pattern, not two.

## Follow-ups

- Phase 3 ([#289](https://github.com/williamzujkowski/aegis-boot/issues/289)) — auto-gen `docs/CLI.md` subcommand sections. Builds on the same marker-injection muscle.
- Phase 4 ([#290](https://github.com/williamzujkowski/aegis-boot/issues/290)) — `schemars` JSON schemas. Independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)