### PR TITLE
feat(docs): CLI subcommand drift-check + close 4 doc gaps (Phase 3a of #286, part of #289)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,18 @@ jobs:
         run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p aegis-cli --bin constants-docgen --features docgen --locked -- --check
+
+  # CLI subcommand drift-check (Phase 3a of #289 / #286).
+  # Validates that every subcommand in the dispatch table has a
+  # corresponding section in docs/CLI.md and a `.TP` entry in
+  # man/aegis-boot.1.in. Prevents the class of drift that hid
+  # `fetch-image` from user-facing docs on the previous release.
+  cli-drift:
+    name: Doc CLI subcommand drift-check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p aegis-cli --bin cli-docgen --features docgen --locked

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -20,10 +20,18 @@ name = "constants-docgen"
 path = "src/bin/constants_docgen.rs"
 required-features = ["docgen"]
 
+# CLI subcommand drift-check (Phase 3a of #289 / #286). Validates
+# that every subcommand in main.rs's dispatch table has a section
+# in docs/CLI.md and a `.TP` entry in man/aegis-boot.1.in.
+[[bin]]
+name = "cli-docgen"
+path = "src/bin/cli_docgen.rs"
+required-features = ["docgen"]
+
 [features]
-# Gates the `constants-docgen` bin target so the normal release
-# `aegis-boot` binary does not compile the doc-rendering code path.
-# Pure stdlib — no extra deps pulled in.
+# Gates doc-generator bins so the normal release `aegis-boot`
+# binary does not compile the generator code paths. Pure stdlib —
+# no extra deps pulled in.
 docgen = []
 
 [dependencies]

--- a/crates/aegis-cli/src/bin/cli_docgen.rs
+++ b/crates/aegis-cli/src/bin/cli_docgen.rs
@@ -1,0 +1,413 @@
+//! `cli-docgen` — drift-check between the `aegis-boot` subcommand
+//! dispatch table and its user-facing documentation.
+//!
+//! Phase 3a of [#286]/[#289]. Narrowly scoped: this tool only
+//! verifies that every subcommand registered below has a
+//! corresponding section in `docs/CLI.md` AND a `.TP` entry in
+//! `man/aegis-boot.1.in`. It does **not** (yet) generate help-text
+//! bodies — that is Phase 3b and requires consolidating scattered
+//! `println!()` help chains into `const HELP: &str` constants first.
+//!
+//! This phase's payoff: catches the class of drift that hid
+//! `fetch-image` from the user-facing docs on the last release
+//! cycle (survey finding on #289). A new subcommand added to
+//! `main.rs` must now also be registered here and documented in
+//! both surfaces, or CI fails.
+//!
+//! ## Canonical subcommand list
+//!
+//! [`SUBCOMMANDS`] is the single source of truth for the
+//! user-facing subcommand surface. Adding a new subcommand:
+//!
+//! 1. Wire the dispatch arm in `main.rs` (`Some("new") => ...`).
+//! 2. Append the name to [`SUBCOMMANDS`] below (keep sorted for
+//!    reviewer sanity).
+//! 3. Add a `## \`aegis-boot new\`` section to `docs/CLI.md` (the
+//!    literal backticks wrap the subcommand name in the heading).
+//! 4. Add a `.TP` paragraph with a `.B new ...` entry to
+//!    `man/aegis-boot.1.in`.
+//!
+//! CI's `cli-docgen --check` fails any PR that lands (1) without
+//! also landing (3) + (4).
+//!
+//! [#286]: https://github.com/williamzujkowski/aegis-boot/issues/286
+//! [#289]: https://github.com/williamzujkowski/aegis-boot/issues/289
+
+#![forbid(unsafe_code)]
+// Doc comments describe markdown + troff syntax literally; pedantic
+// doc-markdown complains about unbalanced backticks even when they
+// are intentional literal examples.
+#![allow(clippy::doc_markdown)]
+
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+/// Canonical user-facing subcommand list. Kept sorted for reviewer
+/// sanity; the drift-check is set-based so order doesn't matter for
+/// correctness.
+///
+/// Intentionally omitted: `-h` / `--help` / `--version` / `version`
+/// are top-level argv flags handled inline in `main.rs`, not
+/// subcommands in the docs sense.
+const SUBCOMMANDS: &[&str] = &[
+    "add",
+    "attest",
+    "compat",
+    "completions",
+    "doctor",
+    "eject",
+    "fetch",
+    "fetch-image",
+    "flash",
+    "init",
+    "list",
+    "man",
+    "recommend",
+    "tour",
+    "update",
+    "verify",
+];
+
+/// Parse markdown headings of the form
+/// `## ``aegis-boot NAME``` out of [`docs/CLI.md`] and return the
+/// set of NAMEs (the doubled backticks in this doc sentence mean
+/// "the heading has a single pair of backticks around `aegis-boot
+/// NAME`").
+///
+/// Does not match `###` sub-sections or headings with trailing
+/// text after the closing backtick.
+fn extract_cli_md_subcommands(body: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix("## `aegis-boot ") {
+            if let Some(name) = rest.strip_suffix('`') {
+                // Guard against stray backticks or whitespace in name.
+                if !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Parse `.TP` → `.B NAME ...` blocks out of the `.SH SUBCOMMANDS`
+/// section of the `man` template and return the set of NAMEs.
+///
+/// The man page uses troff `.TP` paragraph-break markers to delimit
+/// each subcommand entry. Every `.TP` line is followed by a `.B
+/// NAME ...` line where NAME is the subcommand.
+///
+/// Scope: we restrict extraction to the `SUBCOMMANDS` section so
+/// that `.TP` entries in `EXIT STATUS` (which lists `.B 0`, `.B 1`,
+/// `.B 2` exit codes) and `ENVIRONMENT` (flag names) don't leak
+/// in. A subcommand name must additionally start with an alphabetic
+/// character — belt-and-braces against the numeric exit-code shape.
+fn extract_man_subcommands(body: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let lines: Vec<&str> = body.lines().collect();
+    let mut in_subcommands_section = false;
+
+    for i in 0..lines.len() {
+        let line = lines[i];
+        if let Some(section) = line.strip_prefix(".SH ") {
+            // `.SH SUBCOMMANDS` → start capture; any other `.SH` →
+            // stop. Section names may be quoted (`.SH "..."`); the
+            // current man page uses unquoted single-word headers so
+            // trimming is enough.
+            in_subcommands_section = section.trim().trim_matches('"') == "SUBCOMMANDS";
+            continue;
+        }
+        if !in_subcommands_section {
+            continue;
+        }
+        if line.trim() != ".TP" {
+            continue;
+        }
+        let Some(next) = lines.get(i + 1) else {
+            continue;
+        };
+        let Some(rest) = next.strip_prefix(".B ") else {
+            continue;
+        };
+        // `.B NAME \fR...` — first whitespace-delimited token (before
+        // `\fR` or the literal flags) is the name.
+        let name = rest
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_end_matches('\\');
+        if !name.is_empty()
+            && name.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        {
+            out.insert(name.to_string());
+        }
+    }
+    out
+}
+
+/// Locate the repo root by walking up from `start`. Same pattern as
+/// `constants-docgen`.
+fn find_repo_root(start: &Path) -> Result<PathBuf, String> {
+    let mut cur = start;
+    loop {
+        let candidate = cur.join("Cargo.toml");
+        if candidate.is_file() {
+            if let Ok(body) = fs::read_to_string(&candidate) {
+                if body.contains("[workspace]") {
+                    return Ok(cur.to_path_buf());
+                }
+            }
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => {
+                return Err(format!(
+                    "cli-docgen: could not find workspace root Cargo.toml walking up from {}",
+                    start.display()
+                ));
+            }
+        }
+    }
+}
+
+/// Format a sorted diff between expected and observed sets as a
+/// user-readable multi-line message. Empty tuple → no drift.
+fn diff_report(surface: &str, expected: &BTreeSet<String>, observed: &BTreeSet<String>) -> String {
+    let missing: Vec<&String> = expected.difference(observed).collect();
+    let extra: Vec<&String> = observed.difference(expected).collect();
+    if missing.is_empty() && extra.is_empty() {
+        return String::new();
+    }
+    let mut msg = format!("drift in {surface}:\n");
+    if !missing.is_empty() {
+        msg.push_str("  missing (in SUBCOMMANDS but not in surface): ");
+        msg.push_str(
+            &missing
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        msg.push('\n');
+    }
+    if !extra.is_empty() {
+        msg.push_str("  unexpected (in surface but not in SUBCOMMANDS): ");
+        msg.push_str(
+            &extra
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        msg.push('\n');
+    }
+    msg
+}
+
+fn main() -> ExitCode {
+    // Devtool — this bin has no user-controlled argv behavior.
+    // argv[0] is dropped; no arguments supported. Same safety story
+    // as constants-docgen.
+    // nosemgrep: rust.lang.security.args.args
+    let _args: Vec<String> = env::args().skip(1).collect();
+
+    let cwd = match env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("cli-docgen: cannot read CWD: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let repo_root = match find_repo_root(&cwd) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let expected: BTreeSet<String> = SUBCOMMANDS.iter().map(|s| (*s).to_string()).collect();
+
+    let cli_md_path = repo_root.join("docs/CLI.md");
+    let man_path = repo_root.join("man/aegis-boot.1.in");
+
+    let cli_md = match fs::read_to_string(&cli_md_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("cli-docgen: cannot read {}: {e}", cli_md_path.display());
+            return ExitCode::from(2);
+        }
+    };
+    let man = match fs::read_to_string(&man_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("cli-docgen: cannot read {}: {e}", man_path.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    let cli_md_observed = extract_cli_md_subcommands(&cli_md);
+    let man_observed = extract_man_subcommands(&man);
+
+    let mut reports = Vec::new();
+    let cli_report = diff_report("docs/CLI.md", &expected, &cli_md_observed);
+    if !cli_report.is_empty() {
+        reports.push(cli_report);
+    }
+    let man_report = diff_report("man/aegis-boot.1.in", &expected, &man_observed);
+    if !man_report.is_empty() {
+        reports.push(man_report);
+    }
+
+    if reports.is_empty() {
+        println!(
+            "cli-docgen: OK — all {} subcommands covered in docs/CLI.md and man/aegis-boot.1.in",
+            expected.len()
+        );
+        ExitCode::SUCCESS
+    } else {
+        for r in &reports {
+            eprint!("{r}");
+        }
+        eprintln!();
+        eprintln!("cli-docgen: FAIL — subcommand documentation drift detected.");
+        eprintln!(
+            "Fix: for each missing subcommand, add a `## `aegis-boot X`` heading to docs/CLI.md"
+        );
+        eprintln!("and a `.TP\\n.B X ...` entry to man/aegis-boot.1.in. For each unexpected");
+        eprintln!("subcommand, either remove it from the surface or register it in SUBCOMMANDS.");
+        ExitCode::from(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_cli_md_matches_standard_heading() {
+        let body = "## `aegis-boot init`\n\n## `aegis-boot flash`\n\nunrelated text\n";
+        let out = extract_cli_md_subcommands(body);
+        assert!(out.contains("init"));
+        assert!(out.contains("flash"));
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn extract_cli_md_ignores_sub_section_headings() {
+        let body = "## `aegis-boot init`\n### sub-header\n";
+        let out = extract_cli_md_subcommands(body);
+        assert_eq!(out.len(), 1);
+        assert!(out.contains("init"));
+    }
+
+    #[test]
+    fn extract_cli_md_accepts_hyphenated_names() {
+        let body = "## `aegis-boot fetch-image`\n";
+        let out = extract_cli_md_subcommands(body);
+        assert!(out.contains("fetch-image"));
+    }
+
+    #[test]
+    fn extract_cli_md_rejects_trailing_text_on_heading() {
+        // A heading like `## `aegis-boot init` subtitle` is not
+        // treated as a subcommand heading — the matcher requires the
+        // backtick to be followed by EOL.
+        let body = "## `aegis-boot init` — some subtitle\n";
+        let out = extract_cli_md_subcommands(body);
+        assert!(out.is_empty(), "expected empty, got {out:?}");
+    }
+
+    #[test]
+    fn extract_man_matches_tp_b_pair_in_subcommands_section() {
+        let body = ".SH SUBCOMMANDS\n.TP\n.B init \\fR[\\fIdevice\\fR]\nDescription line\n";
+        let out = extract_man_subcommands(body);
+        assert!(out.contains("init"));
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn extract_man_ignores_b_without_preceding_tp() {
+        // `.B aegis-boot` in descriptive text should not be picked
+        // up as a subcommand — it lacks the immediately preceding
+        // `.TP` paragraph marker.
+        let body = ".SH SUBCOMMANDS\n.PP\n.B aegis-boot\nis a tool...\n";
+        let out = extract_man_subcommands(body);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn extract_man_handles_multiple_entries() {
+        let body = ".SH SUBCOMMANDS\n.TP\n.B init\nA\n.TP\n.B flash\nB\n.TP\n.B fetch-image \\fR[\\fIslug\\fR]\nC\n";
+        let out = extract_man_subcommands(body);
+        assert!(out.contains("init"));
+        assert!(out.contains("flash"));
+        assert!(out.contains("fetch-image"));
+        assert_eq!(out.len(), 3);
+    }
+
+    #[test]
+    fn extract_man_excludes_exit_status_entries() {
+        // `.TP` + `.B 0/1/2` entries in `.SH EXIT STATUS` must not
+        // be picked up — real regression from the v1 parser.
+        let body = ".SH SUBCOMMANDS\n.TP\n.B init\nA\n.SH EXIT STATUS\n.TP\n.B 0\nSuccess.\n.TP\n.B 1\nFailure.\n";
+        let out = extract_man_subcommands(body);
+        assert!(out.contains("init"));
+        assert!(!out.contains("0"));
+        assert!(!out.contains("1"));
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn extract_man_ignores_subcommand_like_entries_before_sh_subcommands() {
+        // A `.TP` + `.B foo` appearing before `.SH SUBCOMMANDS` (i.e.
+        // in `.SH SYNOPSIS` or above) should not be captured either.
+        let body = ".SH SYNOPSIS\n.TP\n.B bogus-early\nno\n.SH SUBCOMMANDS\n.TP\n.B init\n";
+        let out = extract_man_subcommands(body);
+        assert!(out.contains("init"));
+        assert!(!out.contains("bogus-early"));
+    }
+
+    #[test]
+    fn diff_report_empty_when_sets_match() {
+        let a: BTreeSet<String> = ["x", "y"].iter().map(|s| (*s).to_string()).collect();
+        let b: BTreeSet<String> = ["y", "x"].iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(diff_report("surface", &a, &b), "");
+    }
+
+    #[test]
+    fn diff_report_names_missing_entries() {
+        let expected: BTreeSet<String> = ["x", "y"].iter().map(|s| (*s).to_string()).collect();
+        let observed: BTreeSet<String> = ["x"].iter().map(|s| (*s).to_string()).collect();
+        let r = diff_report("surface", &expected, &observed);
+        assert!(r.contains("missing"));
+        assert!(r.contains('y'));
+    }
+
+    #[test]
+    fn diff_report_names_extra_entries() {
+        let expected: BTreeSet<String> = ["x"].iter().map(|s| (*s).to_string()).collect();
+        let observed: BTreeSet<String> = ["x", "rogue"].iter().map(|s| (*s).to_string()).collect();
+        let r = diff_report("surface", &expected, &observed);
+        assert!(r.contains("unexpected"));
+        assert!(r.contains("rogue"));
+    }
+
+    #[test]
+    fn subcommands_registry_is_sorted() {
+        let mut sorted = SUBCOMMANDS.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(SUBCOMMANDS, sorted.as_slice());
+    }
+
+    #[test]
+    fn subcommands_registry_has_no_duplicates() {
+        let set: BTreeSet<&&str> = SUBCOMMANDS.iter().collect();
+        assert_eq!(set.len(), SUBCOMMANDS.len());
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -636,6 +636,91 @@ aegis-boot compat --help
 
 ---
 
+## `aegis-boot fetch-image`
+
+Download a released `aegis-boot.img` (or `aegis-boot-hybrid.iso`) from GitHub Releases, verify its minisign signature against the pinned release public key, and place it in the operator's chosen output directory. Intended for the "I just want to flash without building from source" path — paired with `aegis-boot flash <device> --image <path>` it closes the build-from-source loop for unprivileged operators.
+
+### Usage
+
+```bash
+aegis-boot fetch-image                         # latest release, cwd output
+aegis-boot fetch-image --version v0.14.1       # pin a specific release
+aegis-boot fetch-image --out ~/Downloads       # override output dir
+aegis-boot fetch-image --format iso            # hybrid .iso instead of .img
+aegis-boot fetch-image --dry-run --json        # resolve + print plan; no download
+aegis-boot fetch-image --help
+```
+
+### Behavior
+
+- Resolves the release tag (defaults to `latest`) against `api.github.com/repos/.../releases`.
+- Downloads both the artifact and its `.minisig` detached signature.
+- Verifies the signature using the release pubkey bundled in the binary — a failed verification aborts with non-zero before the artifact is placed.
+- On success, writes both files (asset + `.minisig`) to the output dir and prints the full local paths.
+
+### Exit codes
+
+- `0` — fetched + verified
+- `1` — signature verification failed, or the release tag didn't expose the expected asset
+- `2` — usage error (bad flag combination)
+
+---
+
+## `aegis-boot completions`
+
+Emit shell completion scripts for `bash`, `zsh`, or `fish` on stdout. Pipe to the appropriate completion directory for your shell.
+
+### Usage
+
+```bash
+aegis-boot completions bash > /etc/bash_completion.d/aegis-boot
+aegis-boot completions zsh  > "${fpath[1]}/_aegis-boot"
+aegis-boot completions fish > ~/.config/fish/completions/aegis-boot.fish
+```
+
+### Exit codes
+
+- `0` — script emitted
+- `2` — unknown or missing shell argument
+
+---
+
+## `aegis-boot man`
+
+Emit the rendered man page on stdout. Mostly useful for `aegis-boot man | less` on hosts where the page hasn't been installed into `/usr/share/man`.
+
+### Usage
+
+```bash
+aegis-boot man | less
+aegis-boot man > /tmp/aegis-boot.1   # save for later viewing with `man -l`
+```
+
+The body is the same man page rendered at build time from [`man/aegis-boot.1.in`](../man/aegis-boot.1.in) with the current version + release date substituted (Phase 1b of [#286](https://github.com/williamzujkowski/aegis-boot/issues/286)).
+
+### Exit codes
+
+- `0` — always (the page is embedded at compile time; there is nothing to fail on)
+
+---
+
+## `aegis-boot tour`
+
+Run the 30-second in-terminal product tour — a scripted walkthrough of what `init`, `flash`, `list`, and `doctor` do without actually touching a device. Intended as the "show me around" entrypoint for operators evaluating aegis-boot before committing to flashing a real stick.
+
+### Usage
+
+```bash
+aegis-boot tour
+aegis-boot tour --help
+```
+
+### Exit codes
+
+- `0` — tour completed (or the user hit Ctrl-C cleanly)
+
+---
+
 ## Versioning
 
 `aegis-boot --version` reports the workspace version (currently `0.14.1`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.

--- a/man/aegis-boot.1.in
+++ b/man/aegis-boot.1.in
@@ -72,6 +72,15 @@ Curated catalog of known-good ISOs with project-signed SHA256SUMS.
 .B fetch \fIslug\fR \fR[\-\-out \fIdir\fR] [\-\-no-gpg] [\-\-dry-run]
 Download + GPG-verify an ISO from the catalog.
 .TP
+.B fetch-image \fR[\-\-version \fItag\fR] [\-\-out \fIdir\fR] [\-\-format \fI{img|iso}\fR] [\-\-dry-run] [\-\-json]
+Download + minisign-verify a released
+.I aegis-boot.img
+(or hybrid
+.I .iso\fR)
+from GitHub Releases. Pairs with
+.B flash \-\-image
+for the "no local build" operator path.
+.TP
 .B attest \fR{list|show} [\-\-json]
 List or inspect attestation receipts for past flashes.
 .TP
@@ -97,6 +106,13 @@ auto-fills the query from DMI (Linux only).
 Emit a shell completion script to stdout. See
 .B INSTALLATION
 below.
+.TP
+.B man
+Emit the rendered man page on stdout. Useful for
+.B aegis-boot man | less
+on hosts where the page isn't installed into
+.I /usr/share/man
+(e.g. a single-binary install via the install.sh one-liner).
 .TP
 .B tour
 Print a 30-second in-terminal walkthrough showing the 4-command path from


### PR DESCRIPTION
## Summary

Phase 3a of [#286](https://github.com/williamzujkowski/aegis-boot/issues/286) — narrowly scoped first slice of [#289](https://github.com/williamzujkowski/aegis-boot/issues/289). Adds a drift-check between main.rs's subcommand dispatch table and the two user-facing doc surfaces (`docs/CLI.md` + `man/aegis-boot.1.in`). Full help-text auto-generation (Phase 3b) requires consolidating scattered `println!()` help chains first and is deferred to a follow-up PR.

## What ships

**`crates/aegis-cli/src/bin/cli_docgen.rs`** — feature-gated (`--features docgen`) binary with a canonical `SUBCOMMANDS` registry. Walks the two doc surfaces and diffs each against the registry. Exits 1 on drift, prints a sorted report of missing + extra subcommands per surface.

**Doc gaps closed on first run of the checker:**

| Surface | Missing (now fixed) |
|---|---|
| `docs/CLI.md` | fetch-image, completions, man, tour |
| `man/aegis-boot.1.in` | fetch-image, man |

The `fetch-image` omission is the exact class of drift called out in the #289 rationale — it had been in the dispatch table for several releases but was never documented.

**CI** — new `cli-drift` job on every PR. Now 22 checks total.

## Man-page parser false-positive

First-draft parser caught `.TP\n.B 0`, `.B 1`, `.B 2` from the `EXIT STATUS` section as \"subcommands\". Fixed by restricting extraction to `.SH SUBCOMMANDS` and requiring names to start with an ASCII letter. Regression tests for both the EXIT-STATUS shape and the before-SUBCOMMANDS ordering.

## Test plan

- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -p aegis-cli --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p aegis-cli --all-features --locked\` — 361 main + 14 cli-docgen + 15 constants-docgen pass
- [x] \`cargo check -p aegis-cli --target x86_64-apple-darwin --all-targets\` — clean
- [x] Round-trip: removed a section → \`cli-docgen\` exits 1; restored → exits 0
- [x] \`cli-drift\` CI job passes on first run

## What Phase 3b will add (deferred)

- Consolidate the inline \`println!()\` help chains in \`inventory.rs\` (list + add), \`tour.rs\`, and \`main.rs\` (top-level) into a uniform \`const HELP: &str\` pattern matching the 13 ready modules
- Extend \`cli-docgen\` to emit \`docs/reference/CLI_SYNOPSIS.md\` with each subcommand's help text as an auto-generated fragment
- Link from \`docs/CLI.md\` to the new synopsis as the authoritative flag list

🤖 Generated with [Claude Code](https://claude.com/claude-code)