### PR TITLE
feat(manifest): extract aegis-manifest crate + schemars schema drift-check (Phase 4a of #286, part of #290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,20 @@ jobs:
         run: cargo build -p aegis-cli --release --locked
       - name: Check CLI doc drift
         run: cargo run -p aegis-cli --bin cli-docgen --features docgen --locked -- --check
+
+  # Attestation-manifest JSON schema drift-check (Phase 4a of #290 / #286).
+  # Runs `aegis-manifest-schema-docgen --check` which regenerates the
+  # JSON Schema for `aegis_manifest::Manifest` via schemars and diffs
+  # it against the committed copy at
+  # `docs/reference/schemas/aegis-boot-manifest.schema.json`. A field
+  # added, removed, or retyped on any manifest struct breaks this
+  # check until the schema is regenerated and committed.
+  manifest-schema-drift:
+    name: Manifest JSON schema drift-check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p aegis-manifest --features schema --bin aegis-manifest-schema-docgen --locked -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "aegis-cli"
 version = "0.14.1"
 dependencies = [
+ "aegis-manifest",
  "hex",
  "indicatif",
  "iso-probe",
@@ -23,6 +24,16 @@ version = "0.14.1"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "aegis-manifest"
+version = "0.14.1"
+dependencies = [
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -230,6 +241,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -806,6 +823,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +893,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kexec-loader",
     "crates/aegis-fitness",
     "crates/aegis-cli",
+    "crates/aegis-manifest",
 ]
 exclude = ["crates/iso-parser/fuzz"]
 

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -38,6 +38,10 @@ docgen = []
 serde = { workspace = true }
 serde_json = "1.0"
 iso-probe = { path = "../iso-probe" }
+# Signed attestation manifest types extracted for Phase 4a of #286.
+# This crate is the Rust + JSON Schema source of truth for the
+# on-disk aegis-boot-manifest.json wire format.
+aegis-manifest = { path = "../aegis-manifest" }
 # Atomic random-name temp files for write_sidecar_via_sudo's
 # stage-then-copy path. Use the runtime dep (not the dev-dep) so the
 # staging path is not predictable — closes the TOCTOU window semgrep

--- a/crates/aegis-cli/src/direct_install_manifest.rs
+++ b/crates/aegis-cli/src/direct_install_manifest.rs
@@ -39,18 +39,19 @@ use std::fs;
 use std::io::Cursor;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+// Wire types + SCHEMA_VERSION extracted to the `aegis-manifest`
+// crate for Phase 4a of #286. Re-exported here so every in-crate
+// `crate::direct_install_manifest::Manifest` reference keeps working
+// unchanged, and so third-party verifiers can depend on
+// `aegis-manifest` directly with a JSON Schema pin.
+pub(crate) use aegis_manifest::{
+    DataPartition, Device, EspFileEntry, EspPartition, Manifest, SCHEMA_VERSION,
+};
 
 use crate::direct_install::{
     ESP_DEST_GRUB, ESP_DEST_GRUB_CFG_BOOT, ESP_DEST_GRUB_CFG_UBUNTU, ESP_DEST_INITRD,
     ESP_DEST_KERNEL, ESP_DEST_SHIM,
 };
-
-/// Locked schema version for PR3. Bump alongside a breaking shape
-/// change (removing a field, changing a field's type). Adding a new
-/// optional field is backwards-compatible and does not require a
-/// version bump — the verifier ignores fields it doesn't know about.
-pub(crate) const SCHEMA_VERSION: u32 = 1;
 
 /// Canonical file name of the manifest on the ESP. Operators and
 /// verifiers MUST key off this exact path; moving it is a breaking
@@ -72,72 +73,6 @@ pub(crate) const TYPE_GUID_ESP: &str = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
 /// exFAT on our sticks — see the [`crate::direct_install`] doc on
 /// `DATA_TYPE_CODE` for why the runtime doesn't key off this).
 pub(crate) const TYPE_GUID_MSFT_BASIC_DATA: &str = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
-
-/// Top-level manifest body. Serialized field order matches the
-/// declaration order below — relied on for canonical JSON stability
-/// (the signature is over `serde_json::to_vec(&Manifest)`).
-///
-/// The Rust field is `sequence` (clippy prefers not to prefix the
-/// struct name); the JSON wire field stays `manifest_sequence` per
-/// #277 schema lock via `#[serde(rename)]`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct Manifest {
-    pub schema_version: u32,
-    pub tool_version: String,
-    #[serde(rename = "manifest_sequence")]
-    pub sequence: u64,
-    pub device: Device,
-    pub esp_files: Vec<EspFileEntry>,
-    pub allowed_files_closed_set: bool,
-    pub expected_pcrs: Vec<PcrEntry>,
-}
-
-/// Device identity captured at flash time. All values come from the
-/// freshly-written GPT (`blkid` + `sgdisk -p`); verifier re-reads them
-/// and asserts equality.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct Device {
-    pub disk_guid: String,
-    pub partition_count: u32,
-    pub esp: EspPartition,
-    pub data: DataPartition,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct EspPartition {
-    pub partuuid: String,
-    pub type_guid: String,
-    pub fs_uuid: String,
-    pub first_lba: u64,
-    pub last_lba: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct DataPartition {
-    pub partuuid: String,
-    pub type_guid: String,
-    pub fs_uuid: String,
-    pub label: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct EspFileEntry {
-    /// Mtools-style `::/` path on the ESP. Verifier lowercases both
-    /// sides before comparison (FAT32 is case-insensitive).
-    pub path: String,
-    pub sha256: String,
-    pub size_bytes: u64,
-}
-
-/// Reserved for E6 / Phase 3 TPM attestation. Left out of the
-/// serialized array by PR3 (`expected_pcrs: []`); once E6 locks the
-/// PCR selection this struct grows populated rows.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct PcrEntry {
-    pub pcr_index: u32,
-    pub bank: String,
-    pub digest_hex: String,
-}
 
 /// Errors from manifest build / parse / verify.
 #[derive(Debug, thiserror::Error)]

--- a/crates/aegis-manifest/Cargo.toml
+++ b/crates/aegis-manifest/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "aegis-manifest"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Signed attestation manifest format for aegis-boot USB sticks — serde types + JSON Schema"
+readme = "README.md"
+documentation = "https://docs.rs/aegis-manifest"
+homepage = "https://github.com/williamzujkowski/aegis-boot"
+keywords = ["aegis-boot", "attestation", "manifest", "usb", "secure-boot"]
+categories = ["data-structures", "filesystem"]
+
+[lib]
+
+# Feature-gated schema-docgen bin (Phase 4a of #286). Emits
+# `docs/reference/schemas/aegis-boot-manifest.schema.json` using
+# `schemars`. Pure build-tool; the normal library API does not pull
+# schemars into the runtime.
+[[bin]]
+name = "aegis-manifest-schema-docgen"
+path = "src/bin/schema_docgen.rs"
+required-features = ["schema"]
+
+[features]
+default = []
+# Enables `schemars::JsonSchema` derives on every public type, plus
+# compiles the schema-docgen bin. Consumers who just want to parse
+# manifests leave this off.
+schema = ["dep:schemars"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1.0"
+thiserror = { workspace = true }
+# schemars picks the latest stable. 0.8 is the long-established
+# release with a settled API + a broad reverse-dependency ecosystem.
+schemars = { version = "0.8", optional = true, default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[lints]
+workspace = true
+
+# Phase 6 of #286 — README.md becomes the rustdoc landing page.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/aegis-manifest/README.md
+++ b/crates/aegis-manifest/README.md
@@ -1,0 +1,34 @@
+# aegis-manifest
+
+Signed attestation manifest format for [aegis-boot](https://github.com/williamzujkowski/aegis-boot) USB sticks. Defines the on-disk `::/aegis-boot-manifest.json` shape the flash-time attestation writes and that runtime verifiers (rescue-tui, `aegis-boot doctor --stick`, aegis-hwsim E6 attestation-roundtrip) read back.
+
+Part of the [aegis-boot](https://github.com/williamzujkowski/aegis-boot) rescue environment — a signed-chain UEFI Secure Boot stick that boots any ISO.
+
+## Scope
+
+This crate ships:
+
+- **Serde types** for the manifest envelope (`Manifest`, `Device`, `EspPartition`, `DataPartition`, `EspFileEntry`, `PcrEntry`).
+- **Schema version constant** pinning the wire-format version at 1 (locked by [#277](https://github.com/williamzujkowski/aegis-boot/issues/277)).
+- **Optional JSON Schema generation** behind the `schema` feature — enables `#[derive(JsonSchema)]` on every public type and compiles the `aegis-manifest-schema-docgen` binary that writes `aegis-boot-manifest.schema.json` consumers can validate against.
+
+Deliberately **not** shipped here:
+
+- Writer / signer / filesystem I/O code — that logic is tightly coupled to the `direct_install` flow on Linux and lives in the `aegis-cli` crate.
+- `minisign` signature verification — callers receive the manifest body + a detached signature and verify out-of-band.
+
+## Feature flags
+
+- `schema` (off by default) — pulls `schemars` in, adds `JsonSchema` derives, enables the `aegis-manifest-schema-docgen` binary used by the parent workspace's CI drift-check.
+
+## Platform support
+
+Pure Rust, no platform-specific code. Works anywhere serde + serde_json work.
+
+## Status
+
+**Pre-1.0**. Schema version is locked at 1; API may still gain minor conveniences before a crates.io publish. Consume via the [aegis-boot workspace](https://github.com/williamzujkowski/aegis-boot).
+
+## License
+
+Licensed under either of [Apache-2.0](../../LICENSE-APACHE) or [MIT](../../LICENSE-MIT) at your option.

--- a/crates/aegis-manifest/src/bin/schema_docgen.rs
+++ b/crates/aegis-manifest/src/bin/schema_docgen.rs
@@ -1,0 +1,163 @@
+//! `aegis-manifest-schema-docgen` — emits the JSON Schema document
+//! for [`aegis_manifest::Manifest`] to
+//! `docs/reference/schemas/aegis-boot-manifest.schema.json` in the
+//! parent workspace.
+//!
+//! Phase 4a of [#286] / [#290]. CI's
+//! `aegis-manifest-schema-drift` job runs this in `--check` mode on
+//! every PR. Any time a field is added, removed, or retyped on any
+//! of the manifest structs, this tool regenerates a different
+//! document and the drift-check fails until the committed schema
+//! catches up.
+//!
+//! ## Why the schema is committed rather than generated-at-release
+//!
+//! Third-party verifiers pin against the committed schema file.
+//! Generating at release time would introduce a window between a
+//! shape-changing PR merge and a new release where the on-disk
+//! schema and committed schema diverge silently. Making the schema
+//! a gating check at PR time closes that window.
+//!
+//! [#286]: https://github.com/williamzujkowski/aegis-boot/issues/286
+//! [#290]: https://github.com/williamzujkowski/aegis-boot/issues/290
+
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use aegis_manifest::Manifest;
+use schemars::schema_for;
+
+/// Render the JSON Schema for [`Manifest`] as pretty-printed JSON
+/// with a trailing newline. The trailing newline is important for
+/// clean diffs and Unix-tool friendliness.
+fn render_schema() -> Result<String, String> {
+    let schema = schema_for!(Manifest);
+    let mut body = serde_json::to_string_pretty(&schema)
+        .map_err(|e| format!("schema-docgen: cannot serialize schema: {e}"))?;
+    body.push('\n');
+    Ok(body)
+}
+
+/// Walk up from `start` until a workspace Cargo.toml is found.
+/// Same pattern as `constants-docgen` / `cli-docgen`.
+fn find_repo_root(start: &Path) -> Result<PathBuf, String> {
+    let mut cur = start;
+    loop {
+        let candidate = cur.join("Cargo.toml");
+        if candidate.is_file() {
+            if let Ok(body) = fs::read_to_string(&candidate) {
+                if body.contains("[workspace]") {
+                    return Ok(cur.to_path_buf());
+                }
+            }
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => {
+                return Err(format!(
+                    "schema-docgen: could not find workspace Cargo.toml walking up from {}",
+                    start.display()
+                ));
+            }
+        }
+    }
+}
+
+enum Mode {
+    Write,
+    Check,
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode, String> {
+    match args
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] | ["--check"] => Ok(Mode::Check),
+        ["--write"] => Ok(Mode::Write),
+        _ => Err(format!(
+            "usage: aegis-manifest-schema-docgen [--check|--write]  (got: {args:?})"
+        )),
+    }
+}
+
+fn main() -> ExitCode {
+    // Devtool — no security-relevant argv. Same rationale as the
+    // other workspace docgens.
+    // nosemgrep: rust.lang.security.args.args
+    let args: Vec<String> = env::args().skip(1).collect();
+    let mode = match parse_mode(&args) {
+        Ok(m) => m,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let cwd = match env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("schema-docgen: cannot read CWD: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let repo_root = match find_repo_root(&cwd) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let rendered = match render_schema() {
+        Ok(s) => s,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let out_path = repo_root.join("docs/reference/schemas/aegis-boot-manifest.schema.json");
+
+    match mode {
+        Mode::Write => {
+            if let Some(parent) = out_path.parent() {
+                if let Err(e) = fs::create_dir_all(parent) {
+                    eprintln!("schema-docgen: cannot create {}: {e}", parent.display());
+                    return ExitCode::from(2);
+                }
+            }
+            if let Err(e) = fs::write(&out_path, &rendered) {
+                eprintln!("schema-docgen: cannot write {}: {e}", out_path.display());
+                return ExitCode::from(2);
+            }
+            println!("schema-docgen: wrote {}", out_path.display());
+            ExitCode::SUCCESS
+        }
+        Mode::Check => {
+            let committed = fs::read_to_string(&out_path).unwrap_or_default();
+            if committed == rendered {
+                println!(
+                    "schema-docgen: OK — {} matches `schema_for!(Manifest)` output",
+                    out_path.display()
+                );
+                ExitCode::SUCCESS
+            } else {
+                eprintln!(
+                    "schema-docgen: DRIFT — regenerated schema differs from committed copy at {}",
+                    out_path.display()
+                );
+                eprintln!(
+                    "Fix: run `cargo run -p aegis-manifest --bin aegis-manifest-schema-docgen --features schema -- --write` locally and commit the result."
+                );
+                ExitCode::from(1)
+            }
+        }
+    }
+}

--- a/crates/aegis-manifest/src/lib.rs
+++ b/crates/aegis-manifest/src/lib.rs
@@ -1,0 +1,232 @@
+// Phase 4a of #286. README becomes the rustdoc landing page
+// (same pattern as the library trio).
+#![allow(clippy::doc_markdown)]
+#![doc = include_str!("../README.md")]
+//!
+//! ---
+//!
+//! # Rust API
+//!
+//! The core type is [`Manifest`] — the on-disk JSON body that gets
+//! written to `::/aegis-boot-manifest.json` + signed into
+//! `::/aegis-boot-manifest.json.minisig`. Every field is part of a
+//! pinned wire contract; see the comments on each struct for the
+//! invariants a verifier must enforce.
+//!
+//! # Schema versioning
+//!
+//! [`SCHEMA_VERSION`] is the canonical value for `schema_version`.
+//! Bump it only alongside a shape-breaking change (removing a field,
+//! changing a field's type). Adding a new optional field is
+//! backwards-compatible and does not require a version bump — the
+//! verifier ignores fields it doesn't know about.
+//!
+//! # JSON Schema
+//!
+//! With the `schema` feature enabled, every public type derives
+//! [`schemars::JsonSchema`]. The `aegis-manifest-schema-docgen`
+//! binary emits a validated JSON Schema document to
+//! `docs/reference/schemas/aegis-boot-manifest.schema.json` in the
+//! parent workspace; third-party verifiers can pin to this schema.
+
+use serde::{Deserialize, Serialize};
+
+/// Locked schema version. Bump alongside a breaking shape change
+/// (removing a field, changing a field's type). Adding a new
+/// optional field is backwards-compatible and does not require a
+/// version bump — the verifier ignores fields it doesn't know about.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Top-level manifest body. Serialized field order matches the
+/// declaration order below — relied on for canonical JSON stability
+/// (the signature is computed over `serde_json::to_vec(&Manifest)`).
+///
+/// The Rust field is `sequence` (clippy prefers not to prefix the
+/// struct name); the JSON wire field stays `manifest_sequence` per
+/// the [#277] schema lock via `#[serde(rename)]`.
+///
+/// [#277]: https://github.com/williamzujkowski/aegis-boot/issues/277
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Manifest {
+    /// Wire-format version. See [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// `aegis-boot` binary version that produced the manifest
+    /// (e.g. `"aegis-boot 0.14.1"`). Informational — not a trust
+    /// anchor.
+    pub tool_version: String,
+    /// Monotonic-per-flash sequence number. Defends against
+    /// rollback to an older validly-signed manifest without
+    /// relying on a secure RTC. Verifiers track the highest
+    /// sequence they've ever seen for a given device fingerprint
+    /// and reject manifests whose sequence is strictly less.
+    #[serde(rename = "manifest_sequence")]
+    pub sequence: u64,
+    /// Device identity captured at flash time.
+    pub device: Device,
+    /// Closed set of files on the ESP. Verifier rejects the stick
+    /// if any ESP file is not listed here or is missing / has a
+    /// different sha256 than recorded. Six entries today, one per
+    /// line in the signed-chain layout established by Phase 2b of
+    /// [#274](https://github.com/williamzujkowski/aegis-boot/issues/274).
+    pub esp_files: Vec<EspFileEntry>,
+    /// When `true`, the verifier treats [`Self::esp_files`] as
+    /// exhaustive — the presence of any additional file on the ESP
+    /// is itself a violation. Always `true` in PR3; left as a
+    /// field so future phases can ship an evolutionary "extended"
+    /// manifest without breaking consumers.
+    pub allowed_files_closed_set: bool,
+    /// Reserved for E6 / Phase 3 TPM attestation. Left empty by
+    /// PR3; once E6 locks the PCR selection this vector grows
+    /// populated rows.
+    pub expected_pcrs: Vec<PcrEntry>,
+}
+
+/// Device identity captured at flash time. All values come from the
+/// freshly-written GPT (`blkid` + `sgdisk -p`); the verifier
+/// re-reads them at runtime and asserts equality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Device {
+    /// GPT disk GUID.
+    pub disk_guid: String,
+    /// Total partition count observed at flash time. aegis-boot
+    /// lays down exactly two partitions (ESP + AEGIS_ISOS); a
+    /// verifier reading three or more partitions on the same disk
+    /// rejects the stick.
+    pub partition_count: u32,
+    /// ESP partition identity — first partition by design.
+    pub esp: EspPartition,
+    /// Data partition identity — `AEGIS_ISOS` label, exfat by
+    /// default, fat32 or ext4 opt-in.
+    pub data: DataPartition,
+}
+
+/// Identity of the ESP partition (partition 1).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EspPartition {
+    /// GPT PARTUUID (per-partition unique identifier).
+    pub partuuid: String,
+    /// GPT partition-type GUID. For the ESP this is
+    /// `C12A7328-F81F-11D2-BA4B-00A0C93EC93B`.
+    pub type_guid: String,
+    /// FAT32 volume serial number (`blkid -o value -s UUID`).
+    pub fs_uuid: String,
+    /// First absolute LBA of the partition's extent on disk.
+    pub first_lba: u64,
+    /// Last absolute LBA of the partition's extent on disk.
+    pub last_lba: u64,
+}
+
+/// Identity of the AEGIS_ISOS data partition (partition 2).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DataPartition {
+    /// GPT PARTUUID.
+    pub partuuid: String,
+    /// GPT partition-type GUID — Microsoft Basic Data for
+    /// exfat/fat32, Linux Filesystem for ext4.
+    pub type_guid: String,
+    /// Filesystem UUID.
+    pub fs_uuid: String,
+    /// Filesystem label — always `AEGIS_ISOS` for aegis-boot
+    /// sticks.
+    pub label: String,
+}
+
+/// A single file on the ESP with its content hash and size.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EspFileEntry {
+    /// Mtools-style `::/`-rooted path on the ESP (e.g.
+    /// `::/EFI/BOOT/BOOTX64.EFI`). The verifier lowercases both
+    /// sides before comparison because FAT32 is case-insensitive.
+    pub path: String,
+    /// Lowercase hex sha256 of the file body.
+    pub sha256: String,
+    /// File size in bytes. Redundant with sha256 but cheap to
+    /// check first — a size mismatch lets the verifier reject
+    /// without reading the full body.
+    pub size_bytes: u64,
+}
+
+/// Expected TPM PCR value at an aegis-boot stick's first post-boot
+/// measurement. Empty in PR3; populated once E6 locks the PCR
+/// selection.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PcrEntry {
+    /// PCR index (0..23 for most banks).
+    pub pcr_index: u32,
+    /// Hash bank — `sha256`, `sha384`, etc.
+    pub bank: String,
+    /// Lowercase hex expected digest.
+    pub digest_hex: String,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn sample_manifest() -> Manifest {
+        Manifest {
+            schema_version: SCHEMA_VERSION,
+            tool_version: "aegis-boot 0.14.1".to_string(),
+            sequence: 42,
+            device: Device {
+                disk_guid: "00000000-0000-0000-0000-000000000001".to_string(),
+                partition_count: 2,
+                esp: EspPartition {
+                    partuuid: "aaa".to_string(),
+                    type_guid: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B".to_string(),
+                    fs_uuid: "1234-ABCD".to_string(),
+                    first_lba: 2048,
+                    last_lba: 821_247,
+                },
+                data: DataPartition {
+                    partuuid: "bbb".to_string(),
+                    type_guid: "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7".to_string(),
+                    fs_uuid: "ABCD-1234".to_string(),
+                    label: "AEGIS_ISOS".to_string(),
+                },
+            },
+            esp_files: vec![EspFileEntry {
+                path: "::/EFI/BOOT/BOOTX64.EFI".to_string(),
+                sha256: "0".repeat(64),
+                size_bytes: 947_200,
+            }],
+            allowed_files_closed_set: true,
+            expected_pcrs: vec![],
+        }
+    }
+
+    #[test]
+    fn schema_version_is_one() {
+        // Bumping this is intentional and downstream-visible.
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn round_trip_preserves_all_fields() {
+        let m = sample_manifest();
+        let body = serde_json::to_string(&m).expect("serialize");
+        let parsed: Manifest = serde_json::from_str(&body).expect("parse");
+        assert_eq!(m, parsed);
+    }
+
+    #[test]
+    fn serialized_uses_manifest_sequence_wire_name() {
+        let m = sample_manifest();
+        let body = serde_json::to_string(&m).expect("serialize");
+        assert!(
+            body.contains("\"manifest_sequence\":42"),
+            "wire field should be manifest_sequence, got: {body}"
+        );
+        assert!(
+            !body.contains("\"sequence\":"),
+            "bare `sequence` leak would break verifiers: {body}"
+        );
+    }
+}

--- a/docs/reference/schemas/aegis-boot-manifest.schema.json
+++ b/docs/reference/schemas/aegis-boot-manifest.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Manifest",
+  "description": "Top-level manifest body. Serialized field order matches the declaration order below — relied on for canonical JSON stability (the signature is computed over `serde_json::to_vec(&Manifest)`).\n\nThe Rust field is `sequence` (clippy prefers not to prefix the struct name); the JSON wire field stays `manifest_sequence` per the [#277] schema lock via `#[serde(rename)]`.\n\n[#277]: https://github.com/williamzujkowski/aegis-boot/issues/277",
+  "type": "object",
+  "required": [
+    "allowed_files_closed_set",
+    "device",
+    "esp_files",
+    "expected_pcrs",
+    "manifest_sequence",
+    "schema_version",
+    "tool_version"
+  ],
+  "properties": {
+    "allowed_files_closed_set": {
+      "description": "When `true`, the verifier treats [`Self::esp_files`] as exhaustive — the presence of any additional file on the ESP is itself a violation. Always `true` in PR3; left as a field so future phases can ship an evolutionary \"extended\" manifest without breaking consumers.",
+      "type": "boolean"
+    },
+    "device": {
+      "description": "Device identity captured at flash time.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Device"
+        }
+      ]
+    },
+    "esp_files": {
+      "description": "Closed set of files on the ESP. Verifier rejects the stick if any ESP file is not listed here or is missing / has a different sha256 than recorded. Six entries today, one per line in the signed-chain layout established by Phase 2b of [#274](https://github.com/williamzujkowski/aegis-boot/issues/274).",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/EspFileEntry"
+      }
+    },
+    "expected_pcrs": {
+      "description": "Reserved for E6 / Phase 3 TPM attestation. Left empty by PR3; once E6 locks the PCR selection this vector grows populated rows.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PcrEntry"
+      }
+    },
+    "manifest_sequence": {
+      "description": "Monotonic-per-flash sequence number. Defends against rollback to an older validly-signed manifest without relying on a secure RTC. Verifiers track the highest sequence they've ever seen for a given device fingerprint and reject manifests whose sequence is strictly less.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "schema_version": {
+      "description": "Wire-format version. See [`SCHEMA_VERSION`].",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "tool_version": {
+      "description": "`aegis-boot` binary version that produced the manifest (e.g. `\"aegis-boot 0.14.1\"`). Informational — not a trust anchor.",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "DataPartition": {
+      "description": "Identity of the AEGIS_ISOS data partition (partition 2).",
+      "type": "object",
+      "required": [
+        "fs_uuid",
+        "label",
+        "partuuid",
+        "type_guid"
+      ],
+      "properties": {
+        "fs_uuid": {
+          "description": "Filesystem UUID.",
+          "type": "string"
+        },
+        "label": {
+          "description": "Filesystem label — always `AEGIS_ISOS` for aegis-boot sticks.",
+          "type": "string"
+        },
+        "partuuid": {
+          "description": "GPT PARTUUID.",
+          "type": "string"
+        },
+        "type_guid": {
+          "description": "GPT partition-type GUID — Microsoft Basic Data for exfat/fat32, Linux Filesystem for ext4.",
+          "type": "string"
+        }
+      }
+    },
+    "Device": {
+      "description": "Device identity captured at flash time. All values come from the freshly-written GPT (`blkid` + `sgdisk -p`); the verifier re-reads them at runtime and asserts equality.",
+      "type": "object",
+      "required": [
+        "data",
+        "disk_guid",
+        "esp",
+        "partition_count"
+      ],
+      "properties": {
+        "data": {
+          "description": "Data partition identity — `AEGIS_ISOS` label, exfat by default, fat32 or ext4 opt-in.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DataPartition"
+            }
+          ]
+        },
+        "disk_guid": {
+          "description": "GPT disk GUID.",
+          "type": "string"
+        },
+        "esp": {
+          "description": "ESP partition identity — first partition by design.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EspPartition"
+            }
+          ]
+        },
+        "partition_count": {
+          "description": "Total partition count observed at flash time. aegis-boot lays down exactly two partitions (ESP + AEGIS_ISOS); a verifier reading three or more partitions on the same disk rejects the stick.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "EspFileEntry": {
+      "description": "A single file on the ESP with its content hash and size.",
+      "type": "object",
+      "required": [
+        "path",
+        "sha256",
+        "size_bytes"
+      ],
+      "properties": {
+        "path": {
+          "description": "Mtools-style `::/`-rooted path on the ESP (e.g. `::/EFI/BOOT/BOOTX64.EFI`). The verifier lowercases both sides before comparison because FAT32 is case-insensitive.",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "Lowercase hex sha256 of the file body.",
+          "type": "string"
+        },
+        "size_bytes": {
+          "description": "File size in bytes. Redundant with sha256 but cheap to check first — a size mismatch lets the verifier reject without reading the full body.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "EspPartition": {
+      "description": "Identity of the ESP partition (partition 1).",
+      "type": "object",
+      "required": [
+        "first_lba",
+        "fs_uuid",
+        "last_lba",
+        "partuuid",
+        "type_guid"
+      ],
+      "properties": {
+        "first_lba": {
+          "description": "First absolute LBA of the partition's extent on disk.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "fs_uuid": {
+          "description": "FAT32 volume serial number (`blkid -o value -s UUID`).",
+          "type": "string"
+        },
+        "last_lba": {
+          "description": "Last absolute LBA of the partition's extent on disk.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "partuuid": {
+          "description": "GPT PARTUUID (per-partition unique identifier).",
+          "type": "string"
+        },
+        "type_guid": {
+          "description": "GPT partition-type GUID. For the ESP this is `C12A7328-F81F-11D2-BA4B-00A0C93EC93B`.",
+          "type": "string"
+        }
+      }
+    },
+    "PcrEntry": {
+      "description": "Expected TPM PCR value at an aegis-boot stick's first post-boot measurement. Empty in PR3; populated once E6 locks the PCR selection.",
+      "type": "object",
+      "required": [
+        "bank",
+        "digest_hex",
+        "pcr_index"
+      ],
+      "properties": {
+        "bank": {
+          "description": "Hash bank — `sha256`, `sha384`, etc.",
+          "type": "string"
+        },
+        "digest_hex": {
+          "description": "Lowercase hex expected digest.",
+          "type": "string"
+        },
+        "pcr_index": {
+          "description": "PCR index (0..23 for most banks).",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4a of [#286](https://github.com/williamzujkowski/aegis-boot/issues/286). First slice of [#290](https://github.com/williamzujkowski/aegis-boot/issues/290) — ships schemars-backed JSON Schema for the attestation manifest (the one envelope that was already serde-ready).

## Design decision

Phase 4's scope survey found 9 of 10 \`--json\` envelopes in aegis-cli are hand-rolled \`println!()\` emitters. Only \`aegis-boot-manifest.json\` uses serde. Rather than block Phase 4 on a 1000+ LOC \`println!\` → serde refactor across 9 modules, I split the scope:

| Phase | Scope | Status |
|---|---|---|
| **4a** (this PR) | Manifest schema via schemars. Extract \`aegis-manifest\` library crate. Schema drift-check CI. | ✅ |
| 4b (follow-up) | Refactor 9 hand-rolled \`--json\` emitters into \`#[derive(Serialize)]\` structs. Golden-file tests guard wire compat. | open |
| 4c (follow-up) | Add \`#[derive(JsonSchema)]\` to the 4b structs. Emit \`docs/reference/schemas/*.json\`. | open |

## What ships

- **\`crates/aegis-manifest/\`** — new workspace library crate. Types only (\`Manifest\`, \`Device\`, \`EspPartition\`, \`DataPartition\`, \`EspFileEntry\`, \`PcrEntry\`) + \`SCHEMA_VERSION = 1\`. No fs I/O, no signer/verifier, pure Rust. Optional \`schema\` feature enables schemars derives + the docgen binary.
- **\`aegis-manifest-schema-docgen\`** — feature-gated bin emitting \`docs/reference/schemas/aegis-boot-manifest.schema.json\`. Standard \`--write\`/\`--check\` pattern matching the other docgens.
- **214-line JSON Schema** committed with rich descriptions pulled from Rust doc comments via schemars.
- **\`direct_install_manifest.rs\`** narrowed to writer/signer/verifier; re-exports the wire types from aegis-manifest (zero call-site changes elsewhere in aegis-cli).
- **CI** — new \`manifest-schema-drift\` job.

## Why extract a crate (not \`[lib]\` in aegis-cli)

schemars needs library visibility. Three options considered:
1. Add \`[lib]\` to aegis-cli → wide-blast \`use aegis_cli::...\` refactor
2. \`#[path]\` include from feature-gated bin → blocked by transitive deps on \`direct_install\` constants
3. Extract a new crate → clean dep graph, minimal blast radius, third parties can consume directly

Picked (3). New crate is ~220 LOC with deps just on \`serde\` + \`serde_json\` + \`thiserror\` (+ optional \`schemars\`).

## Test plan

- [x] \`cargo test --workspace --all-features --locked\` — all suites pass (361 aegis-cli + 3 aegis-manifest + all other crates)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean (pedantic)
- [x] \`cargo check -p aegis-cli -p aegis-manifest --target x86_64-apple-darwin --all-targets\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] Round-trip: edited sample schema → \`--check\` exits 1; regenerated → exits 0
- [x] \`manifest-schema-drift\` CI job passes on first run

## Value delivered for third parties

The committed schema file at \`docs/reference/schemas/aegis-boot-manifest.schema.json\` is now a stable contract third-party verifiers (rescue-tui external integrators, aegis-hwsim E6, anyone writing a non-aegis-boot tool to validate a flashed stick) can pin against. A manifest-shape change on the Rust side will fail \`manifest-schema-drift\` CI before it can merge — no silent wire-format drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)