### PR TITLE
feat(ux): preflight mkusb.sh deps in doctor + install.sh (closes #313)

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -314,6 +314,30 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
         "lsblk",
         "lists removable drives for `flash` auto-detect",
     );
+    // mkusb.sh dependencies (#313). These are required by the build
+    // path `aegis-boot init` invokes — mcopy stages the ESP, mkfs.vfat
+    // formats the ESP, mkfs.exfat formats the AEGIS_ISOS data
+    // partition (default since #243). Pre-flighting them here catches
+    // the class of late failure that motivated operator-reported
+    // bug #282.
+    check_command_present_with_pkg(
+        &mut report,
+        "mcopy",
+        "mtools",
+        "copies the signed boot chain onto the ESP (`aegis-boot flash`)",
+    );
+    check_command_present_with_pkg(
+        &mut report,
+        "mkfs.vfat",
+        "dosfstools",
+        "formats the ESP partition FAT32 (`aegis-boot flash`)",
+    );
+    check_command_present_with_pkg(
+        &mut report,
+        "mkfs.exfat",
+        "exfatprogs",
+        "formats the AEGIS_ISOS data partition exFAT (`aegis-boot flash`)",
+    );
     check_command_present(
         &mut report,
         "curl",
@@ -642,6 +666,14 @@ fn check_cosign_optional(report: &mut Report) {
 }
 
 fn check_command_present(report: &mut Report, cmd: &str, why: &str) {
+    check_command_present_with_pkg(report, cmd, cmd, why);
+}
+
+/// Like [`check_command_present`] but lets callers specify the
+/// package name when it differs from the binary name (e.g. the
+/// `mkfs.vfat` binary ships in the `dosfstools` package). Used for
+/// the mkusb.sh dependency preflight (#313).
+fn check_command_present_with_pkg(report: &mut Report, cmd: &str, pkg: &str, why: &str) {
     let found = which(cmd);
     let name = format!("command: {cmd}");
     if let Some(path) = found {
@@ -651,7 +683,11 @@ fn check_command_present(report: &mut Report, cmd: &str, why: &str) {
             Verdict::Fail,
             name,
             format!("not found in PATH ({why})"),
-            format!("install `{cmd}` (e.g. on Debian/Ubuntu: `sudo apt-get install {cmd}`)"),
+            format!(
+                "install `{cmd}` (on Debian/Ubuntu: `sudo apt-get install {pkg}`; \
+                 on Fedora/RHEL: `sudo dnf install {pkg}`; \
+                 on Arch: `sudo pacman -S {pkg}`)"
+            ),
         );
     }
 }
@@ -1074,5 +1110,55 @@ mod tests {
         assert_eq!(r.rows.len(), 2);
         assert!(matches!(r.rows[0].0, Verdict::Skip));
         assert!(matches!(r.rows[1].0, Verdict::Skip));
+    }
+
+    #[test]
+    fn check_command_present_with_pkg_finds_existing_binary() {
+        // `ls` is present on every supported platform's PATH — use
+        // it as a known-good probe to verify the Pass path of the
+        // pkg-aware variant.
+        let mut r = Report::new();
+        check_command_present_with_pkg(&mut r, "ls", "coreutils", "canary");
+        assert_eq!(r.rows.len(), 1);
+        assert!(
+            matches!(r.rows[0].0, Verdict::Pass),
+            "expected Pass for `ls`, got {:?}",
+            r.rows[0].0
+        );
+        assert!(r.rows[0].2.contains("canary"));
+    }
+
+    #[test]
+    fn check_command_present_with_pkg_reports_package_name_on_miss() {
+        // The package name is load-bearing — `mkfs.vfat` ships in
+        // `dosfstools`, not in a hypothetical `mkfs.vfat` package.
+        // On a miss, the remedy text must name the package, not
+        // the binary. #313 acceptance criterion.
+        let mut r = Report::new();
+        check_command_present_with_pkg(
+            &mut r,
+            "aegis-probe-never-installed-binary-for-test",
+            "dosfstools",
+            "guards the pkg-name surfaces in remedy text",
+        );
+        assert_eq!(r.rows.len(), 1);
+        assert!(
+            matches!(r.rows[0].0, Verdict::Fail),
+            "expected Fail for missing binary, got {:?}",
+            r.rows[0].0
+        );
+        // First-Fail remedy gets promoted to Report::next_action.
+        // Verify it names the package + the three common distro
+        // families (the #313 acceptance criterion is a multi-distro
+        // hint, not a per-distro auto-detection).
+        let na = r.next_action.as_deref().unwrap_or("");
+        assert!(
+            na.contains("dosfstools"),
+            "remedy must name the package, got: {na}"
+        );
+        assert!(
+            na.contains("apt-get") && na.contains("dnf") && na.contains("pacman"),
+            "remedy must list the three common distro families, got: {na}"
+        );
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,11 +278,57 @@ main() {
     install_completions "$version"
     install_manpage "$version"
 
+    # Post-install dependency preflight (#313). `aegis-boot doctor`
+    # already checks the mkusb.sh dep stack (mcopy, mkfs.vfat,
+    # mkfs.exfat, sgdisk, dd, …); running it here surfaces any gaps
+    # at install time instead of at first-flash time. Warning-only —
+    # the operator may have installed just to read `aegis-boot man`
+    # or `aegis-boot recommend`, and the missing deps only matter
+    # when they later try to flash. The actual `aegis-boot flash`
+    # path will still FAIL on any missing dep; this just advises
+    # fix-it-now with a copy-pasteable install line.
+    preflight_deps "$target"
+
     note ""
     note "Try it:"
     note "  $target --version"
     note "  $target doctor"
     note "  $target recommend"
+}
+
+# Run `aegis-boot doctor` as a post-install dep preflight. Prints
+# the report verbatim on exit code 0 (all-pass, no warnings); on any
+# non-zero exit suppresses the full report but surfaces a short
+# "follow-up" note pointing the operator at `aegis-boot doctor` for
+# detail. Never fails the installer — the binary is installed, the
+# operator just has follow-up work.
+preflight_deps() {
+    bin="$1"
+    if [ ! -x "$bin" ]; then
+        return 0
+    fi
+    note ""
+    note "Running post-install dependency preflight (\`$bin doctor\`)..."
+    # Capture doctor's exit code without blowing up the installer.
+    # `doctor` exits 0 on all-pass, 1 if any FAIL rows surfaced.
+    # The `&& x=0 || x=$?` pattern captures the real exit code under
+    # `set -e` — a plain `|| true` would always yield $? = 0.
+    doctor_out="$("$bin" doctor 2>&1)" && doctor_code=0 || doctor_code=$?
+    if [ "$doctor_code" -eq 0 ]; then
+        # All-pass: collapse to a single line to keep the install
+        # output tight. Operator can always re-run `doctor` for full
+        # detail.
+        note "  all checks pass"
+    else
+        # Non-zero: dump the report so the operator sees the gaps
+        # immediately. Prefix each line so it's clearly doctor
+        # output (not install.sh noise).
+        note ""
+        printf '%s\n' "$doctor_out" | sed 's/^/  /'
+        note ""
+        note "Some checks above warrant follow-up. Re-run \`$bin doctor\` for detail."
+        note "This is a warning, not a failure — aegis-boot itself is installed."
+    fi
 }
 
 # Install bash + zsh completion files from the repo (raw.githubusercontent.com).


### PR DESCRIPTION
## Summary

Fixes the operator-experience gap surfaced in [#310](https://github.com/williamzujkowski/aegis-boot/issues/310)'s UX assessment, ratified by the consensus_vote at 80% approve. Same class of bug as [#282](https://github.com/williamzujkowski/aegis-boot/issues/282). **Closes [#313](https://github.com/williamzujkowski/aegis-boot/issues/313).**

## What ships

- **\`doctor\` gains 3 new binary checks** (\`mcopy\`, \`mkfs.vfat\`, \`mkfs.exfat\`) covering the mkusb.sh dep stack that was previously uncaught.
- **New \`check_command_present_with_pkg\` helper** for binary-vs-package name asymmetry. Multi-distro remedy text (Debian/Ubuntu + Fedora/RHEL + Arch one-liners).
- **\`install.sh\` post-install preflight** — calls \`\$target doctor\` after the binary is installed. All-pass → single-line acknowledgement. Any gaps → full report dumped (indented), never fails the installer.

## Scope correction vs. original issue

Original #313 suggested a \`doctor --remedy\` flag with structured output. Deferred as YAGNI — \`doctor --json\` already surfaces the same rows structurally. A \`--remedy\` follow-up can land when a concrete automation consumer emerges.

Per the consensus-vote Contrarian: this is NOT full package-manager matrix detection. It's three static one-liners per common distro, the operator picks.

## Test plan

- [x] 363 aegis-cli tests (up from 361 — 2 new \`check_command_present_with_pkg\` tests)
- [x] Full \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] macOS cross-compile clean
- [x] \`shellcheck -S warning scripts/install.sh\` clean
- [x] All 4 schema drift-checks + constants + CLI + doc-version drifts still pass

## New tests

- \`check_command_present_with_pkg_finds_existing_binary\` — Pass path via \`ls\`
- \`check_command_present_with_pkg_reports_package_name_on_miss\` — Fail path verifies the PACKAGE name (not binary name) is in the remedy, and all three distro families are listed

## Related

- [#310](https://github.com/williamzujkowski/aegis-boot/issues/310) — UX umbrella (3 findings)
- [#282](https://github.com/williamzujkowski/aegis-boot/issues/282) — the operator-reported bug that motivated this class
- Consensus vote: higher_order 80% approve, Contrarian's scope-creep callout addressed

## Follow-ups per the ratified vote sequencing

- [#312](https://github.com/williamzujkowski/aegis-boot/issues/312) — rescue-tui empty-state footer affordances (next)
- [#311](https://github.com/williamzujkowski/aegis-boot/issues/311) — fetch/recommend progress bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)