### PR TITLE
feat(doctor): refactor doctor --json to typed envelope + JSON Schema (Phase 4b-8 of #286, closes Phase 4b of #290)

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -199,32 +199,27 @@ impl Report {
     fn print_json_summary(&self) {
         let score = self.score();
         let band = band_for_score(score);
-        println!("{{");
-        println!("  \"schema_version\": 1,");
-        println!("  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
-        println!("  \"score\": {score},");
-        println!("  \"band\": \"{band}\",");
-        println!(
-            "  \"has_any_fail\": {},",
-            if self.has_any_fail() { "true" } else { "false" }
-        );
-        match &self.next_action {
-            Some(na) => println!("  \"next_action\": \"{}\",", json_escape(na)),
-            None => println!("  \"next_action\": null,"),
+        let report = aegis_manifest::DoctorReport {
+            schema_version: aegis_manifest::DOCTOR_SCHEMA_VERSION,
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            score: u32::from(score),
+            band: band.to_string(),
+            has_any_fail: self.has_any_fail(),
+            next_action: self.next_action.clone(),
+            rows: self
+                .rows
+                .iter()
+                .map(|(verdict, name, detail)| aegis_manifest::DoctorRow {
+                    verdict: verdict.label().to_string(),
+                    name: name.clone(),
+                    detail: detail.clone(),
+                })
+                .collect(),
+        };
+        match serde_json::to_string_pretty(&report) {
+            Ok(body) => println!("{body}"),
+            Err(e) => eprintln!("aegis-boot doctor: failed to serialize --json envelope: {e}"),
         }
-        println!("  \"rows\": [");
-        let last = self.rows.len().saturating_sub(1);
-        for (i, (verdict, name, detail)) in self.rows.iter().enumerate() {
-            let comma = if i == last { "" } else { "," };
-            println!(
-                "    {{ \"verdict\": \"{}\", \"name\": \"{}\", \"detail\": \"{}\" }}{comma}",
-                verdict.label(),
-                json_escape(name),
-                json_escape(detail),
-            );
-        }
-        println!("  ]");
-        println!("}}");
     }
 }
 

--- a/crates/aegis-manifest/src/bin/schema_docgen.rs
+++ b/crates/aegis-manifest/src/bin/schema_docgen.rs
@@ -34,9 +34,9 @@
 //! * [`aegis_manifest::CompatSubmitReport`] →
 //!   `docs/reference/schemas/aegis-boot-compat-submit.schema.json`
 //!   (Phase 4b-7 of [#286])
-//! * [`aegis_manifest::RecommendReport`] →
-//!   `docs/reference/schemas/aegis-boot-recommend.schema.json`
-//!   (Phase 4b-6 of [#286])
+//! * [`aegis_manifest::DoctorReport`] →
+//!   `docs/reference/schemas/aegis-boot-doctor.schema.json`
+//!   (Phase 4b-8 of [#286])
 //!
 //! CI's `manifest-schema-drift` job runs this in `--check` mode on
 //! every PR. Any time a field is added, removed, or retyped on any
@@ -63,8 +63,8 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use aegis_manifest::{
-    AttestListReport, Attestation, CompatReport, CompatSubmitReport, ListReport, Manifest,
-    RecommendReport, UpdateReport, VerifyReport, Version,
+    AttestListReport, Attestation, CompatReport, CompatSubmitReport, DoctorReport, ListReport,
+    Manifest, RecommendReport, UpdateReport, VerifyReport, Version,
 };
 use schemars::schema_for;
 
@@ -128,6 +128,11 @@ fn targets() -> Vec<Target> {
             relative_path: "docs/reference/schemas/aegis-boot-compat-submit.schema.json",
             render: render_compat_submit_schema,
         },
+        Target {
+            name: "DoctorReport",
+            relative_path: "docs/reference/schemas/aegis-boot-doctor.schema.json",
+            render: render_doctor_schema,
+        },
     ]
 }
 
@@ -169,6 +174,10 @@ fn render_compat_schema() -> Result<String, String> {
 
 fn render_compat_submit_schema() -> Result<String, String> {
     render_pretty(&schema_for!(CompatSubmitReport))
+}
+
+fn render_doctor_schema() -> Result<String, String> {
+    render_pretty(&schema_for!(DoctorReport))
 }
 
 /// Serialize a JSON Schema as pretty-printed JSON with a trailing

--- a/crates/aegis-manifest/src/lib.rs
+++ b/crates/aegis-manifest/src/lib.rs
@@ -44,8 +44,8 @@
 //! * **CLI envelopes** ([`Version`], [`ListReport`],
 //!   [`AttestListReport`], [`VerifyReport`], [`UpdateReport`],
 //!   [`RecommendReport`], [`CompatReport`], [`CompatSubmitReport`],
-//!   with their `*_SCHEMA_VERSION` constants) — the `--json`
-//!   envelopes emitted by `aegis-boot --version --json`,
+//!   [`DoctorReport`], with their `*_SCHEMA_VERSION` constants) —
+//!   the `--json` envelopes emitted by `aegis-boot --version --json`,
 //!   `... list --json`, `... attest list --json`, `... verify --json`,
 //!   `... update --json`, `... recommend --json`, `... compat --json`,
 //!   `... compat --submit --json`, and siblings. Phase 4b of [#286].
@@ -117,6 +117,11 @@ pub const COMPAT_SCHEMA_VERSION: u32 = 1;
 /// consumer contracts (operators draft-submit vs. scripted
 /// lookup).
 pub const COMPAT_SUBMIT_SCHEMA_VERSION: u32 = 1;
+
+/// Locked schema version for the [`DoctorReport`] envelope emitted
+/// by `aegis-boot doctor --json`. Independent of the other envelope
+/// contracts.
+pub const DOCTOR_SCHEMA_VERSION: u32 = 1;
 
 /// Top-level manifest body. Serialized field order matches the
 /// declaration order below — relied on for canonical JSON stability
@@ -946,6 +951,54 @@ pub struct CompatSubmitReport {
     pub firmware: String,
 }
 
+/// Envelope emitted by `aegis-boot doctor --json`. Reports host +
+/// stick health as a rollup score + per-check rows. The monitoring /
+/// CI consumer target — a non-zero `has_any_fail` is the signal to
+/// surface to an operator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DoctorReport {
+    /// Wire-format version. See [`DOCTOR_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// `aegis-boot` binary version that produced this envelope.
+    pub tool_version: String,
+    /// Aggregate score (0–100). PASS = 1.0, WARN = 0.7, FAIL =
+    /// 0.0; skipped rows are excluded from the denominator.
+    pub score: u32,
+    /// Human-readable score band: typically `"EXCELLENT"`,
+    /// `"GOOD"`, `"FAIR"`, or `"POOR"`. Exact thresholds are an
+    /// implementation detail of the CLI; consumers should treat
+    /// these as opaque labels paired with the numeric `score`.
+    pub band: String,
+    /// True iff any row's `verdict` is `"FAIL"`. The minimal
+    /// rollup bit for monitoring: operator attention required.
+    pub has_any_fail: bool,
+    /// Operator-facing remediation hint pulled from the first
+    /// `FAIL` row's `next_action` text. `None` when no row failed
+    /// or none carried a remedy.
+    pub next_action: Option<String>,
+    /// One entry per check run. Order is check-declaration order
+    /// inside `doctor.rs` — stable across invocations on the same
+    /// host.
+    pub rows: Vec<DoctorRow>,
+}
+
+/// One check result in a [`DoctorReport`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DoctorRow {
+    /// Verdict label — `"PASS"`, `"WARN"`, `"FAIL"`, or `"SKIP"`.
+    /// String (not enum) because the CLI's verdict vocabulary is
+    /// intentionally loose: new verdicts can be added without a
+    /// `schema_version` bump so long as consumers treat unknown
+    /// values as "don't block on this."
+    pub verdict: String,
+    /// Short check name (e.g. `"command: mcopy"`).
+    pub name: String,
+    /// Single-line detail (filepath, value, or error message).
+    pub detail: String,
+}
+
 /// One curated catalog entry. Used in both
 /// [`RecommendCatalogReport::entries`] and
 /// [`RecommendSingleReport::entry`].
@@ -1745,5 +1798,85 @@ mod tests {
         assert!(body.contains("\"tool\":\"aegis-boot\""));
         assert!(!body.contains("\"tool_version\""), "{body}");
         assert!(body.contains("\"submit_url\""));
+    }
+
+    fn sample_doctor_report() -> DoctorReport {
+        DoctorReport {
+            schema_version: DOCTOR_SCHEMA_VERSION,
+            tool_version: "0.14.1".to_string(),
+            score: 85,
+            band: "GOOD".to_string(),
+            has_any_fail: false,
+            next_action: None,
+            rows: vec![
+                DoctorRow {
+                    verdict: "PASS".to_string(),
+                    name: "OS".to_string(),
+                    detail: "Linux 6.17.0".to_string(),
+                },
+                DoctorRow {
+                    verdict: "WARN".to_string(),
+                    name: "Secure Boot (host)".to_string(),
+                    detail: "disabled".to_string(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn doctor_schema_version_is_one() {
+        assert_eq!(DOCTOR_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn doctor_round_trips_and_preserves_all_fields() {
+        let r = sample_doctor_report();
+        let body = serde_json::to_string(&r).expect("serialize");
+        let parsed: DoctorReport = serde_json::from_str(&body).expect("parse");
+        assert_eq!(r, parsed);
+    }
+
+    #[test]
+    fn doctor_next_action_null_when_absent() {
+        // next_action = null when no FAIL row carried a remedy.
+        // Must serialize as `null` (not omitted) to keep the field
+        // set stable for consumers.
+        let r = sample_doctor_report();
+        let body = serde_json::to_string(&r).expect("serialize");
+        assert!(
+            body.contains("\"next_action\":null"),
+            "next_action must be explicit null: {body}"
+        );
+    }
+
+    #[test]
+    fn doctor_next_action_populated_on_fail() {
+        let mut r = sample_doctor_report();
+        r.has_any_fail = true;
+        r.next_action = Some("install mcopy".to_string());
+        r.rows.push(DoctorRow {
+            verdict: "FAIL".to_string(),
+            name: "command: mcopy".to_string(),
+            detail: "not found in PATH".to_string(),
+        });
+        let body = serde_json::to_string(&r).expect("serialize");
+        assert!(body.contains("\"has_any_fail\":true"));
+        assert!(body.contains("\"next_action\":\"install mcopy\""));
+    }
+
+    #[test]
+    fn doctor_row_verdict_is_free_string_not_enum() {
+        // The verdict field accepts any string — the CLI's
+        // vocabulary can grow with new verdict labels without
+        // bumping schema_version. Consumer contract: treat
+        // unknown verdicts as "informational / don't block."
+        let r = DoctorRow {
+            verdict: "FUTURE-VERDICT-LABEL".to_string(),
+            name: "some new check".to_string(),
+            detail: "novel condition".to_string(),
+        };
+        let body = serde_json::to_string(&r).expect("serialize");
+        let parsed: DoctorRow = serde_json::from_str(&body).expect("parse");
+        assert_eq!(r, parsed);
     }
 }

--- a/docs/reference/schemas/aegis-boot-doctor.schema.json
+++ b/docs/reference/schemas/aegis-boot-doctor.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DoctorReport",
+  "description": "Envelope emitted by `aegis-boot doctor --json`. Reports host + stick health as a rollup score + per-check rows. The monitoring / CI consumer target — a non-zero `has_any_fail` is the signal to surface to an operator.",
+  "type": "object",
+  "required": [
+    "band",
+    "has_any_fail",
+    "rows",
+    "schema_version",
+    "score",
+    "tool_version"
+  ],
+  "properties": {
+    "band": {
+      "description": "Human-readable score band: typically `\"EXCELLENT\"`, `\"GOOD\"`, `\"FAIR\"`, or `\"POOR\"`. Exact thresholds are an implementation detail of the CLI; consumers should treat these as opaque labels paired with the numeric `score`.",
+      "type": "string"
+    },
+    "has_any_fail": {
+      "description": "True iff any row's `verdict` is `\"FAIL\"`. The minimal rollup bit for monitoring: operator attention required.",
+      "type": "boolean"
+    },
+    "next_action": {
+      "description": "Operator-facing remediation hint pulled from the first `FAIL` row's `next_action` text. `None` when no row failed or none carried a remedy.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "rows": {
+      "description": "One entry per check run. Order is check-declaration order inside `doctor.rs` — stable across invocations on the same host.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DoctorRow"
+      }
+    },
+    "schema_version": {
+      "description": "Wire-format version. See [`DOCTOR_SCHEMA_VERSION`].",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "score": {
+      "description": "Aggregate score (0–100). PASS = 1.0, WARN = 0.7, FAIL = 0.0; skipped rows are excluded from the denominator.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "tool_version": {
+      "description": "`aegis-boot` binary version that produced this envelope.",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "DoctorRow": {
+      "description": "One check result in a [`DoctorReport`].",
+      "type": "object",
+      "required": [
+        "detail",
+        "name",
+        "verdict"
+      ],
+      "properties": {
+        "detail": {
+          "description": "Single-line detail (filepath, value, or error message).",
+          "type": "string"
+        },
+        "name": {
+          "description": "Short check name (e.g. `\"command: mcopy\"`).",
+          "type": "string"
+        },
+        "verdict": {
+          "description": "Verdict label — `\"PASS\"`, `\"WARN\"`, `\"FAIL\"`, or `\"SKIP\"`. String (not enum) because the CLI's verdict vocabulary is intentionally loose: new verdicts can be added without a `schema_version` bump so long as consumers treat unknown values as \"don't block on this.\"",
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Final emitter of the Phase 4b sweep.** Completes the 8-emitter serde-refactor (version, list, attest list, verify, update, recommend, compat, doctor). Every `aegis-boot --json` surface now emits via typed envelopes in `aegis-manifest` with schemars-generated JSON Schemas third-party consumers can pin.

## What ships

- `DoctorReport` + `DoctorRow` serde types in aegis-manifest
- `DOCTOR_SCHEMA_VERSION = 1`
- `docs/reference/schemas/aegis-boot-doctor.schema.json` (11th committed schema)
- `doctor::print_json_summary` narrowed to ~20 LOC; removes hand-rolled println chain

## Design note

`verdict` is a free `String` (not enum) so the CLI can add new verdict labels (e.g. `INFO`, `DEPRECATED`) without bumping `schema_version`. Consumer contract: treat unknown verdicts as informational.

## Test plan

- [x] 43 aegis-manifest tests (up from 38) — 5 new doctor guards
- [x] 363 aegis-cli tests unchanged
- [x] Full clippy + fmt + macOS cross clean
- [x] All 11 schema drift-checks pass

## Phase 4 — COMPLETE after this merge

| Sub-phase | PR | Status |
|---|---|---|
| 4a (manifest) | #303 | ✅ merged |
| 4c-1 (attestation) | #304 | ✅ merged |
| 4b-1 (version) | #305 | ✅ merged |
| 4b-2 (list) | #308 | ✅ merged |
| 4b-3 (attest list) | #309 | ✅ merged |
| 4b-4 (verify) | #315 | ✅ merged |
| 4b-5 (update) | #316 | ✅ merged |
| 4b-6 (recommend) | #317 | ✅ merged |
| 4b-7 (compat) | #318 | pending |
| 4b-8 (doctor) | this PR | pending |

#290 ready to close once #318 + this PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)