### PR TITLE
docs: roll stale version refs forward in INSTALL.md + fetch-image help

### DIFF
--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -472,13 +472,16 @@ fn parse_args(args: &[String]) -> Result<ParsedArgs, u8> {
 fn print_help() {
     println!("aegis-boot fetch-image — download + verify a pre-built aegis-boot image");
     println!();
+    let current_ver = env!("CARGO_PKG_VERSION");
     println!("USAGE:");
     println!("  aegis-boot fetch-image                               # latest release, cosign auto-verify");
-    println!("  aegis-boot fetch-image --version v0.14.0             # pin to a specific release");
+    println!(
+        "  aegis-boot fetch-image --version v{current_ver}             # pin to a specific release"
+    );
     println!("  aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL");
     println!();
     println!("  --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)");
-    println!("  --version TAG   Pin to a specific release tag (e.g. v0.14.0)");
+    println!("  --version TAG   Pin to a specific release tag (e.g. v{current_ver})");
     println!("  --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)");
     println!("  --sha256 HEX    Required sha256; mismatch deletes the download + exits 1");
     println!("  --no-cosign     Skip the cosign keyless signature check (air-gap, offline)");

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,7 +143,7 @@ If the firmware refuses to show the USB entry, your boot mode might be CSM/Legac
 `rescue-tui` shows your ISOs with verification status:
 
 ```
-aegis-boot v0.12.0    SB:enforcing  TPM:available
+aegis-boot v0.14.1    SB:enforcing  TPM:available
 
   ▸ ubuntu-24.04.2-live-server-amd64.iso        1.6 GiB  [✓ sha256]
     alpine-3.20.3-x86_64.iso                     198 MiB  [no verify]

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -167,11 +167,11 @@ aegis-boot fetch-image — download + verify a pre-built aegis-boot image
 
 USAGE:
   aegis-boot fetch-image                               # latest release, cosign auto-verify
-  aegis-boot fetch-image --version v0.14.0             # pin to a specific release
+  aegis-boot fetch-image --version v0.14.1             # pin to a specific release
   aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL
 
   --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)
-  --version TAG   Pin to a specific release tag (e.g. v0.14.0)
+  --version TAG   Pin to a specific release tag (e.g. v0.14.1)
   --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)
   --sha256 HEX    Required sha256; mismatch deletes the download + exits 1
   --no-cosign     Skip the cosign keyless signature check (air-gap, offline)


### PR DESCRIPTION
Accuracy audit of user-facing docs found 2 stale example-version refs (INSTALL.md's rescue-tui output mockup showed `v0.12.0`; `fetch-image --help`'s `--version` example hardcoded `v0.14.0`).

Fixes:
1. INSTALL.md:146 — `v0.12.0` → `v0.14.1` in the TUI output example
2. fetch-image print_help() — hardcoded version → `env!("CARGO_PKG_VERSION")` so the example stays current every release automatically
3. Regenerated `docs/reference/CLI_SYNOPSIS.md` to reflect the new help output

4 historical refs of the form "As of v0.12.0 (#109)…" in USB_LAYOUT/UNSIGNED_KERNEL/LOCAL_TESTING are intentionally NOT touched — those are shipping-history markers, not stale examples.

Audit sweep also found: 0 marketing exaggeration, 0 out-of-date claims, 0 misleading statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)