### PR TITLE
docs: correct stale scaffolding comments + Alpine validation phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.14.1 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown validated on Alpine + Ubuntu under Secure Boot enforcing ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.14.1 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown under Secure Boot enforcing validated Ubuntu (successful kexec) + Alpine (unsigned-kernel rejection surfaces the MOK-enrollment hint as designed) ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 
@@ -68,7 +68,7 @@ curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scr
 brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
 brew install aegis-boot
 
-# Or pin a version: sh install.sh --version v0.12.0
+# Or pin a version: sh install.sh --version v0.14.1
 # Or skip cosign (NOT recommended): sh install.sh --no-verify
 # Build from source: see BUILDING.md.
 ```

--- a/crates/aegis-cli/src/plan.rs
+++ b/crates/aegis-cli/src/plan.rs
@@ -1,9 +1,7 @@
-// Foundational scaffolding for #247 — every item in this module is
-// exercised by the unit tests below but has no production caller until
-// the per-command rollout lands. Module-scoped allow keeps clippy quiet
-// without masking dead-code regressions in real callers; once the first
-// caller (planned: `flash`) wires up, drop this allow and let
-// `dead_code` surface anything that's still unwired.
+// First production caller (`flash::build_flash_plan`) uses a subset of
+// `Operation` variants + `Plan::new`/`add`. Variants and accessors reserved
+// for the `update`/`add`/`init`/`expand` rollout per #247 are kept
+// behind this module-level allow until those commands wire up.
 #![allow(dead_code)]
 
 //! `Plan` — typed, inspectable description of operations a command would perform.
@@ -12,8 +10,8 @@
 //!   - prints the plan and exits (`--dry-run` mode), or
 //!   - executes the plan in order and emits a receipt.
 //!
-//! No callers wired up in this PR. Tracked in #247; per-command rollout
-//! lands in follow-up PRs (`flash`, `update`, `add`, `init`, `expand`).
+//! First production caller: `flash::build_flash_plan`. Per-command rollout
+//! continues in follow-ups (`update`, `add`, `init`, `expand`) per #247.
 //!
 //! # Why a typed plan, not a `Vec<String>`
 //!

--- a/crates/aegis-cli/src/readback.rs
+++ b/crates/aegis-cli/src/readback.rs
@@ -10,8 +10,11 @@
 //! ~64 MB and re-checking the sha256 closes that window before the
 //! operator pulls the stick.
 //!
-//! No callers wired up in this PR. The `flash` integration lands in
-//! PR2 alongside the `indicatif`-based progress UI from #244.
+//! Wired up by `flash`: `sha256_of_first_bytes` + `DEFAULT_READBACK_BYTES`
+//! are called inline from `precompute_image_prefix_hash` (pre-dd) and
+//! `readback_verify_device` (post-dd). The high-level `verify_readback`
+//! wrapper is kept as the library-shaped API but has no production
+//! caller. See #244 for the rollout history.
 //!
 //! # Why bound to a prefix
 //!
@@ -22,7 +25,12 @@
 //! data partition isn't readback-verified because it's mutable
 //! operator content (per `USB_LAYOUT.md`).
 
-#![allow(dead_code)] // Foundation PR — callers wired in PR2. See #244.
+// `flash` uses `sha256_of_first_bytes` + `DEFAULT_READBACK_BYTES` inline
+// and surfaces its own error strings; the high-level `verify_readback`
+// helper + typed `ReadbackError` remain unused in production but are
+// kept (and unit-tested) as the library-shaped API. Dead-code allow
+// covers that deliberate gap until a caller wants structured errors.
+#![allow(dead_code)]
 
 use std::fs::File;
 use std::io::{self, Read};


### PR DESCRIPTION
## Summary

Accuracy pass over three stale-by-omission spots discovered during a scheduled staleness sweep.

- **plan.rs + readback.rs** — module-level `#[allow(dead_code)]` comments claimed "no callers wired up in this PR". That stopped being true once #244 PR2 + the flash command's #247 plan rollout landed. Updated comments to name the actual caller (`flash`) and scope what's reserved for the per-command rollout (`update`/`add`/`init`/`expand`). Allows remain — they're load-bearing under CI's `-D warnings`. No behavior change.
- **README.md status line** — "validated on Alpine + Ubuntu" understated what #109 actually established. Ubuntu kexecs successfully; Alpine is correctly *rejected* at kernel-sig-check time and the rescue-tui surfaces the MOK-enrollment hint. That's the designed behavior for unsigned kernels under `KEXEC_SIG`, not a boot success. Rephrased to match reality per distro.
- **README.md pinned-install example** — still showed `v0.12.0`; rolled to `v0.14.1`.

## Test plan

- [x] `cargo check -p aegis-cli` clean
- [x] `cargo clippy -p aegis-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] No code behavior changes — comments + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)