### PR TITLE
fix(cosign): correct sigstore docs URL (closes #329)

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -633,7 +633,7 @@ fn check_cosign_optional(report: &mut Report) {
             Verdict::Warn,
             name,
             "not found in PATH — `fetch-image` cannot cosign-verify signed images".to_string(),
-            "install cosign: https://docs.sigstore.dev/cosign/installation/ \
+            "install cosign: https://docs.sigstore.dev/cosign/system_config/installation/ \
              (not required unless you use `aegis-boot fetch-image`)"
                 .to_string(),
         );

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -172,7 +172,7 @@ fn try_cosign_verify(url: &str, image_path: &Path) {
     if !cosign_on_path() {
         eprintln!(
             "aegis-boot fetch-image: WARNING — cosign not on PATH; skipping signature \
-             verification. Install cosign (https://docs.sigstore.dev/cosign/installation/) \
+             verification. Install cosign (https://docs.sigstore.dev/cosign/system_config/installation/) \
              or pass --no-cosign to silence this warning."
         );
         return;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -196,7 +196,7 @@ main() {
     # Cosign required unless --no-verify.
     if [ "$skip_verify" -eq 0 ]; then
         if ! command -v cosign >/dev/null 2>&1; then
-            err "cosign not found in PATH. Install from https://docs.sigstore.dev/cosign/installation/"
+            err "cosign not found in PATH. Install from https://docs.sigstore.dev/cosign/system_config/installation/"
             err "or re-run with --no-verify (not recommended)"
             return 64
         fi


### PR DESCRIPTION
## Summary

Closes #329. External user @garyoakidoki reported the cosign-install URL we print in the \`aegis-boot fetch-image\` "cosign missing" warning points at a stale path. The old path \`https://docs.sigstore.dev/cosign/installation/\` still resolves via 301 redirect but sends operators on an unnecessary hop. Canonical URL per sigstore is \`https://docs.sigstore.dev/cosign/system_config/installation/\`.

Three call-sites updated:
- \`crates/aegis-cli/src/fetch_image.rs\` — the warning #329 was filed against
- \`crates/aegis-cli/src/doctor.rs\` — \`cosign (optional)\` WARN row's NEXT ACTION line
- \`scripts/install.sh\` — \`--verify\` preflight's "cosign required" error

\`docs/RELEASE_NOTES_FOOTER.md\` links \`https://docs.sigstore.dev/\` root (context, not install-me-now) so unchanged.

## Test plan

- [x] \`cargo check -p aegis-cli\` clean
- [x] \`cargo test -p aegis-cli --bin aegis-boot\` — 362 tests pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] Confirmed \`https://docs.sigstore.dev/cosign/system_config/installation/\` returns 200; old URL 301-redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)