### PR TITLE
fix(#328): doctor sbin-fallback + install.sh --cosign flag

### DIFF
--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -667,10 +667,33 @@ fn check_command_present_with_pkg(report: &mut Report, cmd: &str, pkg: &str, why
     }
 }
 
+/// Canonical sbin directories probed when `$PATH` lookup misses.
+/// Many distros (notably openSUSE, #328) do not include `/usr/sbin`
+/// in the `$PATH` inherited by `sudo` or by child processes of the
+/// install.sh post-install preflight. Root-utility commands that
+/// live only in sbin (e.g. `sgdisk`) would otherwise produce a
+/// FAIL row in `doctor` despite being installed.
+const SBIN_FALLBACKS: &[&str] = &["/usr/sbin", "/sbin", "/usr/local/sbin"];
+
 fn which(cmd: &str) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path) {
-        let candidate = dir.join(cmd);
+    which_in(cmd, std::env::var_os("PATH").as_deref(), SBIN_FALLBACKS)
+}
+
+fn which_in(
+    cmd: &str,
+    path_env: Option<&std::ffi::OsStr>,
+    sbin_fallbacks: &[&str],
+) -> Option<PathBuf> {
+    if let Some(path) = path_env {
+        for dir in std::env::split_paths(path) {
+            let candidate = dir.join(cmd);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    for sbin in sbin_fallbacks {
+        let candidate = PathBuf::from(sbin).join(cmd);
         if candidate.is_file() {
             return Some(candidate);
         }
@@ -1080,6 +1103,47 @@ mod tests {
             r.rows[0].0
         );
         assert!(r.rows[0].2.contains("canary"));
+    }
+
+    #[test]
+    fn which_in_finds_binary_on_path() {
+        let Ok(dir) = tempfile::tempdir() else { return };
+        let bin = dir.path().join("fake-cmd");
+        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
+            return;
+        }
+        let path_env = std::ffi::OsString::from(dir.path());
+        let found = which_in("fake-cmd", Some(path_env.as_os_str()), &[]);
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+    }
+
+    #[test]
+    fn which_in_falls_back_to_sbin_when_path_misses() {
+        // #328: on openSUSE the invoking shell's PATH often lacks
+        // /usr/sbin, so `sgdisk` (installed at /usr/sbin/sgdisk)
+        // reads as absent. The sbin-fallback closes that hole.
+        let Ok(dir) = tempfile::tempdir() else { return };
+        let bin = dir.path().join("sbin-only-cmd");
+        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
+            return;
+        }
+        let fallback = dir.path().to_string_lossy().into_owned();
+        let found = which_in(
+            "sbin-only-cmd",
+            Some(std::ffi::OsStr::new("/nonexistent-path")),
+            &[&fallback],
+        );
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+    }
+
+    #[test]
+    fn which_in_returns_none_when_both_miss() {
+        let found = which_in(
+            "definitely-not-a-real-binary-for-aegis-test",
+            Some(std::ffi::OsStr::new("/nonexistent-path")),
+            &["/nonexistent-sbin"],
+        );
+        assert!(found.is_none());
     }
 
     #[test]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,21 +34,26 @@ usage() {
 aegis-boot installer
 
 USAGE:
-  install.sh [--version VER] [--prefix DIR] [--no-verify] [--help]
+  install.sh [--version VER] [--prefix DIR] [--cosign PATH] [--no-verify] [--help]
 
 OPTIONS:
-  --version VER   Install a specific release tag (e.g. v0.12.0).
+  --version VER   Install a specific release tag (e.g. v0.14.1).
                   Default: latest GitHub release.
   --prefix DIR    Install destination. Default: $DEFAULT_PREFIX_ROOT
                   if running as root, else $DEFAULT_PREFIX_USER.
+  --cosign PATH   Explicit path to the cosign binary. Use this when
+                  cosign is installed but not on \$PATH (#328).
+                  Defaults to auto-detect: \$PATH, then script dir,
+                  then --prefix dir.
   --no-verify     Skip cosign signature verification.
                   Strongly discouraged outside dev/test.
   --help          This message.
 
 EXAMPLES:
   curl -sSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | sh
-  sh install.sh --version v0.12.0
+  sh install.sh --version v0.14.1
   sudo sh install.sh --prefix /usr/local/bin
+  sh install.sh --cosign /mnt/Data/Downloads/aegis-boot/cosign
 EOF
 }
 
@@ -114,6 +119,7 @@ download() {
 main() {
     version=""
     prefix=""
+    cosign_bin=""
     skip_verify=0
     while [ "$#" -gt 0 ]; do
         case "$1" in
@@ -138,6 +144,17 @@ main() {
                 ;;
             --prefix=*)
                 prefix="${1#*=}"
+                ;;
+            --cosign)
+                shift
+                cosign_bin="${1:-}"
+                if [ -z "$cosign_bin" ]; then
+                    err "--cosign requires a path argument"
+                    return 2
+                fi
+                ;;
+            --cosign=*)
+                cosign_bin="${1#*=}"
                 ;;
             --no-verify)
                 skip_verify=1
@@ -194,10 +211,36 @@ main() {
     fi
 
     # Cosign required unless --no-verify.
+    # Resolution order (#328): explicit --cosign, then $PATH, then
+    # canonical fallbacks (script dir, --prefix dir). Operators who
+    # keep cosign alongside the installer or the installed binary
+    # get signature verification without having to edit $PATH.
     if [ "$skip_verify" -eq 0 ]; then
-        if ! command -v cosign >/dev/null 2>&1; then
-            err "cosign not found in PATH. Install from https://docs.sigstore.dev/cosign/system_config/installation/"
-            err "or re-run with --no-verify (not recommended)"
+        if [ -n "$cosign_bin" ]; then
+            if [ ! -x "$cosign_bin" ]; then
+                err "--cosign: $cosign_bin is not an executable file"
+                return 64
+            fi
+        elif command -v cosign >/dev/null 2>&1; then
+            cosign_bin="cosign"
+        else
+            script_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd || echo '')"
+            for candidate in \
+                "${script_dir:+$script_dir/cosign}" \
+                "$prefix/cosign"
+            do
+                [ -z "$candidate" ] && continue
+                if [ -x "$candidate" ]; then
+                    cosign_bin="$candidate"
+                    note "cosign: auto-detected at $cosign_bin"
+                    break
+                fi
+            done
+        fi
+        if [ -z "$cosign_bin" ]; then
+            err "cosign not found in PATH, script dir, or --prefix dir."
+            err "Install from https://docs.sigstore.dev/cosign/system_config/installation/,"
+            err "re-run with --cosign PATH, or --no-verify (not recommended)"
             return 64
         fi
     fi
@@ -216,7 +259,7 @@ main() {
     # Verify cosign signature.
     if [ "$skip_verify" -eq 0 ]; then
         note "verifying cosign signature..."
-        if ! cosign verify-blob \
+        if ! "$cosign_bin" verify-blob \
             --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
             --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
             --signature "$tmpdir/$asset.sig" \


### PR DESCRIPTION
## Summary

Addresses the two UX bugs embedded in @garyoakidoki's #328 hardware-compat report (openSUSE Tumbleweed, ASRock Z690M-ITX/ax).

### Bug 1: \`doctor\` false-FAIL on sgdisk

User's own output:
\`\`\`
$ sudo aegis-boot doctor              # direct run
  [✓ PASS] command: sgdisk    /usr/sbin/sgdisk

$ install.sh ...                       # spawns doctor preflight
  [✗ FAIL] command: sgdisk    not found in PATH
\`\`\`

Root cause (\`crates/aegis-cli/src/doctor.rs\`): \`which()\` consulted only \`\$PATH\`, which doesn't always include \`/usr/sbin\` on openSUSE — especially in install.sh's subprocess env.

Fix: factor into \`which_in(cmd, path_env, sbin_fallbacks)\` and probe canonical sbin dirs (\`/usr/sbin\`, \`/sbin\`, \`/usr/local/sbin\`) when \`\$PATH\` misses. Three new unit tests.

### Bug 2: \`install.sh\` cosign discovery inflexible

User had cosign at \`/mnt/Data/Downloads/aegis-boot/cosign\` and install.sh refused until they manually prepended PATH — even though the binary was sitting right next to install.sh.

Fix: new \`--cosign PATH\` flag + auto-probe (script dir, then --prefix dir). \`verify-blob\` now uses the resolved \`\$cosign_bin\` instead of bare \`cosign\`.

## Test plan

- [x] \`cargo clippy -p aegis-cli --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-cli --bin aegis-boot\` — 365 tests pass (+3 new)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`sh -n scripts/install.sh\` clean
- [x] Smoke-tested new flag: \`--help\` shows it, \`--cosign\` alone errors correctly, \`--cosign /bad/path\` surfaces "not an executable file"

🤖 Generated with [Claude Code](https://claude.com/claude-code)