### PR TITLE
fix(#332): unify cosign path probe between doctor and fetch-image

### DIFF
--- a/crates/aegis-cli/src/cmd_path.rs
+++ b/crates/aegis-cli/src/cmd_path.rs
@@ -1,0 +1,99 @@
+//! Shared command-on-PATH probe. Every aegis-boot surface that asks
+//! "is this command available?" goes through [`which`] so the answer
+//! is the same whether `doctor`, `fetch-image`, or a future caller
+//! is asking. Inconsistent answers were the surface area of #332 —
+//! `doctor` said cosign was present while `fetch-image` said it was
+//! missing, because each used a different probe.
+//!
+//! The probe is deliberately just "does the file exist as a regular
+//! file at one of these paths?". It does NOT try to run the binary
+//! (`--version` probes can return non-zero for reasons unrelated to
+//! whether the binary is installed — missing network, locked
+//! transparency log, corrupted keyring). Execution errors surface
+//! at the actual use-site with the real stderr, which is more
+//! actionable than "cosign not on PATH".
+
+use std::path::{Path, PathBuf};
+
+/// Canonical sbin directories probed when `$PATH` lookup misses.
+/// Many distros (notably openSUSE, #328) do not include `/usr/sbin`
+/// in the `$PATH` inherited by `sudo` or by child processes of the
+/// install.sh post-install preflight. Root-utility commands that
+/// live only in sbin (e.g. `sgdisk`) would otherwise produce a
+/// FAIL row in `doctor` despite being installed.
+pub(crate) const SBIN_FALLBACKS: &[&str] = &["/usr/sbin", "/sbin", "/usr/local/sbin"];
+
+/// Look up `cmd` on the current process's PATH, falling back to the
+/// canonical sbin directories if it's not found on PATH. Returns the
+/// absolute path of the first match, or `None` if neither lookup hits.
+pub(crate) fn which(cmd: &str) -> Option<PathBuf> {
+    which_in(cmd, std::env::var_os("PATH").as_deref(), SBIN_FALLBACKS)
+}
+
+/// Explicit-inputs variant of [`which`] for testing. Takes the PATH
+/// env value and the sbin-fallback list directly so a test can pin
+/// the exact search space without mutating process-wide state.
+pub(crate) fn which_in(
+    cmd: &str,
+    path_env: Option<&std::ffi::OsStr>,
+    sbin_fallbacks: &[&str],
+) -> Option<PathBuf> {
+    if let Some(path) = path_env {
+        for dir in std::env::split_paths(path) {
+            let candidate = dir.join(cmd);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    for sbin in sbin_fallbacks {
+        let candidate = Path::new(sbin).join(cmd);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn which_in_finds_binary_on_path() {
+        let Ok(dir) = tempfile::tempdir() else { return };
+        let bin = dir.path().join("fake-cmd");
+        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
+            return;
+        }
+        let path_env = std::ffi::OsString::from(dir.path());
+        let found = which_in("fake-cmd", Some(path_env.as_os_str()), &[]);
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+    }
+
+    #[test]
+    fn which_in_falls_back_to_sbin_when_path_misses() {
+        let Ok(dir) = tempfile::tempdir() else { return };
+        let bin = dir.path().join("sbin-only-cmd");
+        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
+            return;
+        }
+        let fallback = dir.path().to_string_lossy().into_owned();
+        let found = which_in(
+            "sbin-only-cmd",
+            Some(std::ffi::OsStr::new("/nonexistent-path")),
+            &[&fallback],
+        );
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+    }
+
+    #[test]
+    fn which_in_returns_none_when_both_miss() {
+        let found = which_in(
+            "definitely-not-a-real-binary-for-aegis-test",
+            Some(std::ffi::OsStr::new("/nonexistent-path")),
+            &["/nonexistent-sbin"],
+        );
+        assert!(found.is_none());
+    }
+}

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -667,39 +667,10 @@ fn check_command_present_with_pkg(report: &mut Report, cmd: &str, pkg: &str, why
     }
 }
 
-/// Canonical sbin directories probed when `$PATH` lookup misses.
-/// Many distros (notably openSUSE, #328) do not include `/usr/sbin`
-/// in the `$PATH` inherited by `sudo` or by child processes of the
-/// install.sh post-install preflight. Root-utility commands that
-/// live only in sbin (e.g. `sgdisk`) would otherwise produce a
-/// FAIL row in `doctor` despite being installed.
-const SBIN_FALLBACKS: &[&str] = &["/usr/sbin", "/sbin", "/usr/local/sbin"];
-
-fn which(cmd: &str) -> Option<PathBuf> {
-    which_in(cmd, std::env::var_os("PATH").as_deref(), SBIN_FALLBACKS)
-}
-
-fn which_in(
-    cmd: &str,
-    path_env: Option<&std::ffi::OsStr>,
-    sbin_fallbacks: &[&str],
-) -> Option<PathBuf> {
-    if let Some(path) = path_env {
-        for dir in std::env::split_paths(path) {
-            let candidate = dir.join(cmd);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-    }
-    for sbin in sbin_fallbacks {
-        let candidate = PathBuf::from(sbin).join(cmd);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-    None
-}
+// `which` lives in the `cmd_path` module so `fetch-image` and every
+// other command-presence caller use the same probe. See #332 for why
+// unified lookup matters.
+use crate::cmd_path::which;
 
 fn check_secureboot_state(report: &mut Report) {
     // Try mokutil first (most operator hosts have it). Fall back to reading
@@ -1103,47 +1074,6 @@ mod tests {
             r.rows[0].0
         );
         assert!(r.rows[0].2.contains("canary"));
-    }
-
-    #[test]
-    fn which_in_finds_binary_on_path() {
-        let Ok(dir) = tempfile::tempdir() else { return };
-        let bin = dir.path().join("fake-cmd");
-        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
-            return;
-        }
-        let path_env = std::ffi::OsString::from(dir.path());
-        let found = which_in("fake-cmd", Some(path_env.as_os_str()), &[]);
-        assert_eq!(found.as_deref(), Some(bin.as_path()));
-    }
-
-    #[test]
-    fn which_in_falls_back_to_sbin_when_path_misses() {
-        // #328: on openSUSE the invoking shell's PATH often lacks
-        // /usr/sbin, so `sgdisk` (installed at /usr/sbin/sgdisk)
-        // reads as absent. The sbin-fallback closes that hole.
-        let Ok(dir) = tempfile::tempdir() else { return };
-        let bin = dir.path().join("sbin-only-cmd");
-        if std::fs::write(&bin, b"#!/bin/sh\n").is_err() {
-            return;
-        }
-        let fallback = dir.path().to_string_lossy().into_owned();
-        let found = which_in(
-            "sbin-only-cmd",
-            Some(std::ffi::OsStr::new("/nonexistent-path")),
-            &[&fallback],
-        );
-        assert_eq!(found.as_deref(), Some(bin.as_path()));
-    }
-
-    #[test]
-    fn which_in_returns_none_when_both_miss() {
-        let found = which_in(
-            "definitely-not-a-real-binary-for-aegis-test",
-            Some(std::ffi::OsStr::new("/nonexistent-path")),
-            &["/nonexistent-sbin"],
-        );
-        assert!(found.is_none());
     }
 
     #[test]

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -304,16 +304,20 @@ fn run_cosign_verify_blob(image: &Path, sig: &Path, pem: &Path) -> Result<(), St
     }
 }
 
-/// Check `cosign --version` returns 0 on the operator's PATH. Same
-/// pattern as the `sudo` / `sha256sum` presence checks in
-/// `aegis-boot doctor`. Called from both here (lazy) and from doctor
-/// (eager) so operators get the same answer either way.
+/// True if cosign is present at a file path the OS will find when
+/// we `exec` it. Uses the same shared probe as `aegis-boot doctor`
+/// (see `cmd_path::which`), so the two surfaces agree.
+///
+/// Previously this was `cosign --version`-based, which returned false
+/// for reasons unrelated to whether cosign was installed — a broken
+/// binary, a non-zero exit from a cosign version that's fussy about
+/// its config dir, or an intermittent transparency-log lookup would
+/// all read as "cosign not on PATH". #332 surfaced the disagreement
+/// in the wild: `doctor` saw cosign at `/usr/local/bin/cosign`
+/// (PASS), but `fetch-image` said cosign not on PATH. Unified probe
+/// fixes that.
 pub(crate) fn cosign_on_path() -> bool {
-    Command::new("cosign")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    crate::cmd_path::which("cosign").is_some()
 }
 
 /// Append a suffix to the file path. `/tmp/a.img` + `.sig` →

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -23,6 +23,7 @@
 
 mod attest;
 mod catalog;
+mod cmd_path;
 mod compat;
 mod completions;
 mod constants;


### PR DESCRIPTION
## Summary

Closes #332. External user @garyoakidoki reported that \`doctor\` finds cosign at \`/usr/local/bin/cosign\` and reports PASS, but \`fetch-image\` on the same shell silently says "cosign not on PATH" and falls through to an unverified download.

Root cause: two different probes.

- \`doctor\` used \`which("cosign")\` — file-existence on \`\$PATH\` + sbin fallbacks (after PR #331).
- \`fetch-image\` shelled out to \`cosign --version\` and checked the exit code. That probe returns false for reasons beyond "binary missing": broken binary, non-zero exit from fussy cosign versions, intermittent transparency-log issues, etc.

### Fix

New \`src/cmd_path.rs\` shared module owns \`which\` / \`which_in\`. \`doctor::check_cosign_optional\` and \`fetch_image::cosign_on_path\` both call through it, so their answers can't diverge.

### Behavior deltas

| Scenario | Before | After |
|---|---|---|
| cosign on \$PATH and working | \`fetch-image\` verifies ✓ | same |
| cosign genuinely missing | graceful warn, unverified download | same |
| cosign on \$PATH but \`--version\` exits non-zero (#332) | silent "not on PATH" warn | attempts verify-blob, surfaces real cosign error |

### Review context

Based on top of #331 (which is where \`which_in\` was introduced). Merge #331 first, then this. After #331 merges I can rebase this onto main and the diff will shrink by the \`which_in\` lines (those become a rename/move).

## Test plan

- [x] \`cargo clippy -p aegis-cli --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-cli --bin aegis-boot\` — 365 tests pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo build --release --target x86_64-unknown-linux-musl -p aegis-cli\` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)