### PR TITLE
fix(ci): pass GITHUB_TOKEN to lychee to avoid github.com rate-limit 500s

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -55,6 +55,14 @@ jobs:
       - name: Run lychee
         id: lychee
         uses: lycheeverse/lychee-action@v2
+        env:
+          # github.com responds 500 to unauthenticated link-check
+          # requests under rate-limit pressure. Passing the default
+          # CI token raises the per-hour ceiling from 60 → 5,000 and
+          # keeps lychee from failing on our own pull-request URLs
+          # (surfaced on PR #338 via CHANGELOG refs and README's
+          # /releases/latest link).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Input files: all markdown + the man-page template (which
           # contains URLs in SEE ALSO / TROUBLESHOOTING refs). Exclude


### PR DESCRIPTION
## Summary

PR #338's lychee link-check failed twice with transient 500s on aegis-boot's own URLs:
- 1st try: \`github.com/williamzujkowski/aegis-boot/pull/322\`
- Rerun:   \`github.com/williamzujkowski/aegis-boot/releases/latest\`

Both are valid. Root cause: \`lychee-action\` runs unauthenticated against github.com, which rate-limits at 60 req/hour per IP. Shared Actions runners share that bucket, so under pressure github.com returns 500 on valid URLs (observed in the wild; [lycheeverse/lychee-action#195](https://github.com/lycheeverse/lychee-action/issues/195) recommends passing a token).

### Fix

Expose \`GITHUB_TOKEN\` via env. lychee-action picks it up automatically, authenticates the github.com calls, and the per-hour ceiling rises 60 → 5,000. Transient 500s on our own URLs go away.

### Alternatives rejected

- **Add 500 to \`--accept\`** — hides real GitHub outages and real server-side link rot.
- **\`--max-retries 3\`** — doesn't help when the cause is rate-limit; subsequent retries hit the same ceiling.
- **Lower \`--max-concurrency 8 → 2\`** — slows the job and only delays the problem.

### Permission posture

\`permissions\` block already has \`contents: read\` (enough for the read-only link check) plus \`issues: write\` for the scheduled broken-link-issue filer. \`GITHUB_TOKEN\` with those scopes is sufficient; no permission expansion.

## Test plan

- [x] YAML-syntactic: env block under the correct step
- [x] Doesn't change the lychee args
- [x] Doesn't relax the accept-codes list
- [ ] CI lychee pass on this PR (verifies the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)