### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-04-20
+
+Doc-automation milestone release. Closes epic [#286](https://github.com/williamzujkowski/aegis-boot/issues/286) (7-phase auto-generation + drift-checks for every user-facing doc) and the operator-UX sweep umbrella [#310](https://github.com/williamzujkowski/aegis-boot/issues/310). 12 committed JSON Schemas for every `aegis-boot --json` surface. First community hardware-compat submission surfaced four bugs, all fixed. New local cross-distro test harness. CI grew from 17 → 22 drift-checks.
+
 ### Doc-automation + evergreen-numbers strategy (closes epic [#286](https://github.com/williamzujkowski/aegis-boot/issues/286))
 
 The v0.14.0 release incident — four docs stuck at v0.13.0 after a one-line version bump — motivated a full doc-automation sweep. Seven phases shipped; every user-facing doc that mirrors a code value is now generated, drift-checked, or both. CI grew from 17 to **22 checks** (+doc-version-drift, +lychee link-check, +doc constants drift, +CLI subcommand drift, +manifest JSON schema drift). Every auto-generated doc is gated on every PR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-cli"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aegis-wire-formats",
  "hex",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-wire-formats"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "schemars",
  "serde",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "kexec-loader"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -738,7 +738,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "crossterm",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["crates/iso-parser/fuzz"]
 # Release-cut flow: bump this one line + amend CHANGELOG, tag.
 # CI's doc-version drift-check (Phase 1c) greps an allowlist of
 # user-facing doc files and fails if any version literal diverges.
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A signed UEFI Secure Boot rescue environment that lets operators pick any ISO fr
 
 </div>
 
-**Status:** v0.14.1 — signed `aegis-boot.img` now ships as a release asset (cosign keyless-verified by `fetch-image`), installed-binary flash UX fixed ([#282](https://github.com/williamzujkowski/aegis-boot/issues/282)), direct-install flash foundation landed behind a feature gate ([#274](https://github.com/williamzujkowski/aegis-boot/issues/274) phases 2a–3b). Real-hardware shakedown under Secure Boot enforcing validated Ubuntu (successful kexec) + Alpine (unsigned-kernel rejection surfaces the MOK-enrollment hint as designed) ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
+**Status:** v0.15.0 — doc-automation milestone release (closes epic [#286](https://github.com/williamzujkowski/aegis-boot/issues/286) — 7 phases of auto-gen + drift-checks for every user-facing doc; closes umbrella [#310](https://github.com/williamzujkowski/aegis-boot/issues/310) operator-UX sweep). 12 committed JSON Schemas for every `aegis-boot --json` surface. First community hardware-compat submission surfaced four bugs, all fixed. New local cross-distro test harness (openSUSE / Ubuntu / Alpine / Fedora / Arch). CI grew from 17 → 22 drift-checks. Real-hardware shakedown under Secure Boot enforcing validated Ubuntu (successful kexec) + Alpine (unsigned-kernel rejection surfaces the MOK-enrollment hint as designed) ([#109](https://github.com/williamzujkowski/aegis-boot/issues/109)). Multi-vendor real-hardware sweep (Framework / ThinkPad / Dell) gates v1.0.0 ([#51](https://github.com/williamzujkowski/aegis-boot/issues/51)).
 
 ## What it does
 
@@ -68,7 +68,7 @@ curl -sSL https://raw.githubusercontent.com/williamzujkowski/aegis-boot/main/scr
 brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
 brew install aegis-boot
 
-# Or pin a version: sh install.sh --version v0.14.1
+# Or pin a version: sh install.sh --version v0.15.0
 # Or skip cosign (NOT recommended): sh install.sh --no-verify
 # Build from source: see BUILDING.md.
 ```

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["filesystem", "embedded"]
 [lib]
 
 [dependencies]
-iso-parser = { path = "../iso-parser", version = "0.14" }
+iso-parser = { path = "../iso-parser", version = "0.15" }
 thiserror.workspace = true
 serde = { workspace = true }
 tracing.workspace = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -468,7 +468,7 @@ Every other USB-imaging tool is silent after flash. The attestation receipt is t
 ```json
 {
   "schema_version": 1,
-  "tool_version": "0.14.1",
+  "tool_version": "0.15.0",
   "flashed_at": "2026-04-16T12:34:56Z",
   "operator": "william",
   "host": {
@@ -646,7 +646,7 @@ Download a released `aegis-boot.img` (or `aegis-boot-hybrid.iso`) from GitHub Re
 
 ```bash
 aegis-boot fetch-image                         # latest release, cwd output
-aegis-boot fetch-image --version v0.14.1       # pin a specific release
+aegis-boot fetch-image --version v0.15.0       # pin a specific release
 aegis-boot fetch-image --out ~/Downloads       # override output dir
 aegis-boot fetch-image --format iso            # hybrid .iso instead of .img
 aegis-boot fetch-image --dry-run --json        # resolve + print plan; no download
@@ -725,7 +725,7 @@ aegis-boot tour --help
 
 ## Versioning
 
-`aegis-boot --version` reports the workspace version (currently `0.14.1`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.15.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
 `aegis-boot --version --json` emits the same info as a stable envelope for scripted install verification or Homebrew-style version matching:
 
@@ -733,7 +733,7 @@ aegis-boot tour --help
 {
   "schema_version": 1,
   "tool": "aegis-boot",
-  "version": "0.14.1"
+  "version": "0.15.0"
 }
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,7 +37,7 @@ Option B (Homebrew) auto-installs the Brew-tracked runtime deps (`curl`, `gnupg`
 Sanity check:
 
 ```bash
-aegis-boot --version       # → aegis-boot v0.14.1
+aegis-boot --version       # → aegis-boot v0.15.0
 aegis-boot doctor          # 0–100 health score for host + stick
 ```
 
@@ -143,7 +143,7 @@ If the firmware refuses to show the USB entry, your boot mode might be CSM/Legac
 `rescue-tui` shows your ISOs with verification status:
 
 ```
-aegis-boot v0.14.1    SB:enforcing  TPM:available
+aegis-boot v0.15.0    SB:enforcing  TPM:available
 
   ▸ ubuntu-24.04.2-live-server-amd64.iso        1.6 GiB  [✓ sha256]
     alpine-3.20.3-x86_64.iso                     198 MiB  [no verify]

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -167,11 +167,11 @@ aegis-boot fetch-image — download + verify a pre-built aegis-boot image
 
 USAGE:
   aegis-boot fetch-image                               # latest release, cosign auto-verify
-  aegis-boot fetch-image --version v0.14.1             # pin to a specific release
+  aegis-boot fetch-image --version v0.15.0             # pin to a specific release
   aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL
 
   --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)
-  --version TAG   Pin to a specific release tag (e.g. v0.14.1)
+  --version TAG   Pin to a specific release tag (e.g. v0.15.0)
   --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)
   --sha256 HEX    Required sha256; mismatch deletes the download + exits 1
   --no-cosign     Skip the cosign keyless signature check (air-gap, offline)


### PR DESCRIPTION
## Summary

Closes #325. Doc-automation milestone release.

### What's in v0.15.0 (full CHANGELOG section)

Everything that was in \`[Unreleased]\`:

- **Doc-automation + evergreen-numbers** (closes epic #286) — 7 phases: workspace version single-source + build.rs-templated man page, shared constants registry, CLI synopsis auto-gen, JSON-schema registry via schemars (12 schemas), lychee link-check CI, rustdoc-as-landing-page, git-cliff CHANGELOG draft-assist
- **Operator-UX sweep** (closes umbrella #310) — install.sh mkusb.sh deps preflight (#313), rescue-tui empty-state footer (#312), fetch progress bar (#311)
- **Cross-cutting cleanup** — JSON escaping standardized via \`serde_json\` + \`aegis_wire_formats::CliError\` envelope (#306)
- **External user reports (openSUSE + ASRock Z690M-ITX/ax)** — first community hardware-compat submission surfaced four bugs, all fixed: #328 (doctor sbin fallback + install.sh --cosign flag), #329 (stale sigstore URL), #332 (doctor/fetch-image cosign probe unify), #333 (doctor remedy per-family pkg names)
- **Local cross-distro test harness** (new) — \`tools/distro-smoke/\` Docker matrix (#334)
- **Doc accuracy forward-rolls** — #326, #327

CI grew from 17 → 22 drift-checks across this cycle.

### Mechanical changes in this PR

- \`Cargo.toml [workspace.package].version\`: \`0.14.1\` → \`0.15.0\`
- \`crates/iso-probe/Cargo.toml\` intra-workspace pin: \`iso-parser = "0.14"\` → \`"0.15"\`
- \`CHANGELOG.md\`: promote \`[Unreleased]\` heading to \`[0.15.0] — 2026-04-20\` with a one-paragraph summary at the top; empty \`[Unreleased]\` remains above
- Doc version rolls (5 drift-check patterns): README status line, README pin-install example, INSTALL.md \`--version\` output + TUI screenshot, CLI.md \`tool_version\` JSON example + \`fetch-image --version\` example + prose version reference + \`--version --json\` output
- \`docs/reference/CLI_SYNOPSIS.md\`: regenerated via \`cli-docgen --write\` (picks up the new \`env!(\"CARGO_PKG_VERSION\")\` substitution in fetch-image \`print_help\`)
- \`Cargo.lock\`: version-bump transitive updates

## Next steps (maintainer)

After this merges to main:

\`\`\`bash
git checkout main && git pull
git tag -s v0.15.0 -m \"v0.15.0\" # or unsigned
git push origin v0.15.0
\`\`\`

\`release.yml\` takes over and publishes binaries + signed \`aegis-boot.img\` + cosign sigs.

## Test plan

- [x] \`./scripts/check-doc-version.sh\` — 5/5 drift patterns reference 0.15.0
- [x] \`cargo test --workspace\` — all tests pass (iso-parser 35, iso-probe 50, aegis-wire-formats 92, aegis-fitness 6, rescue-tui clean)
- [x] \`cargo build --release\` clean
- [x] \`cargo run -- --version\` prints \`aegis-boot v0.15.0\`
- [x] \`cli-docgen --write\` regen reflects new version in \`--help\` examples
- [ ] Full CI matrix (22 drift-checks) green on this PR — verifies in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)