### PR TITLE
ci(#51): crates.io publish-readiness dry-run workflow

### DIFF
--- a/.github/workflows/crates-publish-dryrun.yml
+++ b/.github/workflows/crates-publish-dryrun.yml
@@ -1,0 +1,54 @@
+name: Crates.io publish dry-run
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# #51 publish-readiness gate. Keeps the mechanical-prep claims in
+# docs/RELEASE_CRATES.md honest: any PR that breaks `cargo publish`
+# for iso-parser or kexec-loader fails this workflow before merge,
+# so the v1.0.0-rc1 publish day doesn't surprise us with a regression
+# that sat unnoticed in main for weeks.
+#
+# iso-probe is intentionally excluded — its dry-run needs iso-parser
+# to already be published to the registry (per RELEASE_CRATES.md). It
+# will be added to this gate once iso-parser is published.
+#
+# Publishable crates per #51:
+#   - iso-parser      (ISO9660 + boot-config extraction)
+#   - iso-probe       (runtime ISO discovery + verification) — deferred
+#   - kexec-loader    (kexec_file_load FFI wrapper)
+#
+# Non-publishable (intentional):
+#   - rescue-tui, aegis-fitness, aegis-cli, aegis-wire-formats
+#   — all repo-specific or binary crates.
+
+jobs:
+  publish-dryrun:
+    name: cargo publish --dry-run (iso-parser + kexec-loader)
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust (pinned to workspace MSRV)
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup override set 1.85.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo publish --dry-run -p iso-parser
+        # Zero unpublished path deps → registry resolution succeeds
+        # without needing iso-parser on the real registry yet.
+        run: cargo publish --dry-run -p iso-parser --locked
+
+      - name: cargo publish --dry-run -p kexec-loader
+        # Same — no path deps on other workspace crates.
+        run: cargo publish --dry-run -p kexec-loader --locked


### PR DESCRIPTION
## Summary

Adds a per-PR gate that runs \`cargo publish --dry-run\` on iso-parser and kexec-loader. Keeps the mechanical-prep claims in \`docs/RELEASE_CRATES.md\` honest.

## Why this is useful now (pre-v1.0.0-rc1)

The #51 epic is \"mechanical prep done; blocked on real-hardware shakedown.\" The hardware gate is out of our control (#132 requires Framework/ThinkPad/Dell), but the mechanical-prep side can silently regress if e.g.:

- A new \`[dependencies]\` entry lands without \`version =\` set (path-only deps are forbidden by crates.io)
- A new \`[package.metadata]\` field has an invalid format
- \`description\`, \`categories\`, or \`keywords\` drop out of allowed bounds
- A non-publishable file slips in via a missing \`exclude\` glob

Today those failures only surface the day someone runs \`cargo publish\` for real. This workflow catches them on every PR, ~2-3 min added to the PR cycle.

## Scope

- **\`iso-parser\`** (ISO9660 + boot-config extraction) — full dry-run
- **\`kexec-loader\`** (\`kexec_file_load\` FFI wrapper) — full dry-run
- **\`iso-probe\`** — **deferred**. Its dry-run needs iso-parser already on the registry (documented in \`docs/RELEASE_CRATES.md\`). Will be added to this gate once iso-parser publishes.
- Non-publishable crates (\`rescue-tui\`, \`aegis-fitness\`, \`aegis-cli\`, \`aegis-wire-formats\`) — excluded per #51 scope.

## Test plan

- [x] Verified both \`cargo publish --dry-run -p iso-parser --locked\` and \`-p kexec-loader --locked\` pass locally
- [x] Uses pinned MSRV toolchain (1.85.0) to mirror release-day behavior
- [x] Runs on push-to-main + every PR
- [ ] New workflow surfaces in PR checks once this merges (meta — workflow runs against its own PR)

Part of #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)