### PR TITLE
feat(add): catalog-slug shortcut — aegis-boot add <distro-id> (#352 UX-4)

### DIFF
--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -349,7 +349,11 @@ fn report_source_url(url: &str, local_path: &Path, label: &str) {
     println!("  {label:<11}  {url}{cached_note}");
 }
 
-fn default_cache_dir(slug: &str) -> PathBuf {
+/// Default cache directory for a catalog slug. Exposed via
+/// `pub(crate)` so `aegis-boot add <slug>` (#352 UX-4) can resolve
+/// the post-fetch ISO path without duplicating the XDG / HOME /
+/// /tmp fallback chain.
+pub(crate) fn default_cache_dir(slug: &str) -> PathBuf {
     let base = std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
@@ -357,8 +361,19 @@ fn default_cache_dir(slug: &str) -> PathBuf {
     base.join("aegis-boot").join(slug)
 }
 
-fn filename_from_url(url: &str) -> String {
+/// Extract the trailing filename from a catalog URL. Exposed via
+/// `pub(crate)` so `add <slug>` can compute the cached ISO filename
+/// without another round-trip to the catalog entry (#352 UX-4).
+pub(crate) fn filename_from_url(url: &str) -> String {
     url.rsplit('/').next().unwrap_or("download").to_string()
+}
+
+/// Resolve the post-fetch ISO path for a catalog slug. Returns `None`
+/// if the slug is unknown to the catalog. The returned path may not
+/// exist yet — callers should check and fetch if absent.
+pub(crate) fn cached_iso_path(slug: &str) -> Option<PathBuf> {
+    let entry = crate::catalog::find_entry(slug)?;
+    Some(default_cache_dir(entry.slug).join(filename_from_url(entry.iso_url)))
 }
 
 /// Download `url` to `dest`. When `show_progress` is true, curl

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -170,17 +170,24 @@ pub(crate) fn try_run_add(args: &[String]) -> Result<(), u8> {
     }
 
     let AddArgs {
-        iso_path: iso_arg,
+        iso_path: raw_iso_arg,
         mount_arg,
         description,
         version,
         category,
     } = parse_add_args(args)?;
 
-    if !iso_arg.is_file() {
-        eprintln!("aegis-boot add: not a file: {}", iso_arg.display());
+    // #352 UX-4: if the positional arg is a catalog slug (not a real
+    // file path), fetch it first and substitute the cached ISO path.
+    // Collapses today's `fetch <slug> && add <resolved-path>` 2-step
+    // into one `add <slug>` action. Only triggers when:
+    //   - the arg is NOT a file on disk AND
+    //   - the arg IS a known catalog slug
+    // so existing flows (local path, typo'd slug) behave unchanged.
+    let Some(iso_arg) = resolve_iso_arg(&raw_iso_arg)? else {
+        eprintln!("aegis-boot add: not a file: {}", raw_iso_arg.display());
         return Err(1);
-    }
+    };
     let iso_filename = iso_arg
         .file_name()
         .and_then(|n| n.to_str())
@@ -557,13 +564,65 @@ fn copy_classic_sidecars(iso_src: &Path, iso_filename: &str, mount: &Path) -> Ve
 fn print_add_help() {
     println!("aegis-boot add — copy an ISO onto the stick with verification");
     println!();
-    println!("USAGE: aegis-boot add <iso-file> [/dev/sdX | /mnt/aegis-isos]");
+    println!("USAGE: aegis-boot add <iso-file-or-catalog-slug> [/dev/sdX | /mnt/aegis-isos]");
     println!("                  [--description TEXT] [--version VER] [--category CAT]");
+    println!();
+    println!("If the first arg is NOT a file on disk but IS a known catalog slug");
+    println!("(e.g. 'ubuntu-24.04-live-server'), add fetches + verifies it first,");
+    println!("then stages the cached copy — collapses 'fetch X && add <path>' (#352).");
     println!();
     println!("Optional sidecar metadata (#246) is written next to the ISO as");
     println!("<iso>.aegis.toml so rescue-tui can show 'Network-install Debian 12'");
     println!("instead of the bare filename. The sidecar is unsigned cosmetic");
     println!("metadata — boot decisions still key off the sha256-attested manifest.");
+}
+
+/// #352 UX-4: resolve the `<iso-or-slug>` positional arg to a file
+/// path.
+///
+/// If the arg is a real file, returns it unchanged. If it's not a
+/// file but IS a known catalog slug, runs `fetch` to download +
+/// verify it, then returns the cached ISO path. Otherwise returns
+/// `Ok(None)` to signal a usage error (neither file nor slug).
+///
+/// Intentionally preserves the existing "not a file" error path for
+/// unknown / typo'd slugs — we don't want `add --help-typo-lookup`
+/// to silently try to interpret every typo as a slug.
+fn resolve_iso_arg(raw: &Path) -> Result<Option<PathBuf>, u8> {
+    if raw.is_file() {
+        return Ok(Some(raw.to_path_buf()));
+    }
+    // Catalog-slug path: arg must be a bare slug (no /, no spaces),
+    // else it looks like a mistyped path and we preserve the old
+    // "not a file" error.
+    let Some(s) = raw.to_str() else {
+        return Ok(None);
+    };
+    if s.contains('/') || s.contains(char::is_whitespace) || s.starts_with('.') {
+        return Ok(None);
+    }
+    let Some(expected) = crate::fetch::cached_iso_path(s) else {
+        return Ok(None); // unknown slug — fall through to "not a file"
+    };
+    if expected.is_file() {
+        println!(
+            "aegis-boot add: catalog slug '{s}' already cached at {}",
+            expected.display()
+        );
+    } else {
+        println!("aegis-boot add: catalog slug '{s}' — fetching before stage");
+        println!();
+        crate::fetch::try_run(&[s.to_string()])?;
+        println!();
+    }
+    if !expected.is_file() {
+        eprintln!(
+            "aegis-boot add: fetch succeeded but cached ISO not found at {}",
+            expected.display()
+        );
+        return Err(1);
+    }
+    Ok(Some(expected))
 }
 
 /// Operator-supplied aegis sidecar fields collected from `--description`,
@@ -1361,5 +1420,42 @@ mod tests {
         assert_eq!(entries[0].folder, None);
         assert_eq!(entries[1].folder.as_deref(), Some("alpha"));
         assert_eq!(entries[2].folder.as_deref(), Some("zeta"));
+    }
+
+    // ---- #352 UX-4: catalog-slug shortcut for `add` ------------------------
+
+    #[test]
+    fn resolve_iso_arg_returns_path_for_existing_file() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let iso = dir.path().join("local.iso");
+        fs::write(&iso, b"x").unwrap();
+        let got = resolve_iso_arg(&iso).unwrap();
+        assert_eq!(got.as_deref(), Some(iso.as_path()));
+    }
+
+    #[test]
+    fn resolve_iso_arg_rejects_path_shaped_non_file() {
+        // A path with a `/` is treated as a path attempt (not a slug),
+        // so unknown → None → caller emits "not a file". Prevents
+        // `add ./typo.iso` from accidentally being looked up as a slug.
+        let got = resolve_iso_arg(Path::new("./does-not-exist.iso")).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_iso_arg_rejects_whitespace_bearing_arg() {
+        // A multi-word arg ("not a slug") is treated as a path attempt.
+        let got = resolve_iso_arg(Path::new("not a slug")).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_iso_arg_rejects_unknown_slug() {
+        // Slug-shaped arg that doesn't match any catalog entry falls
+        // back to the "not a file" error path — preserves the old
+        // error for typos like `add ubntu-24.04`.
+        let got = resolve_iso_arg(Path::new("totally-not-in-catalog-zzz")).unwrap();
+        assert_eq!(got, None);
     }
 }

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -18,8 +18,12 @@ cargo run -p aegis-cli --bin cli-docgen --features docgen -- --write
 ```text
 aegis-boot add — copy an ISO onto the stick with verification
 
-USAGE: aegis-boot add <iso-file> [/dev/sdX | /mnt/aegis-isos]
+USAGE: aegis-boot add <iso-file-or-catalog-slug> [/dev/sdX | /mnt/aegis-isos]
                   [--description TEXT] [--version VER] [--category CAT]
+
+If the first arg is NOT a file on disk but IS a known catalog slug
+(e.g. 'ubuntu-24.04-live-server'), add fetches + verifies it first,
+then stages the cached copy — collapses 'fetch X && add <path>' (#352).
 
 Optional sidecar metadata (#246) is written next to the ISO as
 <iso>.aegis.toml so rescue-tui can show 'Network-install Debian 12'


### PR DESCRIPTION
## Summary

Third sub-issue of #352. Collapses today's two-step \`fetch <slug> && add <cached-path>\` flow into a single \`add <slug>\` action.

## Before → After

**Before** (2 commands, user must copy-paste cache path):
\`\`\`
$ aegis-boot fetch ubuntu-24.04-live-server
$ aegis-boot add ~/.cache/aegis-boot/ubuntu-24.04-live-server/ubuntu-24.04.2-live-server-amd64.iso
\`\`\`

**After** (1 command):
\`\`\`
$ aegis-boot add ubuntu-24.04-live-server
\`\`\`

## Behavior (back-compat preserved)

- Real file on disk → existing path, unchanged.
- Not a file AND is a known catalog slug → runs \`fetch\` first, resolves to cached ISO path, then normal add flow.
- Neither file nor slug → existing \"not a file\" error, unchanged.
- Cached from a prior \`fetch\` → skip the download, report \"already cached\", proceed.

### Slug-shape gate

Arg must have no \`/\`, no whitespace, no leading \`.\`. This preserves the existing error for \`./typo.iso\`-style mistakes — they look like path attempts, not slug lookups.

## Touches 2 crates

- **\`fetch\`**: \`default_cache_dir\`, \`filename_from_url\`, and new \`cached_iso_path(slug) -> Option<PathBuf>\` helper exposed via \`pub(crate)\` so \`add\` can resolve the post-fetch ISO path without duplicating the XDG / HOME / /tmp fallback chain.
- **\`inventory\`**: intercept in \`try_run_add\` via \`resolve_iso_arg()\`.

## Test plan

- [x] 4 new unit tests: happy path (existing file), path-shaped non-file (\`./foo.iso\` → \"not a file\"), whitespace-bearing (\"not a slug\"), unknown slug falls through
- [x] Full workspace tests: 414 pass
- [x] Clippy clean (\`-D warnings\`)
- [x] fmt check clean
- [x] macOS cross-compile check

## Downstream value

Shaves a \~30-second copy-paste step off the new-user journey. Combined with UX-2 (#353, merged) and UX-3 (#354, pending), the sub-10-minute epic is at 3/5 sub-issues. UX-1 (\`quickstart\`) composes these.

Part of #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)