### PR TITLE
feat(rescue-tui): empty-state points at catalog-slug add shortcut (#352 UX-5)

### DIFF
--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -547,11 +547,11 @@ fn draw_empty_list(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Style::default().add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::from(
-        "  1. On the host, copy an ISO into the AEGIS_ISOS partition:",
+        "  1. On the host, add an ISO from the signed catalog in one step (#352):",
     ));
-    lines.push(Line::from("       aegis-boot add /path/to/distro.iso"));
+    lines.push(Line::from("       aegis-boot add ubuntu-24.04-live-server"));
     lines.push(Line::from(
-        "     (or drag-and-drop the .iso file onto the stick via your file manager).",
+        "     (run `aegis-boot recommend` for slugs — or `aegis-boot add /path/to.iso`)",
     ));
     lines.push(Line::from(
         "  2. If the AEGIS_ISOS partition is on this stick but wasn't auto-mounted,",
@@ -1229,6 +1229,30 @@ mod tests {
         assert!(
             s.contains("rescue shell"),
             "missing rescue-shell escape-hatch mention in: {s}",
+        );
+    }
+
+    #[test]
+    fn empty_list_points_at_catalog_slug_add_shortcut() {
+        // #352 UX-5: the new-user empty state should surface the
+        // one-step `aegis-boot add <catalog-slug>` path (from UX-4,
+        // PR #356) — NOT just the "supply a local ISO path" recipe.
+        // Operator sees the catalog shortcut first, local-path second.
+        let state = AppState::new(vec![]);
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("aegis-boot add ubuntu-24.04-live-server"),
+            "empty state should show the catalog-slug add shortcut: {s}"
+        );
+        assert!(
+            s.contains("aegis-boot recommend"),
+            "empty state should mention `aegis-boot recommend` for catalog discovery: {s}"
+        );
+        // The local-path form must still render for operators with a
+        // pre-downloaded ISO — not a replacement, an ADDITION.
+        assert!(
+            s.contains("aegis-boot add /path/to.iso"),
+            "local-path form must still render alongside the catalog slug: {s}"
         );
     }
 


### PR DESCRIPTION
## Summary

Final sub-issue of #352. When a net-new operator boots a just-flashed stick with zero ISOs, rescue-tui's empty-state panel now surfaces the one-step catalog-slug \`add\` BEFORE the local-path recipe.

## Before → After

**Before** — recipe #1 was the local-path form only:
\`\`\`
  1. On the host, copy an ISO into the AEGIS_ISOS partition:
       aegis-boot add /path/to/distro.iso
     (or drag-and-drop the .iso file onto the stick via your file manager).
\`\`\`

**After** — catalog shortcut first, local-path as alt:
\`\`\`
  1. On the host, add an ISO from the signed catalog in one step (#352):
       aegis-boot add ubuntu-24.04-live-server
     (run \`aegis-boot recommend\` for slugs — or \`aegis-boot add /path/to.iso\`)
\`\`\`

The catalog form is strictly faster for a cold-start user — no browser, no URL lookup, no copy-paste of a hash.

## Layout discipline

Previous draft of this PR added 3 extra lines. The 80×24 test-render geometry clipped the \`Press Enter for rescue shell\` footer out of view — would have shipped a regression on #312's keybinding hint. Trimmed to 3 lines (was 6) so the footer stays visible and all existing empty-state tests stay green.

## Test plan

- [x] New test: \`empty_list_points_at_catalog_slug_add_shortcut\` — pins catalog slug, \`recommend\` cross-reference, and local-path form all render
- [x] Existing tests still pass: enter-rescue-shell footer, no-'entry-below', next-steps heading, help text, scanned-roots surface — 8/8
- [x] Clippy clean (\`-D warnings\`)
- [x] fmt check clean

## Gating note

UX-5 references the catalog-slug \`add\` form from UX-4 (#356). If #356 merges second (as expected), UX-5's text becomes fully-live. If #356 doesn't merge, UX-5's pointer still helps operators discover \`aegis-boot recommend\`, just with the old 2-step flow behind it.

Part of #352. With this + #356 merged, the sub-10-minute epic's 5/5 sub-issues are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)