### PR TITLE
chore(license): add per-file SPDX identifier headers

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot attest` — attestation receipts for flashed sticks.
 //!
 //! A flash operation produces a JSON manifest recording exactly what

--- a/crates/aegis-cli/src/bin/cli_docgen.rs
+++ b/crates/aegis-cli/src/bin/cli_docgen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `cli-docgen` — drift-check between the `aegis-boot` subcommand
 //! dispatch table and its user-facing documentation, and
 //! auto-generator for the CLI synopsis doc.

--- a/crates/aegis-cli/src/bin/constants_docgen.rs
+++ b/crates/aegis-cli/src/bin/constants_docgen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `constants-docgen` — renders values from [`crate::constants`] into
 //! HTML-marker regions in the user-facing docs.
 //!

--- a/crates/aegis-cli/src/bug_report.rs
+++ b/crates/aegis-cli/src/bug_report.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot bug-report` — workstation-side bug report bundler (#342 Phase 1).
 //!
 //! One command that captures everything a maintainer typically asks for

--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot recommend` — curated catalog of known-good ISOs.
 //!
 //! The catalog is an in-binary list of ISO entries with their canonical

--- a/crates/aegis-cli/src/cmd_path.rs
+++ b/crates/aegis-cli/src/cmd_path.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Shared command-on-PATH probe. Every aegis-boot surface that asks
 //! "is this command available?" goes through [`which`] so the answer
 //! is the same whether `doctor`, `fetch-image`, or a future caller

--- a/crates/aegis-cli/src/compat.rs
+++ b/crates/aegis-cli/src/compat.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot compat` — hardware compatibility lookup.
 //!
 //! Answers "will aegis-boot work on my laptop?" with concrete data

--- a/crates/aegis-cli/src/completions.rs
+++ b/crates/aegis-cli/src/completions.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot completions <shell>` — emit a shell completion script.
 //!
 //! Operators install with:

--- a/crates/aegis-cli/src/constants.rs
+++ b/crates/aegis-cli/src/constants.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Shared numeric constants that appear in BOTH source code AND
 //! user-facing documentation.
 //!

--- a/crates/aegis-cli/src/detect/linux.rs
+++ b/crates/aegis-cli/src/detect/linux.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Linux removable-drive detection via sysfs.
 //!
 //! Enumerates `/sys/block/sd*` looking for removable USB mass storage

--- a/crates/aegis-cli/src/detect/macos.rs
+++ b/crates/aegis-cli/src/detect/macos.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! macOS removable-drive detection via `diskutil list -plist` piped
 //! through `plutil -convert json`.
 //!

--- a/crates/aegis-cli/src/detect/mod.rs
+++ b/crates/aegis-cli/src/detect/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Removable-drive detection. Platform-dispatched: Linux uses sysfs,
 //! macOS uses `diskutil list -plist | plutil -convert json`, other
 //! platforms currently return an empty list + a clear error from the

--- a/crates/aegis-cli/src/detect/windows.rs
+++ b/crates/aegis-cli/src/detect/windows.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Windows removable-drive detection via `PowerShell` `Get-Disk`.
 //!
 //! `Get-Disk | ConvertTo-Json -Depth 2` emits a JSON array of physical

--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Rust-native flash provisioning — foundation for #274.
 //!
 //! This module replaces the `scripts/mkusb.sh` + `dd` pipeline with

--- a/crates/aegis-cli/src/direct_install_manifest.rs
+++ b/crates/aegis-cli/src/direct_install_manifest.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Signed attestation manifest for direct-install (#274 PR3, #277).
 //!
 //! Companion module to [`direct_install`]. Produces

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot doctor` — health check for the host environment and any
 //! aegis-boot stick the operator wants to inspect.
 //!

--- a/crates/aegis-cli/src/eject.rs
+++ b/crates/aegis-cli/src/eject.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot eject [device]` — safe-eject helper.
 //!
 //! Operators who pull a stick without first syncing risk FAT32 / ext4

--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot fetch <slug>` — download + verify a catalog ISO.
 //!
 //! Resolves a slug from the catalog, downloads the ISO, the project's

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot fetch-image` — download + verify a pre-built aegis-boot
 //! disk image.
 //!

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot flash` — guided USB writer.
 //!
 //! Three steps:

--- a/crates/aegis-cli/src/init.rs
+++ b/crates/aegis-cli/src/init.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot init` — one-command rescue stick: flash + fetch + add.
 //!
 //! Composes the existing primitives (`doctor`, `flash`, `fetch`,

--- a/crates/aegis-cli/src/init_wizard.rs
+++ b/crates/aegis-cli/src/init_wizard.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot init` wizard helpers — pure logic for the
 //! serial-confirmation safety gate (#245).
 //!

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot list` + `add` subcommands — ISO inventory operations.
 //!
 //! `list` prints ISO files on the stick's `AEGIS_ISOS` partition with

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot` — operator CLI for aegis-boot.
 //!
 //! Subcommands:

--- a/crates/aegis-cli/src/man.rs
+++ b/crates/aegis-cli/src/man.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot man` — emit the man page to stdout.
 //!
 //! The canonical `aegis-boot(1)` source lives at `man/aegis-boot.1` in

--- a/crates/aegis-cli/src/mounts.rs
+++ b/crates/aegis-cli/src/mounts.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Shared helpers for reading `/proc/mounts` and deriving
 //! block-device paths. Consolidates three near-identical implementations
 //! that lived in `inventory.rs` and `attest.rs` (each doing their own

--- a/crates/aegis-cli/src/plan.rs
+++ b/crates/aegis-cli/src/plan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // First production caller (`flash::build_flash_plan`) uses a subset of
 // `Operation` variants + `Plan::new`/`add`. Variants and accessors reserved
 // for the `update`/`add`/`init`/`expand` rollout per #247 are kept

--- a/crates/aegis-cli/src/quickstart.rs
+++ b/crates/aegis-cli/src/quickstart.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot quickstart /dev/sdX` — shortest-path net-new-user flow.
 //!
 //! #352 UX-1: the single-command capstone of the sub-10-minute

--- a/crates/aegis-cli/src/readback.rs
+++ b/crates/aegis-cli/src/readback.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Post-write readback verification — read back the first N bytes of
 //! a freshly-flashed device and verify the sha256 matches the source
 //! image's prefix. PR1 of #244 (the `flash` command's "step 4 of 4

--- a/crates/aegis-cli/src/redact.rs
+++ b/crates/aegis-cli/src/redact.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Consistent-obfuscation redaction for bug-report bundles (#342).
 //!
 //! Pattern borrowed from [`sos clean`](https://manpages.ubuntu.com/manpages/jammy/man1/sos-clean.1.html):

--- a/crates/aegis-cli/src/tour.rs
+++ b/crates/aegis-cli/src/tour.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot tour` — 30-second in-terminal walkthrough.
 //!
 //! Operators who land on `aegis-boot --help` see 16 subcommands and no

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot update [device]` — eligibility check for in-place
 //! signed-chain rotation.
 //!

--- a/crates/aegis-cli/src/userfacing.rs
+++ b/crates/aegis-cli/src/userfacing.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `UserFacing` — structured, operator-friendly errors.
 //!
 //! Replaces the today-pattern of free-text error strings with a typed

--- a/crates/aegis-cli/src/verify.rs
+++ b/crates/aegis-cli/src/verify.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-boot verify [device|mount]` — re-verify every ISO on a stick.
 //!
 //! Closes the trust-narrative loop (flash → add → *verify*). For each

--- a/crates/aegis-fitness/src/main.rs
+++ b/crates/aegis-fitness/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-fitness` — repo, build, and artifact health audit for aegis-boot.
 //!
 //! Runs a fixed set of cheap checks against the working tree and reports a

--- a/crates/aegis-wire-formats/src/bin/schema_docgen.rs
+++ b/crates/aegis-wire-formats/src/bin/schema_docgen.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `aegis-wire-formats-schema-docgen` — emits JSON Schema documents for
 //! every public wire-format type in `aegis-wire-formats` into
 //! `docs/reference/schemas/` in the parent workspace.

--- a/crates/aegis-wire-formats/src/lib.rs
+++ b/crates/aegis-wire-formats/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // Phase 4a of #286. README becomes the rustdoc landing page
 // (same pattern as the library trio).
 #![allow(clippy::doc_markdown)]

--- a/crates/iso-parser/fuzz/fuzz_targets/distribution_from_paths.rs
+++ b/crates/iso-parser/fuzz/fuzz_targets/distribution_from_paths.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![no_main]
 
 use iso_parser::Distribution;

--- a/crates/iso-parser/fuzz/fuzz_targets/validate_path.rs
+++ b/crates/iso-parser/fuzz/fuzz_targets/validate_path.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![no_main]
 
 use iso_parser::{IsoEnvironment, OsIsoEnvironment};

--- a/crates/iso-parser/src/detection_tests.rs
+++ b/crates/iso-parser/src/detection_tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Detection tests for `Distribution::from_paths` against the new variants.
 //!
 //! Kept in a sibling file so the existing `#[cfg(test)] mod tests` block in

--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // Phase 6 of #286 — README.md becomes the rustdoc landing page
 // alongside the Rust-specific module docs below. docs.rs + local
 // `cargo doc --open` visitors see the operator-level overview

--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // Phase 6 of #286 — README.md becomes the rustdoc landing page.
 // `clippy::doc_markdown = allow` — README prose targets a general
 // operator audience; strict auto-backticking of product/tool names

--- a/crates/iso-probe/src/minisign.rs
+++ b/crates/iso-probe/src/minisign.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Minisign detached signature verification.
 //!
 //! Looks for `<iso>.minisig` sibling files and verifies them against a trust

--- a/crates/iso-probe/src/sidecar.rs
+++ b/crates/iso-probe/src/sidecar.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Operator-curated metadata that travels alongside an ISO.
 //!
 //! The rescue-TUI menu shows ISO filenames, which are dense and

--- a/crates/iso-probe/src/signature.rs
+++ b/crates/iso-probe/src/signature.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! ISO hash verification against sibling checksum files.
 //!
 //! Most distros publish their ISOs alongside a `SHA256SUMS` file (or per-ISO

--- a/crates/iso-probe/tests/mount_integration.rs
+++ b/crates/iso-probe/tests/mount_integration.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Integration test for the full `iso-probe` discover → prepare flow.
 //!
 //! Builds a minimal ISO9660 fixture with `xorriso`, then exercises:

--- a/crates/kexec-loader/src/lib.rs
+++ b/crates/kexec-loader/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 // Phase 6 of #286 — README.md becomes the rustdoc landing page.
 // `clippy::doc_markdown = allow` — README prose; see iso-parser for
 // rationale.

--- a/crates/kexec-loader/src/syscall.rs
+++ b/crates/kexec-loader/src/syscall.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Raw Linux syscall FFI for `kexec_file_load(2)` + `reboot(LINUX_REBOOT_CMD_KEXEC)`.
 //!
 //! This is the only module in the crate that touches `unsafe`. Every call site

--- a/crates/kexec-loader/tests/dry_run_integration.rs
+++ b/crates/kexec-loader/tests/dry_run_integration.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Real `kexec_file_load(2)` integration test.
 //!
 //! Exercises [`kexec_loader::load_dry`] against the running kernel and

--- a/crates/rescue-tui/src/failure_log.rs
+++ b/crates/rescue-tui/src/failure_log.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! On-stick failure microreport writer (#342 Phase 2, Tier A).
 //!
 //! When rescue-tui or early initramfs hits a classifiable boot

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! `rescue-tui` — ratatui application shown inside the aegis-boot signed Linux
 //! rescue environment. Discovers ISOs via `iso-probe`, lets the user pick one,
 //! and hands off to `kexec-loader`.

--- a/crates/rescue-tui/src/persistence.rs
+++ b/crates/rescue-tui/src/persistence.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Boot menu persistence — remember the user's last choice so they don't
 //! have to re-navigate after a failed kexec or between sessions.
 //!

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Pure rendering — given an [`AppState`], produce a frame on any
 //! [`ratatui::backend::Backend`]. Tested with `TestBackend`.
 

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Pure state machine for the rescue TUI — no rendering, no I/O.
 //!
 //! Split from rendering so unit tests can cover every transition without a

--- a/crates/rescue-tui/src/theme.rs
+++ b/crates/rescue-tui/src/theme.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! Color theming for the rescue TUI.
 //!
 //! Operators can override the default palette with `AEGIS_THEME=<name>`

--- a/crates/rescue-tui/src/tpm.rs
+++ b/crates/rescue-tui/src/tpm.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 //! TPM PCR extension for kexec attestation.
 //!
 //! Before aegis-boot hands control to a user-selected ISO via kexec, we

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Build a reproducible initramfs.cpio.gz that wraps rescue-tui.
 #
 # The resulting archive is designed to be appended (or concatenated) to a

--- a/scripts/catalog-revalidate.sh
+++ b/scripts/catalog-revalidate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Re-validate all URLs in the `aegis-boot recommend` catalog.
 #
 # Reads iso_url / sha256_url / sig_url fields from

--- a/scripts/check-doc-version.sh
+++ b/scripts/check-doc-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 #
 # check-doc-version.sh — drift-guard for aegis-boot version literals in
 # user-facing docs.

--- a/scripts/check-doc-version.test.sh
+++ b/scripts/check-doc-version.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 #
 # check-doc-version.test.sh — smoke-test that `check-doc-version.sh`
 # (a) passes on the current green tree, and (b) correctly FAILS when

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Full local validation run. Replaces GHA CI during development when
 # billing is constrained or you want instant feedback.
 #

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 #
 # draft-release-notes.sh — produce a first-cut CHANGELOG entry for
 # the next release using `git-cliff`. The output is a DRAFT; the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # aegis-boot installer.
 #
 # Downloads the latest (or a specific) release of the `aegis-boot`

--- a/scripts/mkusb.sh
+++ b/scripts/mkusb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Build a bootable aegis-boot USB image.
 #
 # Output: a raw disk image the user can either:

--- a/scripts/ovmf-secboot-e2e.sh
+++ b/scripts/ovmf-secboot-e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # OVMF SecBoot end-to-end test (Phase 2 of issue #16).
 #
 # Boots a real signed shim → signed grub → signed Canonical kernel chain

--- a/scripts/ovmf-secboot-smoke.sh
+++ b/scripts/ovmf-secboot-smoke.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # OVMF SecBoot foundation smoke test.
 #
 # Phase 1 of issue #16: prove the CI runner can boot QEMU under

--- a/scripts/qemu-kexec-e2e.sh
+++ b/scripts/qemu-kexec-e2e.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # kexec end-to-end smoke test.
 #
 # What this proves (when it passes):

--- a/scripts/qemu-loaded-stick.sh
+++ b/scripts/qemu-loaded-stick.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Build a fresh aegis-boot stick image, copy real ISOs onto its
 # AEGIS_ISOS data partition, then boot the result under QEMU+OVMF
 # Secure Boot — the closest no-real-USB simulation of the operator

--- a/scripts/qemu-smoke.sh
+++ b/scripts/qemu-smoke.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # QEMU smoke boot: assert that the built initramfs actually boots and that
 # rescue-tui reaches its first render.
 #

--- a/scripts/qemu-try.sh
+++ b/scripts/qemu-try.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Boot a mkusb-produced image under QEMU+OVMF SecBoot for developer testing.
 #
 # Usage:

--- a/scripts/qemu-usb-passthrough.sh
+++ b/scripts/qemu-usb-passthrough.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
 # Boot a REAL USB stick (already dd'd with mkusb.sh output) under
 # QEMU+OVMF Secure Boot via USB host passthrough. Safer than
 # rebooting the host for first-hardware shakedown (#109).


### PR DESCRIPTION
## Summary

- Add `// SPDX-License-Identifier: MIT OR Apache-2.0` to every Rust source file under `crates/` (56 files)
- Add `# SPDX-License-Identifier: MIT OR Apache-2.0` directly after the shebang in every shell script under `scripts/` (15 files)
- Enables SBOM tooling (REUSE, scancode, FOSSA) to pick up file-level license markers that corporate consumers' compliance scanners require for dual-licensed projects

## What is unchanged

- Workspace license is still `MIT OR Apache-2.0` (as set in `Cargo.toml`)
- `LICENSE-MIT` and `LICENSE-APACHE` at the repo root are untouched
- No code/logic changes — headers only

## Skipped (per spec)

- `target/`, `.git/`, `docs/`, `artifacts/` — build output / docs
- `build.rs` files — already covered by workspace license
- `crates/aegis-cli/tests/fixtures/` — no `.rs` files there anyway

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] CI matrix (Ubuntu + macOS) green

71 files changed, 127 insertions(+)