### PR TITLE
feat(release): draft winget manifest scaffold for Phase B (#365)

### DIFF
--- a/winget-manifests/README.md
+++ b/winget-manifests/README.md
@@ -131,7 +131,7 @@ no drift between published manifests and the upstream repo.
 
 [#365]: https://github.com/williamzujkowski/aegis-boot/issues/365
 [microsoft/winget-pkgs]: https://github.com/microsoft/winget-pkgs
-[winget-pkgs authoring guide]: https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md
+[winget-pkgs authoring guide]: https://github.com/microsoft/winget-pkgs/blob/master/doc/README.md#authoring-a-manifest
 [1.6.0 version]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.version.1.6.0.json
 [1.6.0 installer schema]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.installer.1.6.0.json
 [1.6.0 defaultLocale schema]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.defaultLocale.1.6.0.json

--- a/winget-manifests/README.md
+++ b/winget-manifests/README.md
@@ -1,0 +1,138 @@
+# winget-manifests/
+
+Template winget manifests for publishing `aegis-boot` to the Windows Package
+Manager (winget) community repo.
+
+> **Status: scaffolding only.** Phase B of [#365] has not yet produced a
+> Windows build. These templates exist so that once `aegis-boot.exe` is
+> built (via the FSCTL flash path), the publishing workflow has a known
+> target shape to substitute into.
+
+## What this directory is
+
+- **`templates/`** — schema-conformant template manifests with
+  `{{PLACEHOLDER}}` tokens. These are the source of truth for what
+  aegis-boot's winget entry will look like.
+- This `README.md` — publishing process + known caveats.
+
+## What this directory is NOT
+
+- It is **not** a copy of the upstream manifest set. Published manifests
+  live in [microsoft/winget-pkgs] under
+  `manifests/a/AegisBootProject/aegis-boot/<version>/`. We do not
+  vendor them here.
+- It is **not** wired into CI yet. No workflow consumes these templates
+  today. The auto-publish workflow is a separate future PR tracked in
+  #365 Phase B2.
+
+## Files
+
+Three manifests are required per version, following the winget-pkgs 1.6.0
+schema:
+
+| File                                          | Manifest type   | Purpose                                                           |
+| --------------------------------------------- | --------------- | ----------------------------------------------------------------- |
+| `AegisBootProject.aegis-boot.yaml`            | `version`       | Version index — points at the locale + installer manifests.       |
+| `AegisBootProject.aegis-boot.installer.yaml`  | `installer`     | Architecture, URL, SHA256, installer type, commands exposed.      |
+| `AegisBootProject.aegis-boot.locale.en-US.yaml` | `defaultLocale` | Human-readable metadata: publisher, description, license, tags.   |
+
+Upstream path convention:
+
+```
+manifests/a/AegisBootProject/aegis-boot/<VERSION>/
+  AegisBootProject.aegis-boot.yaml
+  AegisBootProject.aegis-boot.installer.yaml
+  AegisBootProject.aegis-boot.locale.en-US.yaml
+```
+
+## Placeholders
+
+Templates use `{{UPPERCASE}}` tokens so a future substitution step
+(e.g. `sed -e 's/{{VERSION}}/0.17.0/g'` or a scripted renderer) can fill
+them cleanly. Placeholders are wrapped in double quotes in the templates
+(e.g. `PackageVersion: "{{VERSION}}"`) so that the files parse as valid
+YAML before substitution — the `{{ … }}` sequence would otherwise be
+interpreted as an inline flow-mapping. The sed pattern still matches
+because the `{{TOKEN}}` substring is preserved inside the quotes.
+
+Current tokens:
+
+| Token                 | Filled with                                                      | Source                                   |
+| --------------------- | ---------------------------------------------------------------- | ---------------------------------------- |
+| `{{VERSION}}`         | Release version without a leading `v` (e.g. `0.17.0`)            | Cargo workspace version / git tag        |
+| `{{INSTALLER_URL}}`   | Absolute URL to the `aegis-boot-<VERSION>-windows-x64.zip` asset | GitHub Release asset URL                 |
+| `{{INSTALLER_SHA256}}` | Uppercase hex SHA-256 of the zip archive                         | Computed during the release job          |
+
+## Distribution shape
+
+- **`InstallerType: zip`** with `NestedInstallerType: portable` pointing
+  at `aegis-boot.exe`. This lets the archive bundle license files
+  (`LICENSE-MIT`, `LICENSE-APACHE`) alongside the binary while still
+  exposing `aegis-boot.exe` on PATH via the portable-command alias.
+- **`Scope: user`** — aegis-boot is a CLI tool. It does not need admin
+  install; `winget install aegis-boot` should not prompt for UAC.
+- **`Architecture: x64`** only, for now. Phase B targets
+  `x86_64-pc-windows-msvc` first. When an ARM64 Windows build exists
+  (future, likely Phase C), add a second entry under `Installers:` with
+  `Architecture: arm64` and a matching SHA256 for the ARM zip.
+
+## Publishing flow (planned)
+
+This is the intended flow once Phase B produces a Windows build. It is
+not implemented yet.
+
+1. A release tag `vX.Y.Z` is pushed.
+2. The release workflow builds `aegis-boot-X.Y.Z-windows-x64.zip`,
+   uploads it to the GitHub Release, and records the zip's SHA-256.
+3. A publishing step (tracked in #365 Phase B2) uses [wingetcreate] or an
+   equivalent tool to:
+   - Copy the three templates from `winget-manifests/templates/`.
+   - Substitute `{{VERSION}}`, `{{INSTALLER_URL}}`, `{{INSTALLER_SHA256}}`.
+   - Open a pull request against [microsoft/winget-pkgs] adding the
+     manifests at `manifests/a/AegisBootProject/aegis-boot/X.Y.Z/`.
+4. winget-pkgs CI runs the validation bot; maintainers merge once green.
+
+## Validation caveats
+
+- The winget-pkgs validation bot rejects manifests whose
+  `InstallerUrl`, `PublisherUrl`, `PackageUrl`, `LicenseUrl`,
+  `PublisherSupportUrl`, or `ReleaseNotesUrl` are unreachable. All
+  placeholders and live URLs must resolve before submission; do not
+  submit with `{{…}}` tokens unsubstituted.
+- `InstallerSha256` must match the hash of the artifact at
+  `InstallerUrl` exactly — a mismatch fails the validation bot and
+  blocks merge.
+- Schema version 1.6.0 is strict about unknown fields. Do not add
+  fields that are not in the [1.6.0 installer schema] or
+  [1.6.0 defaultLocale schema]. The validator will reject them.
+- Updates for a new version are additive: submit a new directory at
+  `manifests/a/AegisBootProject/aegis-boot/<NEW_VERSION>/` with all
+  three manifests. Do not edit previously published version directories.
+
+## Org transfer note
+
+Publisher identity is **Aegis Boot Project** (the project entity, not
+`williamzujkowski`). Once the GitHub org transfer to `aegis-boot/` lands
+(see #365 "org move"), the URLs in
+`AegisBootProject.aegis-boot.locale.en-US.yaml` (PublisherUrl,
+PackageUrl, PublisherSupportUrl, LicenseUrl, ReleaseNotesUrl,
+PrivacyUrl) will continue to be correct because they already point at
+`github.com/aegis-boot/aegis-boot`. If the org name changes again,
+update this directory in the same PR that performs the move so there is
+no drift between published manifests and the upstream repo.
+
+## References
+
+- [microsoft/winget-pkgs] — community manifest repo.
+- [winget-pkgs authoring guide] — how to add a new package.
+- [1.6.0 version schema][1.6.0 version] / [1.6.0 installer schema] /
+  [1.6.0 defaultLocale schema].
+- [wingetcreate] — Microsoft's manifest-authoring helper tool.
+
+[#365]: https://github.com/williamzujkowski/aegis-boot/issues/365
+[microsoft/winget-pkgs]: https://github.com/microsoft/winget-pkgs
+[winget-pkgs authoring guide]: https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md
+[1.6.0 version]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.version.1.6.0.json
+[1.6.0 installer schema]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.installer.1.6.0.json
+[1.6.0 defaultLocale schema]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.defaultLocale.1.6.0.json
+[wingetcreate]: https://github.com/microsoft/winget-create

--- a/winget-manifests/templates/AegisBootProject.aegis-boot.installer.yaml
+++ b/winget-manifests/templates/AegisBootProject.aegis-boot.installer.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Installer manifest for aegis-boot (winget-pkgs schema 1.6.0).
+#
+# This is a TEMPLATE. Placeholders (`{{VERSION}}`, `{{INSTALLER_URL}}`,
+# `{{INSTALLER_SHA256}}`) are substituted at release time by the future
+# publishing workflow (tracked in #365 Phase B2).
+#
+# Distribution shape: we ship a .zip containing aegis-boot.exe + LICENSE-MIT +
+# LICENSE-APACHE + README.md. winget extracts the archive and exposes the
+# nested portable exe on PATH via the `Commands` list.
+#
+# Why zip + nested portable (not bare `InstallerType: portable`)?
+#   - Lets us bundle license files alongside the binary (winget-pkgs style
+#     guide recommends shipping licenses with portable distributions).
+#   - Matches the archive layout our GitHub Releases already produce for
+#     Linux / macOS, so the Windows release artifact follows the same shape.
+#
+# Scope is `user` because aegis-boot is a CLI tool; it does not need admin
+# install. This also lets `winget install aegis-boot` succeed without UAC.
+
+PackageIdentifier: AegisBootProject.aegis-boot
+PackageVersion: "{{VERSION}}"
+
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: aegis-boot.exe
+    PortableCommandAlias: aegis-boot
+
+Scope: user
+MinimumOSVersion: 10.0.17763.0
+
+Commands:
+  - aegis-boot
+
+FileExtensions:
+  - iso
+
+Installers:
+  - Architecture: x64
+    InstallerUrl: "{{INSTALLER_URL}}"
+    InstallerSha256: "{{INSTALLER_SHA256}}"
+
+ReleaseNotesUrl: "https://github.com/aegis-boot/aegis-boot/releases/tag/v{{VERSION}}"
+
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/winget-manifests/templates/AegisBootProject.aegis-boot.locale.en-US.yaml
+++ b/winget-manifests/templates/AegisBootProject.aegis-boot.locale.en-US.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# Default locale manifest for aegis-boot (winget-pkgs schema 1.6.0).
+#
+# This is a TEMPLATE. Placeholder (`{{VERSION}}`) is substituted at release
+# time by the future publishing workflow (tracked in #365 Phase B2).
+
+PackageIdentifier: AegisBootProject.aegis-boot
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+
+Publisher: Aegis Boot Project
+PublisherUrl: https://github.com/aegis-boot/aegis-boot
+PublisherSupportUrl: https://github.com/aegis-boot/aegis-boot/issues
+PrivacyUrl: https://github.com/aegis-boot/aegis-boot/blob/main/SECURITY.md
+
+Author: William Zujkowski
+
+PackageName: aegis-boot
+PackageUrl: https://github.com/aegis-boot/aegis-boot
+
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/aegis-boot/aegis-boot/blob/main/LICENSE-MIT
+Copyright: Copyright (c) Aegis Boot Project contributors
+CopyrightUrl: https://github.com/aegis-boot/aegis-boot/blob/main/LICENSE-MIT
+
+ShortDescription: Signed Secure-Boot-enforcing Linux USB rescue stick writer
+Description: |-
+  aegis-boot writes signed, Secure-Boot-enforcing Linux rescue USB sticks
+  from upstream ISO images. It verifies ISO provenance against a signed
+  catalog, preserves the full signature chain on the target device, and
+  supports multiple distributions (Fedora, Debian, Ubuntu, NixOS, Arch,
+  openSUSE, and more) through a single catalog-driven workflow.
+
+  On Windows, aegis-boot uses the native FSCTL flash path so you do not
+  need WSL, Rufus, or balenaEtcher to produce a verified rescue stick.
+
+Moniker: aegis-boot
+
+Tags:
+  - usb
+  - bootable-media
+  - bootable-usb
+  - linux
+  - rescue
+  - secure-boot
+  - iso
+  - flash
+  - cli
+
+ReleaseNotesUrl: "https://github.com/aegis-boot/aegis-boot/releases/tag/v{{VERSION}}"
+
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/winget-manifests/templates/AegisBootProject.aegis-boot.yaml
+++ b/winget-manifests/templates/AegisBootProject.aegis-boot.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Version manifest for aegis-boot (winget-pkgs schema 1.6.0).
+#
+# This is a TEMPLATE. Placeholders (`{{VERSION}}`) are substituted at
+# release time by the future publishing workflow (tracked in #365 Phase B2).
+# Do not submit this file as-is to microsoft/winget-pkgs.
+
+PackageIdentifier: AegisBootProject.aegis-boot
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

**Scaffold only — not a functional winget entry.** `aegis-boot.exe` does not exist yet on Windows; Phase B core (the FSCTL flash path) is a separate future PR. These templates let that future work (and the Phase B2 auto-publish workflow) plug in a real `.exe` URL + SHA-256 + version without re-deriving the manifest shape from scratch.

Context: [#365] Phase B was confirmed as winget-only distribution (maintainer decision 2026-04-21 — *"winget is part of windows by default now… winget flow is fine"*). Publisher identity is **Aegis Boot Project** (the project entity).

## What this PR adds

- `winget-manifests/templates/` — the three manifests winget-pkgs 1.6.0 requires per version, using `{{VERSION}}`, `{{INSTALLER_URL}}`, `{{INSTALLER_SHA256}}` placeholders a future sed/renderer pipeline can substitute:
  - `AegisBootProject.aegis-boot.yaml` (version)
  - `AegisBootProject.aegis-boot.installer.yaml` (installer)
  - `AegisBootProject.aegis-boot.locale.en-US.yaml` (defaultLocale)
- `winget-manifests/README.md` — publishing flow, placeholder reference, schema caveats, org-transfer note.

## Key design decisions

- **Schema version `1.6.0`** — current stable winget-pkgs schema.
- **`InstallerType: zip` + `NestedInstallerType: portable`** over bare `portable`. The zip bundles `LICENSE-MIT` / `LICENSE-APACHE` alongside the binary (winget-pkgs style guide recommends this for portable distributions) while still exposing `aegis-boot.exe` on PATH via `PortableCommandAlias`.
- **`Scope: user`** — CLI tool, no admin install needed; `winget install aegis-boot` should not prompt for UAC.
- **`Architecture: x64` only** — Phase B targets `x86_64-pc-windows-msvc` first. A second `Installers:` entry for `arm64` lands when that build exists.
- **Placeholders are quoted** (e.g. `PackageVersion: "{{VERSION}}"`) so the templates parse as valid YAML — `{{ … }}` unquoted would be interpreted as an inline flow-mapping. The `{{TOKEN}}` substring is preserved inside the quotes, so a sed-based substitution still works.

## Out of scope for this PR

- Actual `aegis-boot.exe` build (Phase B core — FSCTL flash path).
- Auto-publish GitHub Actions workflow that opens the PR against [microsoft/winget-pkgs] (Phase B2 — future PR).
- Testing on a real Windows machine (no `.exe` to test yet).

## Test plan

- [x] All three template YAMLs parse as valid YAML (verified with `python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Top-level keys match the [1.6.0 schema][1.6.0 installer schema] for each manifest type (`version`, `installer`, `defaultLocale`).
- [x] No invented fields outside the 1.6.0 schema — the winget validator rejects unknown fields.
- [x] All placeholder tokens are uppercase and wrapped in `{{…}}` so a future sed pipeline can substitute cleanly.
- [ ] When Phase B core lands, dry-run substitution with a real `aegis-boot-X.Y.Z-windows-x64.zip` asset URL + SHA-256 and run `winget validate` against the rendered manifests before opening the PR against microsoft/winget-pkgs.

[#365]: https://github.com/williamzujkowski/aegis-boot/issues/365
[microsoft/winget-pkgs]: https://github.com/microsoft/winget-pkgs
[1.6.0 installer schema]: https://github.com/microsoft/winget-cli/blob/master/schemas/JSON/manifests/v1.6.0/manifest.installer.1.6.0.json