### PR TITLE
feat(ci): build aarch64-apple-darwin binary for releases (#365 Phase A1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,154 @@ jobs:
             out/SHA256SUMS.sig \
             out/SHA256SUMS.pem
 
+  # -----------------------------------------------------------------
+  # macOS arm64 (Apple Silicon) binary — Phase A1 of epic #365.
+  # -----------------------------------------------------------------
+  # Ships aarch64-apple-darwin alongside the Linux build so Homebrew
+  # and direct-download operators on M1+ Macs can install a native
+  # binary rather than cargo-build from source.
+  #
+  # Phase A1 deliberately does NOT notarize the binary. Notarization
+  # (Phase A2 of #365) is gated on the maintainer enrolling in the
+  # Apple Developer Program ($99/year) and provisioning a Developer ID
+  # Application certificate + notarytool credentials as repo secrets
+  # (APPLE_DEV_ID_CERT, APPLE_DEV_ID_CERT_PASSWORD, APPLE_ID,
+  # APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD). Until Phase A2 lands:
+  #
+  #   - The binary carries an *ad-hoc* code signature (`codesign -s -`).
+  #     This is enough for macOS to execute the binary from a terminal
+  #     but does NOT satisfy Gatekeeper's first-launch policy for
+  #     quarantined downloads.
+  #
+  #   - Operators installing via `brew install` (from the tap) will
+  #     NOT see a Gatekeeper warning — Homebrew fetches binaries over
+  #     HTTPS without setting the com.apple.quarantine extended
+  #     attribute, so the first-launch policy never fires.
+  #
+  #   - Operators who download the raw binary from the GitHub release
+  #     UI (or `curl`'d in a way that inherits quarantine) WILL see
+  #     "cannot be opened because the developer cannot be verified"
+  #     on first launch. Escape hatch: `xattr -d com.apple.quarantine
+  #     ./aegis-boot-aarch64-apple-darwin` or Right-Click → Open once.
+  #     This is called out in docs/INSTALL.md.
+  #
+  # Cosign keyless signing (same OIDC flow as the Linux artifact) is
+  # still produced. That's independent of Apple notarization and gives
+  # operators a verifiable provenance chain from this repo's
+  # release.yml identity regardless of the Apple track.
+  build-macos-arm64:
+    name: Build + sign macOS arm64 binary (aarch64-apple-darwin)
+    runs-on: macos-14
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      id-token: write # cosign keyless signing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust toolchain (pinned)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          # macos-14 runners are arm64-native, so aarch64-apple-darwin
+          # is installed by the rustup bootstrap above. No `rustup target
+          # add` needed — verify the host matches our release target.
+          "$HOME/.cargo/bin/rustc" -vV | grep '^host: aarch64-apple-darwin$'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: Build aegis-boot CLI (release, aarch64-apple-darwin)
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+        run: |
+          cargo build --release --locked \
+            --target aarch64-apple-darwin \
+            -p aegis-cli
+          mkdir -p out
+          cp target/aarch64-apple-darwin/release/aegis-boot \
+            out/aegis-boot-aarch64-apple-darwin
+          file out/aegis-boot-aarch64-apple-darwin
+          # macOS `strip` is fine with Mach-O binaries; preserves the
+          # load commands cosign needs to attest over.
+          strip out/aegis-boot-aarch64-apple-darwin
+          du -h out/aegis-boot-aarch64-apple-darwin
+
+      - name: Ad-hoc codesign the binary
+        # `-s -` is the ad-hoc (identityless) code signature. Enough to
+        # satisfy macOS's "must be signed" execution gate for binaries
+        # *not* quarantined (e.g. brew-installed); NOT enough for
+        # Gatekeeper first-launch on quarantined downloads. That needs
+        # a Developer ID identity + notarization, deferred to Phase A2.
+        run: |
+          codesign -s - --timestamp=none --force \
+            out/aegis-boot-aarch64-apple-darwin
+          codesign -vv out/aegis-boot-aarch64-apple-darwin
+
+      - name: SHA256 for the macOS binary
+        run: |
+          ( cd out && shasum -a 256 \
+              aegis-boot-aarch64-apple-darwin \
+              > aegis-boot-aarch64-apple-darwin.sha256 )
+          cat out/aegis-boot-aarch64-apple-darwin.sha256
+
+      - name: Cosign sign (keyless, same OIDC flow as Linux build)
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          cd out
+          cosign sign-blob --yes \
+            --output-signature  aegis-boot-aarch64-apple-darwin.sig \
+            --output-certificate aegis-boot-aarch64-apple-darwin.pem \
+            aegis-boot-aarch64-apple-darwin
+          ls -1 aegis-boot-aarch64-apple-darwin*
+
+      - name: Upload macOS assets to the release
+        # The Linux job (`build-and-release`) creates the release if it
+        # does not yet exist. macOS runs in parallel, so guard against
+        # the race by retrying `gh release view` briefly before upload.
+        # --clobber overwrites if a re-run uploads the same asset name.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.tag.outputs.name }}"
+          for i in 1 2 3 4 5 6; do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              break
+            fi
+            echo "release $tag not yet visible (attempt $i) — sleeping"
+            sleep 10
+          done
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            # Create it ourselves — the Linux job may still be building
+            # the initramfs + mkusb image. Idempotent either way.
+            gh release create "$tag" \
+              --title "aegis-boot $tag" \
+              --notes "Release ${tag}"
+          fi
+          gh release upload "$tag" --clobber \
+            out/aegis-boot-aarch64-apple-darwin \
+            out/aegis-boot-aarch64-apple-darwin.sha256 \
+            out/aegis-boot-aarch64-apple-darwin.sig \
+            out/aegis-boot-aarch64-apple-darwin.pem
+
   # Bumps Formula/aegis-boot.rb on main when a new tag is pushed. Skipped
   # for workflow_dispatch (which is the manual-backfill path — bumping
   # would risk regressing the formula to an older release).

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ Install the operator CLI:
 | Platform | Status |
 |---|---|
 | Linux x86_64 | Full support — flash + build, add ISOs, kexec, attest, doctor, compat |
-| macOS (Apple Silicon + Intel) | Drive detection + `flash --image PATH` ([#229](https://github.com/williamzujkowski/aegis-boot/pull/229)). Image *building* requires Linux (mkusb.sh deps); use `aegis-boot fetch-image` (zero-arg, auto-resolves to latest release + cosign-verifies the signed `.img` — [#235](https://github.com/williamzujkowski/aegis-boot/issues/235)) then pipe to `flash --image $(...)` |
+| macOS (Apple Silicon, arm64) | **Pre-built binary shipped** ([#365](https://github.com/williamzujkowski/aegis-boot/issues/365) Phase A1). Drive detection + `flash --image PATH` ([#229](https://github.com/williamzujkowski/aegis-boot/pull/229)). Image *building* requires Linux (mkusb.sh deps); use `aegis-boot fetch-image` (zero-arg, auto-resolves to latest release + cosign-verifies the signed `.img` — [#235](https://github.com/williamzujkowski/aegis-boot/issues/235)) then pipe to `flash --image $(...)`. Binary is ad-hoc codesigned but not yet notarized (Phase A2) — `brew install` is unaffected; direct downloads may trip Gatekeeper on first launch, see [docs/INSTALL.md § macOS (Apple Silicon)](./docs/INSTALL.md#macos-apple-silicon). |
+| macOS (Intel, x86_64) | Deferred — maintainer decision to ship arm64 first ([#365](https://github.com/williamzujkowski/aegis-boot/issues/365)). Build from source with `cargo install --path crates/aegis-cli`. |
 | Windows | Drive enumeration via `Get-Disk` ([#230](https://github.com/williamzujkowski/aegis-boot/pull/230)). Raw-disk writing deferred — combine `aegis-boot list` with Rufus or `dd-for-Windows` for the write |
 
-Pre-built binaries below are Linux-only today; macOS/Windows users build with `cargo install --path crates/aegis-cli` until a darwin/windows release artifact ships.
+Pre-built binaries ship today for Linux x86_64 and macOS arm64 (Apple Silicon); Intel-Mac / Windows users build with `cargo install --path crates/aegis-cli` until their release artifact ships ([#365](https://github.com/williamzujkowski/aegis-boot/issues/365)).
 
 ```bash
 # Cosign-verified install from the latest GitHub release.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,7 +2,7 @@
 
 End-to-end: get aegis-boot onto a USB stick, drop ISOs onto it, boot a target machine, and pick an ISO to kexec into. Reading time: ~5 minutes. Hands-on time: ~10 minutes plus dd.
 
-This guide assumes Linux on the operator workstation (where you write the stick). macOS / Windows flashing is tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123).
+This guide assumes Linux on the operator workstation (where you write the stick). macOS / Windows flashing is tracked in [#123](https://github.com/williamzujkowski/aegis-boot/issues/123). A native macOS arm64 (Apple Silicon) CLI binary is shipped with each release as of Phase A1 of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365) — see [§ macOS (Apple Silicon)](#macos-apple-silicon) below.
 
 ## Before you start
 
@@ -33,6 +33,33 @@ Both A and B install the same binary (Linux x86_64 today; cross-platform tracked
 Option A downloads the latest release's `aegis-boot-x86_64-linux` static binary, verifies its Sigstore cosign signature against this repo's `release.yml` workflow identity, and installs to `/usr/local/bin` (root) or `~/.local/bin` (non-root). The installer itself does NOT need root unless you're installing to `/usr/local/bin`. To inspect first: `curl -sSL ... -o install.sh && less install.sh && sh install.sh`.
 
 Option B (Homebrew) auto-installs the Brew-tracked runtime deps (`curl`, `gnupg`, `gptfdisk`, `coreutils`). Runs the same cosign-verifiable binary; verify the cosign signature manually if you want to confirm — see [Formula/README.md](../Formula/README.md).
+
+### macOS (Apple Silicon)
+
+A native `aegis-boot-aarch64-apple-darwin` binary ships with every release from v0.16.0 onward (Phase A1 of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365)). Install via Homebrew (recommended) or direct download:
+
+```bash
+# Option A — Homebrew (no Gatekeeper interaction)
+brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
+brew install aegis-boot
+
+# Option B — direct download (see Gatekeeper note below)
+curl -sSfLO https://github.com/williamzujkowski/aegis-boot/releases/latest/download/aegis-boot-aarch64-apple-darwin
+chmod +x aegis-boot-aarch64-apple-darwin
+```
+
+**Gatekeeper note (direct-download path only).** The macOS binary is currently *ad-hoc codesigned* but **not notarized** — notarization is tracked as Phase A2 of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365) and gated on the project enrolling in the Apple Developer Program. In practice:
+
+- `brew install` operators see no warning — Homebrew fetches over HTTPS without setting the `com.apple.quarantine` extended attribute, so Gatekeeper's first-launch policy never fires.
+- Direct-download operators (browser download, or a `curl` invocation that inherits quarantine) may see "cannot be opened because the developer cannot be verified" on first launch. Clear quarantine explicitly:
+  ```bash
+  xattr -d com.apple.quarantine ./aegis-boot-aarch64-apple-darwin
+  ```
+  Or right-click → Open once in Finder. After first launch, Gatekeeper remembers the approval.
+
+What works on macOS today: `aegis-boot list`, `aegis-boot doctor`, drive detection, and `aegis-boot flash --image PATH` (against a pre-built `.img` fetched via `aegis-boot fetch-image`). Image *building* still requires Linux — see the Quickstart table in [README.md](../README.md).
+
+macOS x86_64 (Intel) and Windows native builds remain deferred — see [#365](https://github.com/williamzujkowski/aegis-boot/issues/365) for the full cross-platform roadmap.
 
 Sanity check:
 


### PR DESCRIPTION
## Summary

Phase A1 of the cross-platform flash-only epic [#365](https://github.com/williamzujkowski/aegis-boot/issues/365) — ship what we already have for macOS. Adds a native arm64 (Apple Silicon) CLI binary to every release so M1+ operators install a pre-built binary via Homebrew instead of cargo-build-from-source.

- New `build-macos-arm64` job in `.github/workflows/release.yml`, runs on `macos-14` (arm64-native, no cross-compile). Produces `aegis-boot-aarch64-apple-darwin` + `.sha256` + cosign `.sig`/`.pem`.
- Binary is **ad-hoc codesigned** (`codesign -s -`); **not notarized**. Notarization is Phase A2, gated on Apple Developer Program enrollment.
- `docs/INSTALL.md` and `README.md` updated to document the macOS install path and the Gatekeeper consequences for direct-download users (`brew install` is unaffected).

## What's deliberately out of scope

- **x86_64-apple-darwin** — maintainer confirmed arm64-only for Phase A1
- **Notarization + signing identity** — Phase A2 of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365), needs Apple Dev Program enrollment
- **Homebrew formula update** — Phase A3 of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365)
- **Windows native build** — separate phase of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365)

## Test plan

- [ ] YAML validates (`python3 -c 'import yaml; yaml.safe_load(...)'`) — done locally
- [ ] Dry-run the workflow on a pre-release tag and verify the macOS binary + signature land as assets
- [ ] On an Apple Silicon Mac: download the binary, `xattr -d com.apple.quarantine`, run `./aegis-boot --version` and `./aegis-boot doctor`
- [ ] Verify cosign signature: `cosign verify-blob --certificate-identity-regexp "https://github.com/williamzujkowski/aegis-boot/" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" --signature aegis-boot-aarch64-apple-darwin.sig --certificate aegis-boot-aarch64-apple-darwin.pem aegis-boot-aarch64-apple-darwin`
- [ ] Confirm existing Linux build and `bump-brew-formula` jobs are unchanged (the macOS job runs in parallel and does not gate them)

Refs #365.