### PR TITLE
feat(brew): ship macOS arm64 bottle via Homebrew (#365 Phase A3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,28 +465,67 @@ jobs:
         run: |
           tag="${{ steps.tag.outputs.name }}"
           version="${tag#v}"
-          new_sha=$(grep '  aegis-boot-x86_64-linux$' /tmp/SHA256SUMS | awk '{print $1}')
-          if [ -z "$new_sha" ]; then
-            echo "no aegis-boot-x86_64-linux row in SHA256SUMS — aborting bump" >&2
+          # Extract both platform shas from the release's SHA256SUMS. If
+          # one is missing (e.g. the macOS build leg failed mid-release),
+          # we warn + skip that block only — don't fail the whole bump,
+          # because a partial bump is still useful for the other arch.
+          linux_sha=$(grep '  aegis-boot-x86_64-linux$' /tmp/SHA256SUMS | awk '{print $1}')
+          macos_sha=$(grep '  aegis-boot-aarch64-apple-darwin$' /tmp/SHA256SUMS | awk '{print $1}')
+          echo "new version:    $version"
+          echo "linux  sha256:  ${linux_sha:-<missing>}"
+          echo "macos  sha256:  ${macos_sha:-<missing>}"
+
+          if [ -z "$linux_sha" ] && [ -z "$macos_sha" ]; then
+            echo "neither aegis-boot-x86_64-linux nor aegis-boot-aarch64-apple-darwin in SHA256SUMS — aborting bump" >&2
             exit 1
           fi
-          echo "new version: $version"
-          echo "new sha256:  $new_sha"
 
           if [ ! -f Formula/aegis-boot.rb ]; then
             echo "Formula/aegis-boot.rb missing — nothing to bump" >&2
             exit 0
           fi
 
-          # Idempotent edits via sed. The formula's three pinned values:
-          #   version "X.Y.Z"
-          #   url "https://github.com/.../v X.Y.Z /aegis-boot-x86_64-linux"
-          #   sha256 "..."
-          sed -i \
-            -e "s|^  version \".*\"|  version \"${version}\"|" \
-            -e "s|/releases/download/v[^/]*/aegis-boot-x86_64-linux\"|/releases/download/v${version}/aegis-boot-x86_64-linux\"|" \
-            -e "s|^      sha256 \"[a-f0-9]*\"|      sha256 \"${new_sha}\"|" \
-            Formula/aegis-boot.rb
+          # Bump version (single line match — unambiguous).
+          sed -i "s|^  version \".*\"|  version \"${version}\"|" Formula/aegis-boot.rb
+
+          # Bump the Linux block — scope the edit to lines between
+          # `on_linux do` and its matching `end` so we don't clobber the
+          # macOS block. Use awk with a small state machine (ranges are
+          # trickier in sed for nested blocks + we want an inner-range).
+          if [ -n "$linux_sha" ]; then
+            awk -v ver="$version" -v sha="$linux_sha" '
+              /^  on_linux do$/ { in_block = 1 }
+              in_block && /^  end$/ { in_block = 0 }
+              in_block && /aegis-boot-x86_64-linux"$/ {
+                sub(/\/releases\/download\/v[^/]+\//, "/releases/download/v" ver "/")
+              }
+              in_block && /^      sha256 "/ {
+                sub(/sha256 "[^"]*"/, "sha256 \"" sha "\"")
+              }
+              { print }
+            ' Formula/aegis-boot.rb > Formula/aegis-boot.rb.tmp
+            mv Formula/aegis-boot.rb.tmp Formula/aegis-boot.rb
+          else
+            echo "::warning::macOS arm64 sha present but Linux x86_64 sha missing — Linux block left unchanged"
+          fi
+
+          # Bump the macOS block — same scoping trick, different block.
+          if [ -n "$macos_sha" ]; then
+            awk -v ver="$version" -v sha="$macos_sha" '
+              /^  on_macos do$/ { in_block = 1 }
+              in_block && /^  end$/ { in_block = 0 }
+              in_block && /aegis-boot-aarch64-apple-darwin"$/ {
+                sub(/\/releases\/download\/v[^/]+\//, "/releases/download/v" ver "/")
+              }
+              in_block && /^      sha256 "/ {
+                sub(/sha256 "[^"]*"/, "sha256 \"" sha "\"")
+              }
+              { print }
+            ' Formula/aegis-boot.rb > Formula/aegis-boot.rb.tmp
+            mv Formula/aegis-boot.rb.tmp Formula/aegis-boot.rb
+          else
+            echo "::warning::Linux x86_64 sha present but macOS arm64 sha missing — macOS block left unchanged"
+          fi
 
           # Show the diff for the run log.
           echo "--- formula diff ---"

--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -10,7 +10,7 @@
 class AegisBoot < Formula
   desc "Signed UEFI Secure Boot rescue environment for booting any ISO from USB"
   homepage "https://github.com/williamzujkowski/aegis-boot"
-  version "0.16.0"
+  version "0.15.0"
   license any_of: ["Apache-2.0", "MIT"]
 
   # Runtime dependencies the operator CLI shells out to. Listed
@@ -23,13 +23,23 @@ class AegisBoot < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-x86_64-linux"
-      sha256 "PLACEHOLDER_LINUX_X86_64_SHA"
+      # v0.15.0 Linux binary — real URL + sha, `brew install` works today.
+      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.15.0/aegis-boot-x86_64-linux"
+      sha256 "cae7fae1b70e8d7576be83f86036eac91c53cfc7397f7f98a92332bbb17467d6"
     end
   end
 
   on_macos do
     on_arm do
+      # macOS arm64 support starts at v0.16.0 (per #365 Phase A1, which
+      # added the release.yml job that builds the aarch64-apple-darwin
+      # binary). Until v0.16.0 ships, this block carries intentional
+      # placeholder values — `brew install` on macOS will fail clean
+      # with "invalid sha256" (no silent-wrong-binary risk).
+      #
+      # When the maintainer cuts v0.16.0, the `bump-brew-formula` job
+      # in release.yml sed-replaces these placeholders with the real
+      # sha from SHA256SUMS, atomically with the Linux block.
       url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-aarch64-apple-darwin"
       sha256 "PLACEHOLDER_MACOS_ARM64_SHA"
     end

--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -21,27 +21,25 @@ class AegisBoot < Formula
   depends_on "gnupg"
   depends_on "gptfdisk" # provides sgdisk
 
+  on_macos do
+    on_arm do
+      # macOS arm64 support starts at v0.16.0 (per #365 Phase A1, which
+      # added the release.yml job that builds the aarch64-apple-darwin
+      # binary). Until v0.16.0 ships, this block's URL 404s and `brew
+      # install` fails clean on the download step — no silent-wrong-binary
+      # risk. The sha256 value is 64 zeros so it passes `brew audit` as
+      # syntactically valid hex; bump-brew-formula replaces it with the
+      # real sha when v0.16.0 is tagged.
+      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-aarch64-apple-darwin"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
   on_linux do
     on_intel do
       # v0.15.0 Linux binary — real URL + sha, `brew install` works today.
       url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.15.0/aegis-boot-x86_64-linux"
       sha256 "cae7fae1b70e8d7576be83f86036eac91c53cfc7397f7f98a92332bbb17467d6"
-    end
-  end
-
-  on_macos do
-    on_arm do
-      # macOS arm64 support starts at v0.16.0 (per #365 Phase A1, which
-      # added the release.yml job that builds the aarch64-apple-darwin
-      # binary). Until v0.16.0 ships, this block carries intentional
-      # placeholder values — `brew install` on macOS will fail clean
-      # with "invalid sha256" (no silent-wrong-binary risk).
-      #
-      # When the maintainer cuts v0.16.0, the `bump-brew-formula` job
-      # in release.yml sed-replaces these placeholders with the real
-      # sha from SHA256SUMS, atomically with the Linux block.
-      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-aarch64-apple-darwin"
-      sha256 "PLACEHOLDER_MACOS_ARM64_SHA"
     end
   end
 

--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -4,12 +4,13 @@
 #   brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot
 #   brew install aegis-boot
 #
-# Cross-platform support: Linux/x86_64 only today. macOS, Windows,
-# and Linux/aarch64 builds are tracked under #123 and #137.
+# Cross-platform support: Linux x86_64 + macOS Apple Silicon (arm64)
+# are shipped as of v0.16.0 (#365 Phase A1 + A3). macOS Intel, Windows,
+# and Linux aarch64 remain open under #365 / #367.
 class AegisBoot < Formula
   desc "Signed UEFI Secure Boot rescue environment for booting any ISO from USB"
   homepage "https://github.com/williamzujkowski/aegis-boot"
-  version "0.15.0"
+  version "0.16.0"
   license any_of: ["Apache-2.0", "MIT"]
 
   # Runtime dependencies the operator CLI shells out to. Listed
@@ -22,64 +23,75 @@ class AegisBoot < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.15.0/aegis-boot-x86_64-linux"
-      sha256 "cae7fae1b70e8d7576be83f86036eac91c53cfc7397f7f98a92332bbb17467d6"
+      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-x86_64-linux"
+      sha256 "PLACEHOLDER_LINUX_X86_64_SHA"
+    end
+  end
+
+  on_macos do
+    on_arm do
+      url "https://github.com/williamzujkowski/aegis-boot/releases/download/v0.16.0/aegis-boot-aarch64-apple-darwin"
+      sha256 "PLACEHOLDER_MACOS_ARM64_SHA"
     end
   end
 
   def install
     if OS.linux? && Hardware::CPU.intel?
       bin.install "aegis-boot-x86_64-linux" => "aegis-boot"
-      # GitHub release downloads come in without the exec bit; bin.install
-      # preserves the source mode. brew's final `test do` phase runs through
-      # a shell that sets 0755 implicitly, but the install-time
-      # generate_completions_from_executable invocation needs the bit set
-      # now. Mode 0555 matches what brew would land with post-install
-      # (read+exec for everyone, no write).
-      (bin/"aegis-boot").chmod 0555
-
-      # Generate completions + man page only when the installed binary
-      # supports them. `completions` + `man` subcommands shipped in
-      # #207 / #211 (post-v0.13.0); pinning to an older tag means these
-      # subcommands exit 2 with "unknown command", which would fail the
-      # install. Probe via `--help` — grep-on-help is more reliable than
-      # semver-parse against a floating --version format.
-      help_output = Utils.safe_popen_read(bin/"aegis-boot", "--help")
-      if help_output.include?("completions")
-        # `shells:` constrains to the two we support — `completions fish`
-        # would exit 2 otherwise and fail the install.
-        generate_completions_from_executable(
-          bin/"aegis-boot", "completions", shells: [:bash, :zsh]
-        )
-      end
-
-      if help_output.include?("aegis-boot man")
-        # Emit the man page from the same binary (self-contained via
-        # include_str! in crates/aegis-cli/src/man.rs). Homebrew has no
-        # built-in `generate_man_from_executable`, so shell-out to the
-        # binary and install the result.
-        (buildpath/"aegis-boot.1").write(Utils.safe_popen_read(bin/"aegis-boot", "man"))
-        man1.install "aegis-boot.1"
-      end
+    elsif OS.mac? && Hardware::CPU.arm?
+      bin.install "aegis-boot-aarch64-apple-darwin" => "aegis-boot"
     else
       odie <<~EOS
-        aegis-boot binaries are currently published only for Linux x86_64.
+        aegis-boot binaries are currently published for:
+          - Linux x86_64
+          - macOS Apple Silicon (arm64)
 
-        Cross-platform support is tracked in:
-          https://github.com/williamzujkowski/aegis-boot/issues/123
-          https://github.com/williamzujkowski/aegis-boot/issues/137
+        Support for macOS Intel, Windows, and Linux aarch64 is tracked in:
+          https://github.com/williamzujkowski/aegis-boot/issues/365
+          https://github.com/williamzujkowski/aegis-boot/issues/367
 
-        Build from source today:
+        If you're on one of the unsupported arches, build from source:
           git clone https://github.com/williamzujkowski/aegis-boot
           cd aegis-boot
           cargo install --path crates/aegis-cli
       EOS
     end
+
+    # GitHub release downloads come in without the exec bit; bin.install
+    # preserves the source mode. Mode 0555 matches what brew would land
+    # with post-install (read+exec for everyone, no write).
+    (bin/"aegis-boot").chmod 0555
+
+    # Generate completions + man page only when the installed binary
+    # supports them. `completions` + `man` subcommands shipped in
+    # #207 / #211 (post-v0.13.0); probing via `--help` is more reliable
+    # than semver-parse against a floating --version format.
+    help_output = Utils.safe_popen_read(bin/"aegis-boot", "--help")
+    if help_output.include?("completions")
+      # `shells:` constrains to the two we support — `completions fish`
+      # would exit 2 otherwise and fail the install.
+      generate_completions_from_executable(
+        bin/"aegis-boot", "completions", shells: [:bash, :zsh]
+      )
+    end
+
+    if help_output.include?("aegis-boot man")
+      # Emit the man page from the same binary (self-contained via
+      # include_str! in crates/aegis-cli/src/man.rs). Homebrew has no
+      # built-in `generate_man_from_executable`, so shell-out and install.
+      (buildpath/"aegis-boot.1").write(Utils.safe_popen_read(bin/"aegis-boot", "man"))
+      man1.install "aegis-boot.1"
+    end
   end
 
   def caveats
+    binary_name = if OS.mac? && Hardware::CPU.arm?
+      "aegis-boot-aarch64-apple-darwin"
+    else
+      "aegis-boot-x86_64-linux"
+    end
     <<~EOS
-      aegis-boot is a USB-imaging tool intended for Linux operator workstations.
+      aegis-boot is a USB-imaging tool for Linux + macOS operator workstations.
 
       Quick start:
         aegis-boot doctor              # check host + stick health
@@ -95,9 +107,9 @@ class AegisBoot < Formula
         cosign verify-blob \\
           --certificate-identity-regexp '^https://github\\.com/williamzujkowski/aegis-boot/.+@refs/tags/v.+$' \\
           --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \\
-          --signature aegis-boot-x86_64-linux.sig \\
-          --certificate aegis-boot-x86_64-linux.pem \\
-          aegis-boot-x86_64-linux
+          --signature #{binary_name}.sig \\
+          --certificate #{binary_name}.pem \\
+          #{binary_name}
       (download .sig + .pem from the same release)
     EOS
   end


### PR DESCRIPTION
## Summary

- Extends `Formula/aegis-boot.rb` with an `on_macos`/`on_arm` block so `brew install aegis-boot` installs the `aegis-boot-aarch64-apple-darwin` binary on Apple Silicon. Completes the maintainer decision that Homebrew is THE recognized macOS install path (#365).
- Refactors `def install` to handle both Linux x86_64 and macOS arm64 branches and shares the completions/man post-install logic across both. Caveats rewrite references the installed platform's binary name in the `cosign verify-blob` recipe.
- Updates `release.yml`'s `bump-brew-formula` job to extract both the `x86_64-linux` and `aarch64-apple-darwin` shas from `SHA256SUMS` and perform block-scoped `awk` substitutions so the Linux and macOS URLs + shas stay independent. Partial-failure handling: if one sha is missing (e.g. the macOS build leg failed mid-release), log a warning and skip that block only.

Builds on #371 (Phase A1, which added the macOS arm64 build + cosign signing in CI). This PR is Phase A3 — the Homebrew distribution wiring.

## Caveats for the maintainer

- The formula URLs reference `v0.16.0` with `PLACEHOLDER_LINUX_X86_64_SHA` / `PLACEHOLDER_MACOS_ARM64_SHA`. The first release to exercise this formula is `v0.16.0` — at tag time, the `bump-brew-formula` job fills in real shas. `v0.15.0` users still see the previous Linux-only formula.
- `brew style --formula Formula/aegis-boot.rb` was not run locally (brew not installed in the dev environment); CI will catch any style issues on PR. Follow-up: wire `brew audit` / `brew style` into CI if not already (tracked as a potential Phase A4).
- Out of scope: macOS Intel (`x86_64-apple-darwin`), Windows (winget handles that), Linux aarch64. All remain tracked under #365 / #367.

## Test plan

- [ ] CI green (YAML + existing lint gates)
- [ ] On v0.16.0 release, verify the bump job produces a correct Formula diff (both Linux and macOS URLs + shas bumped, version bumped, no cross-contamination)
- [ ] On macOS arm64 runner: `brew tap williamzujkowski/aegis-boot https://github.com/williamzujkowski/aegis-boot && brew install aegis-boot && aegis-boot --version` returns `aegis-boot v0.16.0`
- [ ] On Linux x86_64: same install recipe still works (regression)
- [ ] On unsupported arch (e.g. macOS Intel): odie message points at #365 / #367 and includes build-from-source fallback

Closes: #365 Phase A3
Refs: #371 (Phase A1), #367 (follow-on arches)