### PR TITLE
docs(adr-0002): revision 2 — Key Epoch + historical anchors + rotation rehearsal (#366)

### DIFF
--- a/docs/architecture/KEY_MANAGEMENT.md
+++ b/docs/architecture/KEY_MANAGEMENT.md
@@ -1,11 +1,12 @@
 # ADR 0002: Key Management for Signed Attestation + Bundle Trust Anchor
 
-**Status:** PROPOSED (revision 2)
+**Status:** PROPOSED (revision 3)
 **Date:** 2026-04-21
 **Tracking issue:** [#366](https://github.com/williamzujkowski/aegis-boot/issues/366)
 **Revision history:**
 - 2026-04-20 — initial proposal (rev 1)
 - 2026-04-21 — rev 2 adds Decision 7 (Key Epoch), §3.6 (historical anchors), and §5.1 (rotation rehearsal) after consensus vote surfaced revocation-circularity, temporal-deadlock, and rotation-atrophy objections (vote result: 60% approve, below supermajority threshold)
+- 2026-04-21 — rev 3 closes rev-2's residual TOFU window on fresh installs by adding `MIN_REQUIRED_EPOCH` binary-embedded floor to Decision 7; extends §5.1 rehearsal with a signing-handoff audit step to waive the signing-oracle split trigger (§6.2)
 **Consumers:** [#349](https://github.com/williamzujkowski/aegis-boot/issues/349) (signed attestation manifest), [#367](https://github.com/williamzujkowski/aegis-boot/issues/367) (cross-platform `--direct-install` trust anchor, Phase D of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365))
 **Supersedes:** portion of `crates/aegis-cli/src/attest.rs` header comment (lines 22–28) that defers signing to "epic #139"; this ADR claims the design.
 
@@ -71,7 +72,7 @@ And one added in rev 2 to close the revocation-circularity gap surfaced by the f
 
 | # | Question | Decision |
 |---|----------|----------|
-| 7 | Post-compromise replay defense | **Monotonic Key Epoch counter** embedded in every signed manifest (attestation + bundle). Binaries refuse to accept any manifest whose epoch is lower than the highest epoch they have previously observed (persisted to `~/.local/share/aegis-boot/trust/seen-epoch`). A post-compromise attacker who signs `v9.9.9` with epoch N-1 cannot convince operators who have already seen epoch N that the rollback is legitimate. See §3.5 |
+| 7 | Post-compromise replay defense | **Two-layer rollback floor.** (a) Binary-embedded `MIN_REQUIRED_EPOCH` constant: every release hardcodes the epoch active at the time the binary was compiled. Any manifest with `key_epoch < MIN_REQUIRED_EPOCH` is rejected unconditionally (protects fresh installs and systems with wiped trust-state). (b) Monotonic `seen-epoch` counter persisted to `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch`: tracks the highest epoch this installation has observed post-install, and rejects any manifest below that (protects ongoing operators from rollback after install). The two layers compose: `reject if manifest.epoch < max(MIN_REQUIRED_EPOCH, seen-epoch)`. See §3.5 |
 
 ---
 
@@ -158,18 +159,32 @@ A traditional CRL would need a pinned URL (new trust problem), a signature over 
 
 The first consensus vote surfaced a real gap rev 1 missed: **revocation circularity**. If the private key leaks, the attacker can sign a malicious `v9.9.9` binary that ships with replayed-old-pubkey logic, or that silently accepts rollback. Air-gapped operators pulling that build can't distinguish it from a legitimate rotation. A CRL doesn't actually fix this (see above), but *something* has to — "just ship a new binary" breaks down the moment the attacker can also ship a new binary.
 
-**Rev 2 addition: monotonic Key Epoch counter (Decision 7).**
+**Rev 2 addition (extended in rev 3): Key Epoch counter with a two-layer floor (Decision 7).**
 
-Every signed manifest (attestation manifest for #349, bundle manifest for #367) carries an integer `key_epoch` field. The canonical keypair has an associated epoch, bumped on every rotation. Binaries persist the highest-observed epoch to `~/.local/share/aegis-boot/trust/seen-epoch` (or the equivalent under `$XDG_STATE_HOME`). On verify, the binary:
+Every signed manifest (attestation manifest for #349, bundle manifest for #367) carries an integer `key_epoch` field. The canonical keypair has an associated epoch, bumped on every rotation. Rev 3 defines *two* rollback defenses that compose:
 
-1. Verifies the minisign signature against the embedded pubkey. FAIL → reject.
+**Layer 1 — binary-embedded floor (`MIN_REQUIRED_EPOCH`).** Every release hardcodes the epoch active at compile time. At binary build, `build.rs` reads `keys/canonical-epoch.json` and emits:
+
+```rust
+// crates/aegis-cli/src/trust_anchor.rs
+pub const MIN_REQUIRED_EPOCH: u32 = env!("AEGIS_MIN_REQUIRED_EPOCH").parse().unwrap();
+```
+
+Any manifest whose `key_epoch < MIN_REQUIRED_EPOCH` is rejected unconditionally. This closes the TOFU window on fresh installs and on systems whose `seen-epoch` state file has been lost/wiped — the binary itself refuses to accept epochs older than the state of the world when that binary was released.
+
+**Layer 2 — monotonic `seen-epoch`.** Binaries persist the highest observed epoch to `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch`. This layer protects running installations from downgrade *after* install, in case the project rotates the key again post-install and the operator hasn't yet upgraded.
+
+**Composed rule:** `reject if manifest.epoch < max(MIN_REQUIRED_EPOCH, seen-epoch)`. Either layer catches an attacker-replayed old signature; together they close both the pre-install and post-install windows.
+
+**Verification flow.** On verify, the binary:
+1. Verifies the minisign signature against the appropriate historical anchor (§3.6). FAIL → reject.
 2. Reads the manifest's `key_epoch`.
-3. Compares against the locally stored seen-epoch. If manifest epoch is LOWER → reject with `KeyEpochRollback` error.
-4. If manifest epoch is HIGHER → write the new value to seen-epoch (trust-on-first-use for the forward direction).
+3. Computes `floor = max(MIN_REQUIRED_EPOCH, seen-epoch)`. If `manifest.epoch < floor` → reject with `KeyEpochRollback`.
+4. If `manifest.epoch > seen-epoch` → write the new value to `seen-epoch` (trust-on-first-use for the forward direction only; the floor is never mutable downward).
 
-This turns a key compromise into a recoverable event: the maintainer rotates the key, bumps the epoch, ships the new binary. Operators who have *ever* seen the post-rotation epoch are immune to a replay of the old key on a pre-rotation manifest. Old manifests (legitimately signed before rotation) still verify because their epoch equals the seen-epoch at the time they were made — the check is "not LOWER than highest seen," not "equal to current."
+A key compromise becomes a recoverable event: maintainer rotates, bumps epoch, ships a new binary whose `MIN_REQUIRED_EPOCH` equals the new epoch. Fresh installs from that release onward are immune to replayed old-key signatures out of the box. Existing installations get the same immunity as soon as their `seen-epoch` advances past the rotation (either from receiving a new-epoch manifest or from `aegis-boot doctor` surfacing the mismatch and prompting update).
 
-The epoch store is a small integer file; losing it only costs the rollback-protection (the signature still verifies), so it's non-catastrophic. `aegis-boot doctor` reports the current seen-epoch and the repo's published canonical epoch (fetched from a static JSON manifest if online) so the operator can notice "your seen-epoch is N-2, the project's current epoch is N."
+The `seen-epoch` file losing its value only costs Layer 2's ongoing-protection; Layer 1's embedded floor still fires. `aegis-boot doctor` reports both the local `seen-epoch` and the binary's `MIN_REQUIRED_EPOCH`, and if online, compares both against `https://github.com/aegis-boot/aegis-boot/raw/main/keys/canonical-epoch.json` so the operator can notice staleness in any layer.
 
 **Objection 1 (preserved from rev 1): "Without revocation, a compromised key signs forever."** Still true in the absolute sense — nothing invalidates old signatures cryptographically. But the Epoch counter prevents *useful* forgery: an attacker with the pre-rotation key can sign 2019 attestations or replay old bundles, but cannot forge a current-state artifact that any updated operator will accept. The threat we actually need to stop ("attacker signs new-looking artifacts to fool current operators") is addressed.
 
@@ -221,7 +236,7 @@ Historical-anchor entries are append-only. Rotations ADD to the list; the active
 
 - **Single trust anchor *list*** (rev 2). One format, one verification path, one active signing key. Historical keys are retained in-binary for year-N forensics (§3.6).
 - **Offline-verifiable.** Minisign detached signatures verify against static pubkeys with no network dependency. Field responders, air-gapped labs, and FOIA archivists can verify attestations in 2040 as long as they have *any* binary shipped after the manifest was signed.
-- **Rollback-resistant** (rev 2). The Key Epoch counter (§3.5) prevents a post-compromise attacker from replaying an old-key signature on a new-looking manifest. Operators who have observed the post-rotation epoch refuse lower epochs outright.
+- **Rollback-resistant on fresh AND ongoing installs** (rev 3). The Key Epoch counter (§3.5) defends via two layers: Layer 1 is a binary-embedded `MIN_REQUIRED_EPOCH` floor set at release-compile time, immune to local-state wipes; Layer 2 is the monotonic `seen-epoch` file for ongoing rollback protection after install. Rev 2 had only Layer 2, which left a TOFU window on fresh installs. Rev 3 closes it.
 - **Recovery-path exercised** (rev 2). Quarterly rotation rehearsals (§5.1) keep the runbook tested without burdening operators with actual rotations.
 - **Zero new dependencies.** `minisign-verify` is already in the build. `minisign` CLI is already on the maintainer's laptop for ISO signing.
 - **Consistent with existing pattern.** Reuses `.minisig` sidecar convention from `iso-probe/src/minisign.rs`. `aegis-boot flash` writes `<manifest>.minisig` next to `<manifest>.json`; `aegis-boot attest show` verifies inline.
@@ -253,7 +268,7 @@ Historical-anchor entries are append-only. Rotations ADD to the list; the active
 ## 5. Implementation Plan (summary — full tickets to file after approval)
 
 1. **Key generation (maintainer, one-time).** Generate keypair; commit `keys/aegis-boot-trust-anchor-ep1.pub`; store `~/.secrets/aegis-boot/trust-anchor.key` under GPG-encrypted backup. Record fingerprint + epoch=1 in `SECURITY.md`. Write initial `keys/canonical-epoch.json` (`{"epoch": 1}`) alongside the pubkey.
-2. **`trust_anchor.rs` module.** New file at `crates/aegis-cli/src/trust_anchor.rs`. Exports `AEGIS_BOOT_TRUST_ANCHORS: &[TrustAnchor]` (historical-anchors list, HEAD active) + `pub fn verify_manifest(bytes, sig) -> Result<VerifiedManifest, VerifyError>` (walks the list, enforces epoch monotonicity against on-disk `seen-epoch`).
+2. **`trust_anchor.rs` module + `build.rs` hookup.** New file at `crates/aegis-cli/src/trust_anchor.rs`. Exports `AEGIS_BOOT_TRUST_ANCHORS: &[TrustAnchor]` (historical-anchors list, HEAD active) + `MIN_REQUIRED_EPOCH: u32` (rev 3, sourced from `keys/canonical-epoch.json` via `build.rs` at build time) + `pub fn verify_manifest(bytes, sig) -> Result<VerifiedManifest, VerifyError>` (walks the list, enforces epoch floor via `max(MIN_REQUIRED_EPOCH, seen-epoch)` against on-disk `seen-epoch`). A unit test asserts the rollback path rejects correctly in both fresh-install (no seen-epoch) and ongoing (seen-epoch set) configurations.
 3. **Wire-format extension.** Add `key_epoch: u32` field to `aegis_wire_formats::Attestation` and the new `aegis_wire_formats::BundleManifest`. Bump `SCHEMA_VERSION` to 2 on each. Back-compat: binaries reading a `schema_version=1` manifest treat `key_epoch=0` as "pre-epoch manifest, accept if signature verifies under epoch=1 anchor."
 4. **#349 implementation.** `record_flash()` + `record_iso_added()` in `attest.rs` write `<manifest>.json.minisig` alongside the JSON, embedding the current `key_epoch` in the manifest body. Signing uses the private key at a path given by `AEGIS_BOOT_SIGNING_KEY` env var; in release builds this is expected to be unset and signing is a no-op with a warning (the maintainer signs release manifests; operator-written manifests are unsigned by default — see alternative §6.3).
 5. **#367 Phase D implementation.** Bundle mirror publishes `bundle-manifest.json` (with `key_epoch`) + `bundle-manifest.json.minisig`. `fetch-image --direct-install` on macOS/Windows downloads both, calls `trust_anchor::verify_manifest()`, then downloads the individual bundle files and verifies their SHA-256s match the manifest. Failure at any step aborts flash.
@@ -274,7 +289,8 @@ The first consensus vote surfaced **rotation atrophy** as a failure mode: untest
 3. Replace `keys/aegis-boot-trust-anchor-ep-current.pub` with the temp pubkey (HEAD of list); bump epoch.
 4. Run the full CI suite locally (`./scripts/dev-test.sh`) + the attestation/bundle sign+verify integration tests.
 5. Tag a test release (`v0.X.Y-rehearsal-YYYYQN`) — verify `release.yml` bakes the new pubkey, cosign signs the binary, and a test operator install can verify a new attestation.
-6. Revert the branch (`git reset --hard main`); delete temp keys; log the rehearsal with any drift observed.
+6. **Signing-handoff audit (rev 3).** Before each signing operation during the rehearsal, the maintainer verifies: (a) the sha256 of the artifact being fed to `minisign -Sm` matches the sha256 produced by an independent `cargo build --release` run on the same commit (i.e., the thing being signed is the thing that was built); (b) the signing command prompts for the private-key passphrase interactively (never sourced from a file or env var that could leak); (c) if a hardware token is in use, the token's touch-to-sign is actually required (no cached authorization). Each rehearsal log entry records the audit outcome. This step substitutes for the rev-1 two-key-separation proposal under §6.2's addendum: the rehearsal's audit verifies the signing surface's integrity quarterly, which is what the two-key split would have protected against via compartmentalization.
+7. Revert the branch (`git reset --hard main`); delete temp keys; log the rehearsal with any drift observed in `docs/architecture/rotation-rehearsal-log.md`.
 
 **Why quarterly, not monthly, not yearly.** Monthly rehearsal is too frequent to sustain for a solo maintainer and dilutes the "this is a real exercise" signal. Yearly is too infrequent to catch runbook rot — a new release channel added in January is untested until next January. Quarterly splits the difference and aligns with typical security-cycle cadences.
 

--- a/docs/architecture/KEY_MANAGEMENT.md
+++ b/docs/architecture/KEY_MANAGEMENT.md
@@ -1,16 +1,17 @@
 # ADR 0002: Key Management for Signed Attestation + Bundle Trust Anchor
 
-**Status:** PROPOSED (revision 3)
+**Status:** ACCEPTED (revision 3)
 **Date:** 2026-04-21
 **Tracking issue:** [#366](https://github.com/williamzujkowski/aegis-boot/issues/366)
 **Revision history:**
 - 2026-04-20 — initial proposal (rev 1)
 - 2026-04-21 — rev 2 adds Decision 7 (Key Epoch), §3.6 (historical anchors), and §5.1 (rotation rehearsal) after consensus vote surfaced revocation-circularity, temporal-deadlock, and rotation-atrophy objections (vote result: 60% approve, below supermajority threshold)
 - 2026-04-21 — rev 3 closes rev-2's residual TOFU window on fresh installs by adding `MIN_REQUIRED_EPOCH` binary-embedded floor to Decision 7; extends §5.1 rehearsal with a signing-handoff audit step to waive the signing-oracle split trigger (§6.2)
+- 2026-04-21 — **ACCEPTED** on rev 3 via higher-order consensus vote (architect ✓88%, security ✓90%, devex ✓87%, ai_ml ✓90%, pm ✓88%, contrarian ✗95% → 83.3% approve, supermajority cleared). Unblocks #349 (Phase 3b attestation signing) and #367 (Phase D bundle trust anchor). Vote verification hashes preserved in PR #385.
 **Consumers:** [#349](https://github.com/williamzujkowski/aegis-boot/issues/349) (signed attestation manifest), [#367](https://github.com/williamzujkowski/aegis-boot/issues/367) (cross-platform `--direct-install` trust anchor, Phase D of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365))
 **Supersedes:** portion of `crates/aegis-cli/src/attest.rs` header comment (lines 22–28) that defers signing to "epic #139"; this ADR claims the design.
 
-> **Reviewer note.** This ADR is PROPOSED pending consensus. Objections and alternative votes belong on #366, not scattered in PR review comments — consolidate discussion there so the decision log stays single-threaded. The `Alternatives considered` section below names the three strongest contrarian paths explicitly; please answer them before proposing a fourth.
+> **Status note.** This ADR is ACCEPTED as of rev 3 (2026-04-21, higher-order supermajority vote on #366). Future substantive changes should be tracked as a follow-up ADR that supersedes this one rather than in-place revision — the decision log stays linear. The `Alternatives considered` section names the three strongest contrarian paths; revisit triggers in §7 name the conditions under which each becomes worth re-opening.
 
 ---
 

--- a/docs/architecture/KEY_MANAGEMENT.md
+++ b/docs/architecture/KEY_MANAGEMENT.md
@@ -1,8 +1,11 @@
 # ADR 0002: Key Management for Signed Attestation + Bundle Trust Anchor
 
-**Status:** PROPOSED
-**Date:** 2026-04-20
+**Status:** PROPOSED (revision 2)
+**Date:** 2026-04-21
 **Tracking issue:** [#366](https://github.com/williamzujkowski/aegis-boot/issues/366)
+**Revision history:**
+- 2026-04-20 — initial proposal (rev 1)
+- 2026-04-21 — rev 2 adds Decision 7 (Key Epoch), §3.6 (historical anchors), and §5.1 (rotation rehearsal) after consensus vote surfaced revocation-circularity, temporal-deadlock, and rotation-atrophy objections (vote result: 60% approve, below supermajority threshold)
 **Consumers:** [#349](https://github.com/williamzujkowski/aegis-boot/issues/349) (signed attestation manifest), [#367](https://github.com/williamzujkowski/aegis-boot/issues/367) (cross-platform `--direct-install` trust anchor, Phase D of [#365](https://github.com/williamzujkowski/aegis-boot/issues/365))
 **Supersedes:** portion of `crates/aegis-cli/src/attest.rs` header comment (lines 22–28) that defers signing to "epic #139"; this ADR claims the design.
 
@@ -63,6 +66,12 @@ Plus one implicit decision for clarity:
 | # | Question | Decision |
 |---|----------|----------|
 | 6 | Cosign's role after this ADR | **Unchanged.** Cosign keyless continues to sign release artifacts in `release.yml`. It is not the operator-facing trust anchor for attestation manifests or bundle manifests. Operators verify the binary itself via cosign; the binary's embedded minisign pubkey then anchors everything the binary produces or consumes |
+
+And one added in rev 2 to close the revocation-circularity gap surfaced by the first consensus vote:
+
+| # | Question | Decision |
+|---|----------|----------|
+| 7 | Post-compromise replay defense | **Monotonic Key Epoch counter** embedded in every signed manifest (attestation + bundle). Binaries refuse to accept any manifest whose epoch is lower than the highest epoch they have previously observed (persisted to `~/.local/share/aegis-boot/trust/seen-epoch`). A post-compromise attacker who signs `v9.9.9` with epoch N-1 cannot convince operators who have already seen epoch N that the rollback is legitimate. See §3.5 |
 
 ---
 
@@ -143,23 +152,66 @@ The correct rotation trigger is **evidence of compromise**: maintainer laptop st
 
 **Objection 3: "A never-rotated key advertises 'stable target' to attackers."** The key is a 32-byte seed on a laptop that runs `cargo fmt` all day. It's not an internet-facing surface. The attack isn't "crack the key"; it's "exfiltrate it." Rotation on a schedule doesn't help with exfiltration — detection + rotation on discovery does.
 
-### 3.5 Why no revocation
+### 3.5 Why no CRL — and why a Key Epoch counter instead (rev 2)
 
-A compromised key needs a new binary with a new pubkey. That binary ships via the existing release channel; operators update via `curl | sh` or `brew upgrade aegis-boot` or `winget upgrade`. There is no operator population running arbitrary-old binaries that can't update — if they can't update, they can't verify anyway (cosign requires live Sigstore endpoints for cert chain validation, which they'd also fail).
+A traditional CRL would need a pinned URL (new trust problem), a signature over the CRL (new key-custody problem), operator-side fetch logic (new code, new failure mode), and a "what if the CRL URL is down?" offline-verify answer. All of this to solve a problem — "operator runs old binary whose key was revoked" — that the existing update mechanism (`curl | sh`, `brew upgrade`, `winget upgrade`) already solves. Rev 1 stopped there.
 
-A CRL would need:
-- A pinned URL for CRL fetch (new trust problem)
-- A signature over the CRL (new key-custody problem)
-- Operator-side fetch logic (new code, new failure mode)
-- "What if the CRL URL is down?" (new offline-verify problem)
+The first consensus vote surfaced a real gap rev 1 missed: **revocation circularity**. If the private key leaks, the attacker can sign a malicious `v9.9.9` binary that ships with replayed-old-pubkey logic, or that silently accepts rollback. Air-gapped operators pulling that build can't distinguish it from a legitimate rotation. A CRL doesn't actually fix this (see above), but *something* has to — "just ship a new binary" breaks down the moment the attacker can also ship a new binary.
 
-All of this to solve a problem — "operator runs old binary whose key was revoked" — that the existing update mechanism already solves. It's a large implementation cost for a small threat mitigation that's already mostly covered.
+**Rev 2 addition: monotonic Key Epoch counter (Decision 7).**
 
-**Objection 1: "Without revocation, a compromised key signs forever."** A compromised key signs until the maintainer observes the compromise and ships a new release. That window equals the window before the maintainer notices in any revocation scheme (CRLs don't magically detect compromise; they let you publish detection). The difference isn't detection; it's distribution — and our distribution (binary release) already has an update channel.
+Every signed manifest (attestation manifest for #349, bundle manifest for #367) carries an integer `key_epoch` field. The canonical keypair has an associated epoch, bumped on every rotation. Binaries persist the highest-observed epoch to `~/.local/share/aegis-boot/trust/seen-epoch` (or the equivalent under `$XDG_STATE_HOME`). On verify, the binary:
 
-**Objection 2: "Air-gapped operators might never pull the new binary."** Correct. They also can't pull the CRL. Revocation doesn't help air-gapped operators; detection-and-rekey via the next manual update is the same end-state.
+1. Verifies the minisign signature against the embedded pubkey. FAIL → reject.
+2. Reads the manifest's `key_epoch`.
+3. Compares against the locally stored seen-epoch. If manifest epoch is LOWER → reject with `KeyEpochRollback` error.
+4. If manifest epoch is HIGHER → write the new value to seen-epoch (trust-on-first-use for the forward direction).
 
-**Objection 3: "`aegis-boot doctor` could warn on stale trust anchor."** A good follow-up enhancement, not a reason to ship a CRL. Doctor can compare the embedded pubkey against the latest release's pubkey via GitHub API (or a pinned manifest URL) and warn "your trust anchor is older than the current release; consider updating." That's a UX nudge, not a crypto primitive.
+This turns a key compromise into a recoverable event: the maintainer rotates the key, bumps the epoch, ships the new binary. Operators who have *ever* seen the post-rotation epoch are immune to a replay of the old key on a pre-rotation manifest. Old manifests (legitimately signed before rotation) still verify because their epoch equals the seen-epoch at the time they were made — the check is "not LOWER than highest seen," not "equal to current."
+
+The epoch store is a small integer file; losing it only costs the rollback-protection (the signature still verifies), so it's non-catastrophic. `aegis-boot doctor` reports the current seen-epoch and the repo's published canonical epoch (fetched from a static JSON manifest if online) so the operator can notice "your seen-epoch is N-2, the project's current epoch is N."
+
+**Objection 1 (preserved from rev 1): "Without revocation, a compromised key signs forever."** Still true in the absolute sense — nothing invalidates old signatures cryptographically. But the Epoch counter prevents *useful* forgery: an attacker with the pre-rotation key can sign 2019 attestations or replay old bundles, but cannot forge a current-state artifact that any updated operator will accept. The threat we actually need to stop ("attacker signs new-looking artifacts to fool current operators") is addressed.
+
+**Objection 2 (preserved): "Air-gapped operators might never pull the new binary."** They also never observe the epoch bump. Correct, and unchanged by rev 2 — air-gapped operators live at whatever epoch their binary last saw. Document as a known-not-fixed class.
+
+**Objection 3 (preserved): "`aegis-boot doctor` could warn on stale trust anchor."** Preserved as a follow-up UX nudge. Rev 2 adds concrete substance to it: doctor compares `seen-epoch` against a published-canonical-epoch manifest at `https://github.com/aegis-boot/aegis-boot/raw/main/keys/canonical-epoch.json`, fetched over HTTPS (signed by the same trust anchor — recursive but self-consistent).
+
+### 3.6 Why historical-anchors list instead of single-pubkey bake-in (rev 2)
+
+The first consensus vote surfaced a second gap: **temporal deadlock**. A field responder in 2028 using a post-rotation 2028 binary cannot verify a 2026 manifest signed with the pre-rotation 2026 key. Rev 1's "the binary IS the trust anchor" model collapses under its own rotation story — every rotation creates a verification epoch, and the ADR's forensics use-case ("verify 10 years later") stops working.
+
+**Rev 2 addition: the trust anchor is a LIST, not a single pubkey.**
+
+`crates/aegis-cli/src/trust_anchor.rs` exposes:
+
+```rust
+/// All trust anchors this binary recognizes, newest first.
+/// The HEAD of the list is the active key (used for new signatures + epoch checks).
+/// The TAIL is historical keys, kept around for verifying pre-rotation artifacts.
+pub const AEGIS_BOOT_TRUST_ANCHORS: &[TrustAnchor] = &[
+    TrustAnchor {
+        epoch: 2,
+        pubkey: include_bytes!("../../../keys/aegis-boot-trust-anchor-ep2.pub"),
+        valid_from: "2027-03-15",
+        reason: "scheduled rotation per §5.1 rehearsal cadence",
+    },
+    TrustAnchor {
+        epoch: 1,
+        pubkey: include_bytes!("../../../keys/aegis-boot-trust-anchor-ep1.pub"),
+        valid_from: "2026-04-21",
+        reason: "initial keypair",
+    },
+];
+```
+
+On verify, the binary walks the list and accepts the first pubkey for which the signature validates. The Epoch counter (§3.5) prevents rollback of an attacker-controlled old key from tricking operators — a pre-rotation manifest is accepted ONLY if its declared epoch equals the epoch of the pubkey that verified it, AND that epoch is not lower than `seen-epoch` for manifests claiming to be current.
+
+Historical-anchor entries are append-only. Rotations ADD to the list; the active key moves to HEAD. Old operators with an older binary can only verify up to the newest anchor their binary carries, which is the expected behavior (they need to upgrade to verify anything newer than their binary's release). New operators with a new binary can verify everything back to epoch 1. Field-forensics at year-10 works as long as someone kept a binary shipped after the manifest was written.
+
+**Trade-off surfaced:** the binary grows by ~48 bytes per retained historical anchor (Ed25519 pubkey + epoch + metadata). At any reasonable rotation cadence (once a year, catastrophically; zero-to-five times expected lifetime) this is negligible. We do not cap the list.
+
+**Post-compromise purge:** if a key is known-compromised, the ADR explicitly decides it STAYS in the historical list. Removing it would break verification of legitimate pre-compromise artifacts; the Epoch-counter prevents the compromised key from being used to sign NEW-looking current-state artifacts. An optional `--trust-legacy-key <epoch>` flag (follow-up) can let an operator require manual opt-in per-historical-key if they want a stricter posture.
 
 ---
 
@@ -167,24 +219,21 @@ All of this to solve a problem — "operator runs old binary whose key was revok
 
 ### 4.1 Positive
 
-- **Single trust anchor.** One pubkey, one format, one env var (`AEGIS_TRUSTED_KEYS` for third-party ISO pubkeys; the project pubkey is embedded and always trusted for project-produced artifacts).
-- **Offline-verifiable.** Minisign detached signatures verify against a static pubkey with no network dependency. Field responders, air-gapped labs, and FOIA archivists can verify attestations in 2040.
+- **Single trust anchor *list*** (rev 2). One format, one verification path, one active signing key. Historical keys are retained in-binary for year-N forensics (§3.6).
+- **Offline-verifiable.** Minisign detached signatures verify against static pubkeys with no network dependency. Field responders, air-gapped labs, and FOIA archivists can verify attestations in 2040 as long as they have *any* binary shipped after the manifest was signed.
+- **Rollback-resistant** (rev 2). The Key Epoch counter (§3.5) prevents a post-compromise attacker from replaying an old-key signature on a new-looking manifest. Operators who have observed the post-rotation epoch refuse lower epochs outright.
+- **Recovery-path exercised** (rev 2). Quarterly rotation rehearsals (§5.1) keep the runbook tested without burdening operators with actual rotations.
 - **Zero new dependencies.** `minisign-verify` is already in the build. `minisign` CLI is already on the maintainer's laptop for ISO signing.
 - **Consistent with existing pattern.** Reuses `.minisig` sidecar convention from `iso-probe/src/minisign.rs`. `aegis-boot flash` writes `<manifest>.minisig` next to `<manifest>.json`; `aegis-boot attest show` verifies inline.
 - **Clean separation of concerns.** Cosign answers "did this binary come from our CI?" Minisign answers "did this runtime artifact come from a legitimate binary?" Each format serves its use case.
 
 ### 4.2 Negative + mitigations
 
-- **Concrete operational burden: rotation-on-compromise is multi-step.** If the private key leaks:
-  1. Maintainer generates a new keypair (`minisign -G -p keys/aegis-boot-trust-anchor.pub -s ~/.secrets/aegis-boot/trust-anchor.key`).
-  2. Maintainer commits the new `.pub` to the repo.
-  3. Maintainer tags a new release; `release.yml` rebuilds the binary with the new embedded pubkey and cosign-signs it.
-  4. Operators run `curl -sSf https://… | sh` (or `brew upgrade` / `winget upgrade`) to pull the new binary.
-  5. Any attestation or bundle manifest signed with the old key is now "signed by an untrusted key" to operators on the new binary. Old manifests need to be re-signed by the maintainer with the new key OR marked as historical and accepted under an explicit `--trust-legacy-key <fingerprint>` flag (follow-up feature).
+- **Rotation-on-compromise is still multi-step, but now well-exercised** (rev 2). The rotation path runs quarterly (§5.1) in rehearsal mode, so the first real compromise is the maintainer's Nth execution of a familiar checklist, not their first. Production rotation steps: generate new keypair; append new pubkey to `keys/` with bumped epoch; update `trust_anchor.rs` and `canonical-epoch.json`; tag release; cosign-sign; operators upgrade. The rotation window is hours from detection to tag + days-to-weeks for operator adoption — acceptable for the threat model, not a no-downtime rotation. Documented in `SECURITY.md`.
 
-  The rotation window is "hours from detection to tag" + "days-to-weeks for operator adoption." Acceptable for the threat model, but NOT a no-downtime rotation. Document prominently in `SECURITY.md`.
+- **Old manifests remain verifiable across rotations** (rev 2 improvement). Old attestations keep verifying under their original epoch's anchor in the historical-anchors list; the Epoch counter prevents that old anchor from being used to forge new-looking artifacts. The rev 1 mitigation ("re-sign or use `--trust-legacy-key`") is no longer required for normal operation — it becomes a stricter opt-in for operators who want every historical anchor to require manual trust.
 
-- **No cryptographic expiry forces operator vigilance.** An operator verifying a 10-year-old attestation has no cryptographic signal that the key has since been rotated. Mitigation: the `aegis-boot attest show` output includes the tool version that wrote it; an operator concerned about historical validity can cross-reference the `SECURITY.md` "key rotation log" (added in this ADR's follow-up work) to see if the signing version's key is still current.
+- **Two orthogonal failure modes, both mitigated.** (a) A post-compromise attacker who replays an old key: blocked by Epoch counter. (b) A field responder verifying a 10-year-old attestation: works automatically if they're running any binary released after the attestation, because that binary carries the epoch-N anchor. The rev 1 "no cryptographic expiry forces operator vigilance" framing was a bug, not a feature; rev 2 treats historical verification as a first-class requirement.
 
 - **Committing the `.pub` file to `keys/` pins reviewer attention on rotations.** Every rotation is a visible diff in the repo. Positive for transparency, but requires discipline on the maintainer to explain the rotation in the commit message (template: "security: rotate aegis-boot trust anchor — reason: <compromise trigger>").
 
@@ -192,21 +241,46 @@ All of this to solve a problem — "operator runs old binary whose key was revok
 
 ### 4.3 Neutral consequences
 
-- **Adds a `keys/` directory at repo root.** New convention. Populated at first release after this ADR lands. `.gitignore` must explicitly *not* ignore `keys/*.pub` (the file is public by definition).
-- **Adds a `crates/aegis-cli/src/trust_anchor.rs` module.** ~20 lines: the `include_bytes!` const, a `parse_trust_anchor()` wrapper returning `minisign_verify::PublicKey`, a unit test asserting the bytes parse.
-- **`SECURITY.md` gets a new section: "Key rotation log."** Initial entry: "2026-04-XX: initial keypair generated, fingerprint `RWR…`." Future rotations append.
+- **Adds a `keys/` directory at repo root.** New convention. Populated at first release after this ADR lands. `.gitignore` must explicitly *not* ignore `keys/*.pub` (the file is public by definition). Contains one `.pub` per epoch, plus `canonical-epoch.json`.
+- **Adds a `crates/aegis-cli/src/trust_anchor.rs` module.** ~60 lines (rev 2, was ~20 in rev 1): the historical-anchors list, epoch-counter logic, `verify_manifest()` wrapper, `seen-epoch` read/write, unit tests for rollback refusal + historical-anchor walking.
+- **Adds a small state file under `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch`** (rev 2). Contents: single integer. Losing it resets to epoch=0 (trust-on-first-use of whatever epoch is next observed); no catastrophic failure mode.
+- **`SECURITY.md` gets three new sections**: "Key rotation log" (append-only, epoch-indexed), "Compromise response runbook", and "Rotation rehearsal checklist" (rev 2).
+- **Adds `docs/architecture/rotation-rehearsal-log.md`** (rev 2) — dated log of quarterly rehearsal outcomes.
 - **Moving the repo to `github.com/aegis-boot/aegis-boot`** (per #365) does NOT require a key rotation. The minisign pubkey is orthogonal to the GitHub owner slug. Cosign keyless identities DO need to be updated in `release.yml` and in `fetch_image.rs`'s hardcoded identity regex (`fetch_image.rs:260`) — that's the repo-move work, tracked separately.
 
 ---
 
 ## 5. Implementation Plan (summary — full tickets to file after approval)
 
-1. **Key generation (maintainer, one-time).** Generate keypair; commit `keys/aegis-boot-trust-anchor.pub`; store `~/.secrets/aegis-boot/trust-anchor.key` under GPG-encrypted backup. Record fingerprint in `SECURITY.md`.
-2. **`trust_anchor.rs` module.** New file at `crates/aegis-cli/src/trust_anchor.rs`. Exports `AEGIS_BOOT_TRUST_ANCHOR: &[u8]` + `pub fn project_pubkey() -> Result<PublicKey, String>`.
-3. **#349 implementation.** `record_flash()` + `record_iso_added()` in `attest.rs` write `<manifest>.json.minisig` alongside the JSON. Signing uses the private key at a path given by `AEGIS_BOOT_SIGNING_KEY` env var; in release builds this is expected to be unset and signing is a no-op with a warning (the maintainer signs release manifests; operator-written manifests are unsigned by default — see alternative §6.3).
-4. **#367 Phase D implementation.** Bundle mirror publishes `bundle-manifest.json` + `bundle-manifest.json.minisig`. `fetch-image --direct-install` on macOS/Windows downloads both, verifies the `.minisig` against `trust_anchor::project_pubkey()`, then downloads the individual bundle files and verifies their SHA-256s match the manifest. Failure at any step aborts flash.
-5. **`aegis-boot attest show` verifies.** When a `.minisig` sidecar is present, verify inline and surface "signature: verified ✓ (project key)" in the output.
-6. **`SECURITY.md` section.** "Key rotation log" + "Compromise response runbook."
+1. **Key generation (maintainer, one-time).** Generate keypair; commit `keys/aegis-boot-trust-anchor-ep1.pub`; store `~/.secrets/aegis-boot/trust-anchor.key` under GPG-encrypted backup. Record fingerprint + epoch=1 in `SECURITY.md`. Write initial `keys/canonical-epoch.json` (`{"epoch": 1}`) alongside the pubkey.
+2. **`trust_anchor.rs` module.** New file at `crates/aegis-cli/src/trust_anchor.rs`. Exports `AEGIS_BOOT_TRUST_ANCHORS: &[TrustAnchor]` (historical-anchors list, HEAD active) + `pub fn verify_manifest(bytes, sig) -> Result<VerifiedManifest, VerifyError>` (walks the list, enforces epoch monotonicity against on-disk `seen-epoch`).
+3. **Wire-format extension.** Add `key_epoch: u32` field to `aegis_wire_formats::Attestation` and the new `aegis_wire_formats::BundleManifest`. Bump `SCHEMA_VERSION` to 2 on each. Back-compat: binaries reading a `schema_version=1` manifest treat `key_epoch=0` as "pre-epoch manifest, accept if signature verifies under epoch=1 anchor."
+4. **#349 implementation.** `record_flash()` + `record_iso_added()` in `attest.rs` write `<manifest>.json.minisig` alongside the JSON, embedding the current `key_epoch` in the manifest body. Signing uses the private key at a path given by `AEGIS_BOOT_SIGNING_KEY` env var; in release builds this is expected to be unset and signing is a no-op with a warning (the maintainer signs release manifests; operator-written manifests are unsigned by default — see alternative §6.3).
+5. **#367 Phase D implementation.** Bundle mirror publishes `bundle-manifest.json` (with `key_epoch`) + `bundle-manifest.json.minisig`. `fetch-image --direct-install` on macOS/Windows downloads both, calls `trust_anchor::verify_manifest()`, then downloads the individual bundle files and verifies their SHA-256s match the manifest. Failure at any step aborts flash.
+6. **`aegis-boot attest show` verifies.** When a `.minisig` sidecar is present, verify inline and surface "signature: verified ✓ (project key epoch N)" in the output; surface `KeyEpochRollback` as a red error with the mismatched epochs.
+7. **`aegis-boot doctor` trust-anchor row.** New check: "Trust anchor: current epoch N (verified against GitHub-hosted canonical-epoch.json)." Warns on `seen-epoch < canonical-epoch`.
+8. **`SECURITY.md` additions.** "Key rotation log" (epoch, date, fingerprint, reason — append-only); "Compromise response runbook"; "Rotation rehearsal checklist" (see §5.1).
+
+### 5.1 Rotation rehearsal cadence (rev 2)
+
+The first consensus vote surfaced **rotation atrophy** as a failure mode: untested production-critical code paths rot, and the first real compromise is a stressful, mistake-prone first-execution. Rev 1 said "rotate on compromise only"; rev 2 keeps that *production* policy but adds a **non-production rehearsal cadence** so the rotation machinery stays exercised.
+
+**Policy:** every calendar quarter, the maintainer executes the rotation runbook on a throwaway branch. The rehearsal produces a tagged test build, verifies end-to-end cosign+minisign against a temporary keypair, and is then discarded — no commits to `keys/`, no epoch bump, no release. The rehearsal's output is a dated entry in `docs/architecture/rotation-rehearsal-log.md` with: date, branch, any steps that failed or surfaced friction, PR link to any runbook improvements that shipped.
+
+**Rehearsal checklist** (lives in `SECURITY.md` as prose, summarized here):
+
+1. Branch `chore/rotation-rehearsal-YYYYQN` from main.
+2. Generate a temp keypair: `minisign -G -p /tmp/rehearsal.pub -s /tmp/rehearsal.sec`.
+3. Replace `keys/aegis-boot-trust-anchor-ep-current.pub` with the temp pubkey (HEAD of list); bump epoch.
+4. Run the full CI suite locally (`./scripts/dev-test.sh`) + the attestation/bundle sign+verify integration tests.
+5. Tag a test release (`v0.X.Y-rehearsal-YYYYQN`) — verify `release.yml` bakes the new pubkey, cosign signs the binary, and a test operator install can verify a new attestation.
+6. Revert the branch (`git reset --hard main`); delete temp keys; log the rehearsal with any drift observed.
+
+**Why quarterly, not monthly, not yearly.** Monthly rehearsal is too frequent to sustain for a solo maintainer and dilutes the "this is a real exercise" signal. Yearly is too infrequent to catch runbook rot — a new release channel added in January is untested until next January. Quarterly splits the difference and aligns with typical security-cycle cadences.
+
+**This is a rehearsal, not a real rotation.** The production epoch does not bump; the committed keys do not change; operators see nothing. The only artifact is the log entry and any incidental runbook/tooling improvements the rehearsal surfaces.
+
+**If a rehearsal quarter is missed.** Log the gap; do not silently skip. A missed rehearsal means the runbook is that much closer to rot, which is information worth preserving.
 
 ---
 
@@ -223,16 +297,18 @@ All of this to solve a problem — "operator runs old binary whose key was revok
 
 Preserved as the signing tool for *release* artifacts (unchanged); explicitly out of scope for *runtime-emitted* or *bundle-mirror* signatures.
 
-### 6.2 Two keys — one for attestation, one for bundle (rejected)
+### 6.2 Two keys — one for attestation, one for bundle (rejected, with caveat added in rev 2)
 
-**Proposal:** Separate keypairs for `attestation-signing` and `bundle-mirror-signing`. Compromise of one doesn't compromise the other.
+**Proposal:** Separate keypairs for `attestation-signing` and `bundle-mirror-signing`. Compromise of one doesn't compromise the other. First-vote objection: "key overload violates compartmentalization — a signing-oracle bug in attestation code would compromise bundle trust."
 
 **Rejected because:**
 - Both keys live on the same laptop with the same maintainer. Defense-in-depth with no depth.
-- Doubles the operator's pubkey-tracking burden for zero threat-model gain.
+- Doubles the operator's pubkey-tracking burden for zero threat-model gain in the *current* architecture.
 - One-key → two-key migration is strictly cheaper than two-key → one-key. Pick the reversible default.
 
-Revisit trigger: if attestation signing is ever delegated to a CI job (i.e., one key stays on the maintainer laptop, the other moves to a GitHub Actions secret), split at that point.
+**Rev 2 addendum — answering the signing-oracle angle.** The objection is valid *if* aegis-boot ever grows a code path that signs attacker-controlled input. It does not today: signing is a local filesystem operation invoked exclusively by the maintainer (for the project key) or the operator for their own host's attestations (where the operator already has full host control). There is no network-exposed signing surface. The signing-oracle threat requires the key to sign input that another actor influences — which is exactly the "attestation-signing delegated to a CI job" trigger in §7.
+
+Revisit triggers: (a) signing moves off the maintainer laptop to any service that accepts external input, OR (b) attestation signing is delegated to a CI job. At that point, split into root-signs-subordinates per the two-tier model.
 
 ### 6.3 Operator-side signing key per-host (rejected)
 
@@ -253,9 +329,11 @@ This ADR should be re-opened if any of the following occur:
 
 - **Sigstore adds offline-verifiable keyless signatures** (e.g., long-lived Fulcio certs or Rekor-less verification). Reconsider cosign for everything.
 - **Maintainer team grows beyond one person.** Multi-custodian signing (m-of-n) changes the single-laptop threat model and may justify two-key separation.
-- **Attestation-signing is delegated to a CI job.** Splits the key-custody zones; two keys become the right answer.
+- **Attestation-signing is delegated to a CI job** — for example, a signing service that accepts operator-submitted manifests over a network. That surface exposes the key to remote inputs and resurrects the "signing oracle" threat. At that point, split into a root key (offline, signs subordinate keys) + subordinate signing key (online, rotatable independently) per the two-tier model the first consensus vote advocated.
 - **Apple / Microsoft code-signing requirements** force Authenticode / notarization for the binary itself. Doesn't change the trust anchor for manifests, but adds a parallel signature layer worth documenting.
-- **Cryptographic break of Ed25519 at practical scale.** Not expected. Migration to a PQ signature (ML-DSA) would bump the key format; the ADR's shape (one key, baked-in, rotate-on-compromise) is unchanged.
+- **Cryptographic break of Ed25519 at practical scale.** Not expected. Migration to a PQ signature (ML-DSA) would bump the key format; the ADR's shape (historical-anchors list, epoch counter, rotate-on-compromise) is unchanged.
+- **Rehearsal log shows ≥2 consecutive missed quarters.** Triggers a meta-review: either the cadence is wrong for the project's pace, or the runbook friction is too high and the rehearsal is being skipped for the wrong reason. Either way, the cadence decision (§5.1) is worth revisiting.
+- **Epoch counter false-positives at scale.** If operator reports surface "KeyEpochRollback was rejected but should have been accepted" with non-trivial frequency, the trust-on-first-use-of-forward-epoch model may be too strict; consider a grace window or a per-source epoch store.
 
 ---
 


### PR DESCRIPTION
## Summary

Revision 2 of ADR 0002 Key Management, addressing the three substantive objections raised during the first consensus vote on #366 (which rejected rev 1 at 60% approve, below the supermajority threshold).

## What's added in rev 2

**Decision 7: monotonic Key Epoch counter** — every signed manifest (attestation + bundle) carries an integer epoch. Binaries persist highest-observed epoch to `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch` and refuse any manifest with a lower epoch (`KeyEpochRollback`). Turns key compromise into a recoverable event: a post-compromise attacker can replay old artifacts but cannot forge new-looking ones that current operators will accept.

**§3.6: historical-anchors list** — `AEGIS_BOOT_TRUST_ANCHORS` is a LIST keyed by epoch, not a single pubkey. Old manifests verify forever under their original epoch's pubkey. The Epoch counter (Decision 7) prevents old-key abuse on new-state claims. Fixes the rev 1 "field responder in 2028 can't verify a 2026 manifest" gap.

**§5.1: quarterly rotation rehearsals** — maintainer exercises the rotation runbook on a throwaway branch every calendar quarter. No production rotation, no operator impact; outcomes logged in `rotation-rehearsal-log.md`. Keeps the runbook live so the first real-compromise execution isn't the first execution ever.

Also added: §6.2 addendum acknowledging the signing-oracle angle on the two-keys alternative (revisit trigger made explicit); §7 expanded with two new revision triggers (rehearsal-miss and epoch-counter false-positives).

## What's unchanged from rev 1

- minisign (Ed25519) as the signing tool for runtime-emitted signatures (not cosign — offline-verify requirement)
- ONE active signing key (historical keys retained for verification)
- pubkey baked into binary via `include_bytes!`
- rotate-only-on-compromise (production policy; rehearsal cadence is separate)
- cosign keyless stays for release.yml release-artifact signing

## What's NOT adopted from rev-1 REJECT feedback

- **YubiKey mandate** — cost-prohibitive for solo maintainer on an individual account; documented as recommended-not-required
- **Two-tier root+subordinate keys** — revisit trigger now explicit (§7): only when signing surface accepts attacker-influenced input, which the current architecture doesn't
- **Annual forced production rotation** — quarterly REHEARSAL delivers the "keep the runbook exercised" benefit without the fragmentation cost on operators

## Re-vote

A second consensus vote (6-agent, supermajority threshold) has been run against this revised proposal. Result will be appended to this PR when complete. If the vote passes, this PR also bumps status `PROPOSED (revision 2)` → `ACCEPTED`.

## Test plan

- [x] Markdown renders (no structural breakage)
- [ ] Consensus vote passes supermajority
- [ ] Status → ACCEPTED in follow-up commit
- [ ] Unblocks #349 (Phase 3b attestation signing) and #367 (Phase D bundle trust anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)