### PR TITLE
feat(paths): #375 Phase 1 — AEGIS_STATE_DIR override + state-dir helper

### DIFF
--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -536,20 +536,13 @@ fn read_attestation(path: &Path) -> Result<Attestation, String> {
 }
 
 fn data_dir() -> PathBuf {
-    // When running under sudo, prefer the original user's data dir
-    // rather than root's (/root/.local/share/...). Otherwise `aegis-
-    // boot flash` (run via sudo for dd) would write attestations to
-    // root's home, but `aegis-boot attest list` (run as the operator)
-    // would look under their own home and find nothing — see the
-    // companion `sudo_aware_data_dir` in update.rs::attestation_dir.
-    if let Some(sudo_data) = sudo_aware_data_dir() {
-        return sudo_data.join("aegis-boot");
-    }
-    let base = std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
-        .unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join("aegis-boot")
+    // Delegates to the shared resolver (#375 Phase 1) so
+    // `AEGIS_STATE_DIR` override, sudo-aware `HOME` lookup, and the
+    // XDG/fallback chain live in exactly one place. Pre-refactor this
+    // function had its own copy of the lookup; the logic drifted from
+    // `update.rs::attestation_dir` over time and neither honored
+    // `AEGIS_STATE_DIR`. Phase 1 collapses the duplication.
+    crate::paths::aegis_state_root()
 }
 
 /// When the process runs under `sudo`, the kernel preserves

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -44,6 +44,7 @@ mod init_wizard;
 mod inventory;
 mod man;
 mod mounts;
+mod paths;
 mod plan;
 mod quickstart;
 mod readback;

--- a/crates/aegis-cli/src/paths.rs
+++ b/crates/aegis-cli/src/paths.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Operator-visible state paths for aegis-boot (#375 Phase 1).
+//!
+//! Single source of truth for "where does aegis-boot keep its state?"
+//! Previously every caller resolved `XDG_DATA_HOME` / `HOME` / sudo
+//! rewrites independently (see pre-refactor `attest.rs::data_dir` +
+//! `update.rs::attestation_dir`). This module centralizes that
+//! resolution and adds the `AEGIS_STATE_DIR` override foundation that
+//! ADR 0002 (epoch counter seen-epoch state) and ADR 0003 (cross-
+//! reboot last-booted persistence) both build on.
+//!
+//! Resolution order (first match wins):
+//!
+//! 1. `AEGIS_STATE_DIR` — explicit override. Used verbatim; test +
+//!    deployment knob for operators who want state elsewhere. The
+//!    value replaces the entire `<base>/aegis-boot` prefix, so
+//!    `AEGIS_STATE_DIR=/var/lib/aegis-boot` yields
+//!    `/var/lib/aegis-boot/attestations/` (not
+//!    `/var/lib/aegis-boot/aegis-boot/attestations/`).
+//! 2. Sudo-aware `HOME` — when running under `sudo`, prefer the
+//!    original user's `~/.local/share/aegis-boot` over root's,
+//!    so `sudo aegis-boot flash` writes attestations where
+//!    `aegis-boot attest list` (run unprivileged) will look for
+//!    them. See `crate::attest::sudo_aware_data_dir` for the
+//!    mechanism.
+//! 3. `XDG_DATA_HOME/aegis-boot` — standard spec-compliant path.
+//! 4. `$HOME/.local/share/aegis-boot` — XDG default when unset.
+//! 5. `/tmp/aegis-boot` — fall-through when even `HOME` is unset;
+//!    signals a degraded environment (likely a CI sandbox or init
+//!    script context) and keeps things runnable rather than
+//!    panicking.
+
+use std::path::PathBuf;
+
+/// Environment variable that overrides the default state-dir base.
+/// Shared with `crates/rescue-tui/src/persistence.rs` so the same
+/// knob drives both the tmpfs last-choice path and the on-disk
+/// attestation path.
+pub(crate) const AEGIS_STATE_DIR_ENV: &str = "AEGIS_STATE_DIR";
+
+/// Root of the aegis-boot state tree. Everything the CLI persists
+/// (attestations, future trust-anchor seen-epoch, future last-booted
+/// state) lives under this dir.
+///
+/// This is a pure function of the environment; no filesystem i/o and
+/// no subprocess calls.
+#[must_use]
+pub(crate) fn aegis_state_root() -> PathBuf {
+    if let Some(explicit) = std::env::var_os(AEGIS_STATE_DIR_ENV) {
+        return PathBuf::from(explicit);
+    }
+    if let Some(sudo_data) = crate::attest::sudo_aware_data_dir() {
+        return sudo_data.join("aegis-boot");
+    }
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    base.join("aegis-boot")
+}
+
+/// Where flash + add write signed attestation manifests. Always
+/// resolvable (ultimately falls back to `/tmp/aegis-boot/attestations`),
+/// so callers don't need to handle an absent base.
+#[must_use]
+pub(crate) fn attestations_dir() -> PathBuf {
+    aegis_state_root().join("attestations")
+}
+
+/// Where the ADR-0002 Key Epoch counter's `seen-epoch` file lives.
+/// Not yet written or read by any code; defined here so the trust-
+/// anchor module's future plumbing has a canonical path to target.
+/// File contents: a single integer in ASCII, newline-terminated.
+#[must_use]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn trust_seen_epoch_path() -> PathBuf {
+    aegis_state_root().join("trust").join("seen-epoch")
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::missing_panics_doc
+)]
+mod tests {
+    use super::*;
+
+    /// Tests MUST NOT touch process env (crate has `forbid(unsafe_code)`
+    /// which blocks Rust-2024's unsafe `std::env::set_var`). Instead,
+    /// each test inspects the function's behavior under a specific
+    /// current env state and asserts what the state-root *would* be
+    /// given the visible env. This isolates from ambient config and
+    /// doesn't break under parallel tests.
+
+    #[test]
+    fn aegis_state_root_honors_explicit_override_when_set() {
+        // If AEGIS_STATE_DIR is set in the ambient env (e.g. in CI),
+        // the function MUST return exactly that path. Otherwise, skip
+        // the override-specific assertion and only verify the
+        // fallback path.
+        if let Some(explicit) = std::env::var_os(AEGIS_STATE_DIR_ENV) {
+            assert_eq!(aegis_state_root(), PathBuf::from(explicit));
+        } else {
+            // Without the override, we should land in one of the
+            // sudo-aware / XDG / HOME / /tmp paths — they all have
+            // `aegis-boot` as their final segment.
+            let root = aegis_state_root();
+            let last = root.file_name().and_then(|s| s.to_str()).unwrap();
+            assert_eq!(
+                last, "aegis-boot",
+                "non-override resolution should end in 'aegis-boot', got {root:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn attestations_dir_is_state_root_plus_attestations() {
+        let root = aegis_state_root();
+        let att = attestations_dir();
+        assert_eq!(att, root.join("attestations"));
+    }
+
+    #[test]
+    fn trust_seen_epoch_path_is_state_root_plus_trust_seen_epoch() {
+        let root = aegis_state_root();
+        let p = trust_seen_epoch_path();
+        assert_eq!(p, root.join("trust").join("seen-epoch"));
+    }
+}

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -867,7 +867,7 @@ pub(crate) fn parse_partitions(sgdisk_out: &str) -> (bool, String) {
 /// Returns `None` if no match is found OR the attestations dir doesn't
 /// exist yet.
 fn find_attestation_by_guid(target_guid: &str) -> Option<PathBuf> {
-    let dir = attestation_dir()?;
+    let dir = attestation_dir();
     let entries = std::fs::read_dir(&dir).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -898,25 +898,15 @@ pub(crate) fn body_contains_guid(body: &str, target_guid: &str) -> bool {
     lower_body.contains(&needle)
 }
 
-/// Same resolution rules as `attest::attestation_dir()` — duplicated here
-/// to avoid exporting a new pub surface in attest.rs this PR. Kept
-/// `pub(crate)` so a future `mv` into attest.rs is a mechanical rename.
-///
-/// Sudo handling: when running as root with `SUDO_USER` set (the
-/// typical `sudo aegis-boot update` flow — sudo needed to read the
-/// raw block device), prefer the original user's data dir rather
-/// than root's. Otherwise update-via-sudo would never find the
-/// attestations that flash-via-sudo wrote under the same user's
-/// home — that's the exact bug this fix closes (caught 2026-04-18
-/// during real-stick testing of #181).
-pub(crate) fn attestation_dir() -> Option<PathBuf> {
-    if let Some(sudo_data) = crate::attest::sudo_aware_data_dir() {
-        return Some(sudo_data.join("aegis-boot").join("attestations"));
-    }
-    let base = std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))?;
-    Some(base.join("aegis-boot").join("attestations"))
+/// Path to the attestations directory. Delegates to the shared
+/// resolver (#375 Phase 1) which honors `AEGIS_STATE_DIR`, sudo-aware
+/// `HOME` (so `sudo aegis-boot update` lands in the same dir
+/// `aegis-boot flash` wrote to), and the XDG/fallback chain — in one
+/// place, so the lookup can't drift between callers the way it did
+/// pre-refactor. Kept `pub(crate)` because this module has consumers
+/// that are easier to leave on the shim than rewire at call-sites.
+pub(crate) fn attestation_dir() -> PathBuf {
+    crate::paths::attestations_dir()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Centralizes aegis-cli's state-dir resolution into a single `crate::paths` module. Honors `AEGIS_STATE_DIR` as an explicit operator override — previously only rescue-tui's `persistence.rs` honored the var for its tmpfs path; now aegis-cli's host-side attestations + future trust-anchor state obey the same knob.

Foundation work for #375, ADR 0002 rev 3 (seen-epoch file), and ADR 0003 (cross-reboot last-booted persistence) — all three of those land on top of a single shared resolver instead of duplicating the XDG/HOME dance N times.

## What's new

`crate::paths`:
- `aegis_state_root()` — single resolver. Order: `AEGIS_STATE_DIR` → sudo-aware `HOME` → `XDG_DATA_HOME/aegis-boot` → `$HOME/.local/share/aegis-boot` → `/tmp/aegis-boot` (fall-through).
- `attestations_dir()` — returns `<state>/attestations`. Return type shed the old `Option<PathBuf>` since the resolver now always succeeds.
- `trust_seen_epoch_path()` — returns `<state>/trust/seen-epoch`. Pre-defined for ADR 0002 rev 3's Key Epoch counter so Phase 3c wiring has no path debate.

## Refactored callers

- `attest.rs::data_dir` → delegates (was a copy of the XDG/HOME chain with no env-override).
- `update.rs::attestation_dir` → delegates; return type `Option<PathBuf>` → `PathBuf`. One caller site in `find_attestation_by_guid` updated.

## Why this is Phase 1

This PR is pure refactor: no behavioral change for end-users who haven't set `AEGIS_STATE_DIR`. The win is **one resolver** for Phase 2+ (ADR 0003 cross-reboot persistence, ADR 0002 trust-anchor state) to target. Those phases would otherwise have to re-solve the same "where do we put state?" question and would likely drift from attest.rs/update.rs again.

Explicit override semantics:
```bash
AEGIS_STATE_DIR=/tmp/aegis-test aegis-boot flash /dev/loop0
# writes attestations to /tmp/aegis-test/attestations/
```

## Test plan

- [x] `cargo build -p aegis-cli` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p aegis-cli --all-targets -- -D warnings` — clean
- [x] `cargo test -p aegis-cli --locked` — 451 pass (was 448; +3 for paths module)
- [ ] CI: full workspace tests + drift checks

## Deferred to Phase 2

- Rescue-tui's `persistence.rs::default_state_dir()` consumption of the same resolver (it's a different crate with no host-side XDG access; its `/run/aegis-boot` default is already correct for the rescue environment).
- ADR 0003 cross-reboot persistence writing to AEGIS_ISOS partition instead of tmpfs.
- Public-API exposure (`pub fn` instead of `pub(crate) fn`) if aegis-wire-formats or an external verifier wants to compute paths by the same rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)