### PR TITLE
chore(opsec): scrub maintainer-affiliation references from public docs

### DIFF
--- a/docs/architecture/KEY_MANAGEMENT.md
+++ b/docs/architecture/KEY_MANAGEMENT.md
@@ -41,7 +41,7 @@ Both consumers need: (a) a signing tool that runs offline, (b) an operator-verif
 
 ### 1.4 Constraints (ambient; bounds the solution space)
 
-- **Federal-employee maintainer.** No D-U-N-S number, no authenticode certificate, no Apple Developer Program enrollment. Rules out any solution that requires corporate PKI.
+- **Individual-account maintainer.** No D-U-N-S number, no Authenticode certificate, no Apple Developer Program enrollment. Rules out any solution that requires corporate PKI or a business-entity identity.
 - **Solo maintainer.** No ceremony-heavy key-custody protocol ("two-person offline signing with HSMs") is realistic. One person, one laptop, GitHub as ambient identity.
 - **Repo mobility.** Project currently lives at `github.com/williamzujkowski/aegis-boot`; per #365 it migrates to an `aegis-boot` org. Any solution coupled to the owner slug must rotate on that move.
 - **Existing minisign use.** `crates/iso-probe/src/minisign.rs` already verifies minisign detached sigs against `AEGIS_TRUSTED_KEYS` for per-ISO sidecars. Operators who have used `aegis-boot add` have already pointed that env var at a keyring. Pattern + mental model already exists.
@@ -83,7 +83,7 @@ And one added in rev 2 to close the revocation-circularity gap surfaced by the f
 
 Three properties matter for the operator-facing trust anchor: **no PKI infrastructure**, **small trusted compute base**, **operators already know it**.
 
-- **No PKI.** Minisign is Ed25519 with a single pubkey file. No CA, no chain, no OCSP, no Authenticode, no Apple notarization. A federal-employee solo maintainer with no D-U-N-S cannot obtain those credentials; minisign is one of the few signature formats that works without them.
+- **No PKI.** Minisign is Ed25519 with a single pubkey file. No CA, no chain, no OCSP, no Authenticode, no Apple notarization. A solo maintainer on an individual account with no D-U-N-S cannot obtain those credentials; minisign is one of the few signature formats that works without them.
 - **Small TCB.** We already depend on `minisign-verify` in `crates/iso-probe/` (`minisign.rs:27`). Verification adds zero new crates. Compare cosign: pulls Sigstore trust-root fetch + Fulcio cert verification + Rekor transparency log lookups — a large online-only TCB that defeats both consumers' offline-verify requirement.
 - **Operator mindshare.** `AEGIS_TRUSTED_KEYS` env var + `.minisig` sidecar pattern already exist for per-ISO verification (`iso-probe/src/minisign.rs:17-22`). An operator who used `aegis-boot add` on a Fedora ISO has already touched this. Introducing a second format (minisign for ISOs, cosign for attestation) would double the mental model for no operator win.
 

--- a/docs/governance/ORG_MIGRATION_PLAN.md
+++ b/docs/governance/ORG_MIGRATION_PLAN.md
@@ -3,7 +3,7 @@
 **Status:** APPROVED (consensus vote 2026-04-22, 80% supermajority). Maintainer-executed checklist; no bot automation.
 **Vote record:** rev 1 rejected at 60% (Gemini surfaced OIDC discontinuity + crates.io squatter race); rev 2 (PR #389) added §1 crates.io pre-registration + §6.3 OIDC identity bridge; rev 2 passed at 80%. Architect ✓88%, Security ✓95% (flipped from rev-1 REJECT), DevEx ✓87%, PM ✓88%, AI/ML abstained (95%), Contrarian ✗95% (operational nitpicks not security-blocking). Verification hashes in PR #389.
 **Scope:** Move `github.com/williamzujkowski/aegis-boot` and `github.com/williamzujkowski/aegis-hwsim` under a new GitHub Organization at `github.com/aegis-boot`.
-**Maintainer:** William Zujkowski (solo). Federal employee — uses **Individual** Apple Developer Program; does NOT register a business entity.
+**Maintainer:** William Zujkowski (solo). Personal/individual GitHub account; does NOT register a business entity. If Apple Developer Program enrollment becomes necessary (see #369), the **Individual** enrollment tier applies.
 **Org name verified available:** 2026-04-22 — re-verified (`github.com/aegis-boot` → HTTP 404).
 **Plan legend:** [UI] = browser click-through • [CLI] = terminal command • [LOCAL] = local repo edit.
 
@@ -83,7 +83,7 @@
 - [ ] **[UI]** Pick the **Free** plan (public repos are free unlimited Actions; private repos get 2000 minutes/month — irrelevant since both target repos stay public).
 - [ ] **[UI]** Org name: `aegis-boot` (exact, lowercase, hyphen).
 - [ ] **[UI]** Contact email: use your personal email (the one already on your GitHub account).
-- [ ] **[UI]** Ownership: **"My personal account"** (NOT "A business or institution") — this is the correct choice for a federal employee using an individual account; it avoids any "business entity" registration question.
+- [ ] **[UI]** Ownership: **"My personal account"** (NOT "A business or institution") — this is the correct choice for a solo maintainer on an individual account; it avoids any "business entity" registration question and keeps billing/tax handling simple (no D-U-N-S required).
 - [ ] **[UI]** Skip the "Invite members" step (solo maintainer).
 - [ ] **[UI]** Complete the "How will you use this org?" survey (answers don't matter for plan or cost).
 - [ ] **[UI]** Confirm landing page shows `https://github.com/aegis-boot` with you as the sole Owner.


### PR DESCRIPTION
## Summary

Per operator request (2026-04-22), remove all mentions of maintainer employment status from public-facing artifacts. The project's technical constraints — no D-U-N-S, no Authenticode cert, no corporate PKI, Individual-account ownership, $99/yr Apple Developer Program cost if enrolled — stand on their own merit. The rewrites keep every constraint intact while removing the identity-revealing framing.

## Repo scope (this PR's diff)

- **`docs/architecture/KEY_MANAGEMENT.md` §1.4** — "Federal-employee maintainer" → "Individual-account maintainer"
- **`docs/architecture/KEY_MANAGEMENT.md` §3.1** — "federal-employee solo maintainer with no D-U-N-S" → "solo maintainer on an individual account with no D-U-N-S"
- **`docs/governance/ORG_MIGRATION_PLAN.md` header** — "Federal employee — uses Individual Apple Developer Program" → describes project ownership category without identity attribution
- **`docs/governance/ORG_MIGRATION_PLAN.md` §2** — "correct choice for a federal employee" → "correct choice for a solo maintainer on an individual account"

## Companion cleanup (already landed on GitHub, not in this diff)

- **Issue #369** body rewritten — removed "for a federal employee there's an ethics-office conversation" + "Maintainer consults federal agency ethics office". Rationale text now frames enrollment as a $99/yr + personal-data-disclosure decision, which is the same *decision surface* the original text described without naming employment.
- **PR #385** (ADR rev 3) body edited — "cost-prohibitive for solo federal-employee maintainer" → "cost-prohibitive for solo maintainer on an individual account".

## What's NOT scrubbed (deliberate)

- **Commit messages on `main`** — two commits (`0d1467148`, `fb911702e`) reference "solo federal-employee constraint" in their message bodies. Rewriting shared history requires force-push to `main`, which breaks every clone + every CI job pinning the pre-rewrite hashes. Commit messages have much lower discovery surface than docs/issues/PR bodies (which ARE where casual browsers land), so the call here is: leave history, scrub everything forward.
- **`CHANGELOG.md`** — no matches found.

## Verification

```
grep -rniE "federal.employee|ethics.office|government.employ" . \
  --exclude-dir=target --exclude-dir=.git
# → zero matches.
```

## Related

- No tracking issue — dropping this one directly as a chore PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)