### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,90 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-04-22
+
+First release under the dedicated **`aegis-boot` GitHub org**. Direct-install pipeline shipped end-to-end with signed attestation manifests, operator UX gained three one-command workflows (`quickstart`, `init`, catalog-slug `add`), and the supply chain grew a second signed trust anchor (minisign, ADR 0002 ACCEPTED) to sit alongside the cosign-keyless release signing. macOS arm64 release binaries ship per-tag via a new Homebrew bottle and a `release.yml` that builds the darwin target natively. The org move closes the `aegis-boot/aegis-*` naming story, pre-registers all library crates on crates.io with team-based ownership, and replaces the long-lived `CARGO_REGISTRY_TOKEN` with Trusted Publishing (short-lived OIDC tokens per-release).
+
+### Direct-install pipeline lands — v1.0.0 blocker #274 clears (epic [#274](https://github.com/aegis-boot/aegis-boot/issues/274))
+
+`aegis-boot flash --direct-install` replaces the legacy `mkusb.sh + dd` path with a Rust-native pipeline: zap + GPT partition via `sgdisk`, ESP `mkfs.fat`, AEGIS_ISOS `mkfs.exfat` (default) / `fat32` / `ext4`, render grub.cfg, concat initrd, stage the signed chain via `mmd + mcopy`, and — new in this release — write a signed attestation manifest to `::/aegis-boot-manifest.json` on the freshly-staged ESP. Byte-parity against `mkusb.sh` is enforced in CI (`.github/workflows/direct-install-e2e.yml`): each of the 6 canonical ESP files is sha256-compared and the workflow fails on any divergence.
+
+- **Phase 3 — wire `--direct-install`** ([#350](https://github.com/aegis-boot/aegis-boot/pull/350)). First end-to-end run behind the flag; pre-flight deps gate + per-stage wall-clock timers landed in companion PRs ([#353](https://github.com/aegis-boot/aegis-boot/pull/353), [#354](https://github.com/aegis-boot/aegis-boot/pull/354)).
+- **Phase 3b — signed attestation manifest write** ([#386](https://github.com/aegis-boot/aegis-boot/pull/386), closes [#349](https://github.com/aegis-boot/aegis-boot/issues/349)). Stage 7 of the flash pipeline reads device identity (sgdisk + blkid), computes per-file ESP sha256s, builds a `schema_version=1` `Manifest` (`aegis_wire_formats::Manifest`), serializes, and optionally minisign-signs it if `AEGIS_BOOT_SIGNING_KEY` is set. Unsigned operator-default per ADR 0002 §6.3; the maintainer-signed path ships the full cosign-verifiable claim.
+- **Phase 6 — subfolder support** ([#351](https://github.com/aegis-boot/aegis-boot/pull/351), [#381](https://github.com/aegis-boot/aegis-boot/pull/381), [#382](https://github.com/aegis-boot/aegis-boot/pull/382), [#383](https://github.com/aegis-boot/aegis-boot/pull/383)). `aegis-boot list` recurses AEGIS_ISOS; `add --folder NAME` places an ISO under a named subfolder; `doctor --stick` prints per-ISO trust-state rows; rescue-tui surfaces the subfolder prefix in the boot menu.
+
+### Operator UX — three one-command paths (closes [#352](https://github.com/aegis-boot/aegis-boot/issues/352))
+
+The 5-command `doctor → init → fetch → add → boot` walkthrough still works, but two new capstones cover the common cases:
+
+- **`aegis-boot quickstart <device>`** ([#358](https://github.com/aegis-boot/aegis-boot/pull/358)) — sub-10-minute empty-stick-to-booted-rescue with Alpine 3.20 Standard. Thin wrapper over `init --profile minimal --yes --direct-install`.
+- **`aegis-boot init`** — one-command rescue stick with the `panic-room` profile (Alpine + Ubuntu + Rocky) or other curated profiles.
+- **`aegis-boot add <catalog-slug>`** ([#356](https://github.com/aegis-boot/aegis-boot/pull/356)) — operators no longer have to `fetch` then `add`; one verb both fetches (cosign-verifying) and adds to the stick.
+
+rescue-tui's empty-state pointer ([#357](https://github.com/aegis-boot/aegis-boot/pull/357)) surfaces the catalog-slug shortcut directly in the menu when the stick has no ISOs.
+
+### In-place update groundwork — #181 Phase 1 + Phase 2a
+
+`aegis-boot update <device>` goes from not-a-command to two real phases:
+
+- **Phase 1 — eligibility preflight** ([#380](https://github.com/aegis-boot/aegis-boot/pull/380)). Read-only: validates GPT + ESP + AEGIS_ISOS label + attestation-GUID match, prints the per-file sha256 diff between stick and a fresh flash, reports ELIGIBLE / INELIGIBLE with a specific reason. Zero writes.
+- **Phase 2a — rotation planner + `--experimental-apply` gate** ([#388](https://github.com/aegis-boot/aegis-boot/pull/388)). Pure-function planner + rollback analyzer in `update_apply.rs`. The CLI flag `--apply --experimental-apply` dry-prints the plan the Phase 2b executor would run. Still no writes — FAT32 has no journal; Phase 2b will ship the executor with bounded rollback on per-file verify failure.
+
+### macOS arm64 ships — #365 Phase A1 + A3
+
+First cross-platform release binary lands. Native aarch64-apple-darwin build via GitHub Actions macos-14 runner ([#371](https://github.com/aegis-boot/aegis-boot/pull/371)). Homebrew bottle at `aegis-boot/aegis-boot` tap ([#372](https://github.com/aegis-boot/aegis-boot/pull/372)) sidesteps Gatekeeper entirely. Binary is ad-hoc codesigned but not notarized — notarization is demand-signal-gated via [#369](https://github.com/aegis-boot/aegis-boot/issues/369).
+
+### GitHub org migration — williamzujkowski/aegis-* → aegis-boot/ (closes [#365](https://github.com/aegis-boot/aegis-boot/issues/365) migration phase)
+
+Both repositories transferred under a dedicated `aegis-boot` GitHub organization. Old URLs 301-redirect (GitHub preserves for ≥1 year), but all 179 in-repo references + 129 CHANGELOG issue links swept to the new org path ([#394](https://github.com/aegis-boot/aegis-boot/pull/394)). The cosign keyless identity used by `release.yml` changes from `williamzujkowski/aegis-boot/...` to `aegis-boot/aegis-boot/...` — old-identity release signatures remain valid (hash-bound, not location-bound), and the rev-3 ADR 0002 identity-transition bridge (`.github/identity-transition.json` signed under the legacy identity pre-transfer) lets automated verifiers chain cryptographically.
+
+### Crates.io — 8 placeholders + team ownership + Trusted Publishing (ADR 0002)
+
+All 8 workspace + sibling crate names pre-registered as v0.0.0 placeholders to close the post-transfer squatter race: `aegis-boot`, `aegis-bootctl`, `aegis-wire-formats`, `aegis-fitness`, `aegis-hwsim`, `iso-parser`, `iso-probe`, `kexec-loader`. Each is co-owned by `williamzujkowski` + `github:aegis-boot:aegis-boot-admins`, so anyone in the admins team can publish.
+
+**Trusted Publishing** ([#395](https://github.com/aegis-boot/aegis-boot/pull/395)) replaces the long-lived `CARGO_REGISTRY_TOKEN`. The new `.github/workflows/crates-publish.yml` is tag-triggered, gated on the `release` GitHub environment (required-reviewer + `v*`-tag deployment policy), and uses `rust-lang/crates-io-auth-action@v1` to mint a ~30-minute OIDC token per release. No registry secret sits in GitHub org secrets, `pass`, or anywhere else.
+
+**Package rename**: `crates/aegis-cli/` publishes as `aegis-bootctl` on crates.io because the `aegis-cli` name was claimed by an unrelated Aegis Authenticator TOTP tool (v1.3.95). Directory path stays `crates/aegis-cli/` to preserve git history; the binary name is `aegis-boot` (via `[[bin]] name = "aegis-boot"`, independent of package name), so operators see zero change. Tracked in [#392](https://github.com/aegis-boot/aegis-boot/issues/392), landed via [#393](https://github.com/aegis-boot/aegis-boot/pull/393).
+
+### ADRs accepted
+
+- **0002 — Key Management** ([`docs/architecture/KEY_MANAGEMENT.md`](./docs/architecture/KEY_MANAGEMENT.md)). rev 3, **ACCEPTED at 83.3% supermajority** on [#366](https://github.com/aegis-boot/aegis-boot/issues/366). Ships minisign (Ed25519) as the operator-facing trust anchor for runtime-emitted signatures (attestation manifests + future #367 bundle manifests); keeps cosign keyless for release-artifact signing. One active key + historical-anchors list for forever-valid old-manifest verification. Monotonic **Key Epoch counter** with a binary-embedded `MIN_REQUIRED_EPOCH` floor closes the post-compromise rollback window on fresh installs. Quarterly rotation rehearsals keep the runbook exercised.
+- **0003 — Cross-reboot last-booted persistence** ([`docs/architecture/LAST_BOOTED_PERSISTENCE.md`](./docs/architecture/LAST_BOOTED_PERSISTENCE.md)) ([#379](https://github.com/aegis-boot/aegis-boot/pull/379)). PROPOSED. Closes the #132 spec-mismatch: rescue-tui's cursor should persist across reboots, but the shipped module writes to tmpfs. ADR scopes a two-stage `tmpfs → AEGIS_ISOS` migration.
+
+### Bug-report bundler — `aegis-boot bug-report` (closes [#342](https://github.com/aegis-boot/aegis-boot/issues/342))
+
+Three-phase incremental ship of an operator-facing bug-reporting workflow:
+
+- **Phase 1** ([#344](https://github.com/aegis-boot/aegis-boot/pull/344)) — workstation bundler subcommand collects a redacted host-state archive.
+- **Phase 2** ([#345](https://github.com/aegis-boot/aegis-boot/pull/345)) — rescue-tui writes Tier-A failure microreports onto the stick when a kexec fails.
+- **Phase 3a** ([#346](https://github.com/aegis-boot/aegis-boot/pull/346)) — `bug-report --include-stick` pulls those microreports back; exFAT filename fix.
+
+### CI + supply chain
+
+- **SPDX per-file license headers** ([#361](https://github.com/aegis-boot/aegis-boot/pull/361)). Every Rust + shell + YAML source file carries a machine-readable license tag.
+- **cargo-deny license allowlist** ([#362](https://github.com/aegis-boot/aegis-boot/pull/362)). CI fails any PR that introduces a transitive dep under a license not on the allowlist.
+- **NOTICE file** ([#363](https://github.com/aegis-boot/aegis-boot/pull/363)) — upstream-component attribution for the signed Secure Boot chain (shim, grub, distro kernel).
+- **miri UB detection on `kexec-loader`** ([#378](https://github.com/aegis-boot/aegis-boot/pull/378), closes [#364](https://github.com/aegis-boot/aegis-boot/issues/364)). Path-gated `.github/workflows/miri-kexec-loader.yml` runs `cargo +nightly miri test -p kexec-loader` whenever anything under `crates/kexec-loader/` changes. Covers stacked-borrows aliasing + lifetime bugs the normal compiler doesn't catch.
+- **crates.io publish-readiness dry-run workflow** ([#355](https://github.com/aegis-boot/aegis-boot/pull/355)). `cargo publish --dry-run` per library crate on every PR — catches metadata regressions (missing `version =` on path deps, bad category names, oversize `description`) before publish day.
+
+### Documentation + governance
+
+- **Doc-evergreen sweep** ([#384](https://github.com/aegis-boot/aegis-boot/pull/384)) — 14 files refreshed, `<!-- constants:BEGIN:NAME --><!-- constants:END:NAME -->` markers source live values from `crates/aegis-cli/src/constants.rs`, stale issue references re-pointed, dead flag references dropped.
+- **OPSEC scrub** ([#390](https://github.com/aegis-boot/aegis-boot/pull/390)) — public-facing docs no longer reference maintainer employment; technical constraints (no D-U-N-S, Individual Apple Developer enrollment tier) preserved.
+- **Quickstart README promotion** ([#359](https://github.com/aegis-boot/aegis-boot/pull/359)) — `aegis-boot quickstart` now the headlined fastest install.
+
+### Fixed
+
+- **Initramfs exfat modprobe** ([#373](https://github.com/aegis-boot/aegis-boot/pull/373), closes [#132](https://github.com/aegis-boot/aegis-boot/issues/132) external-user report) — rescue kernel now loads `exfat` + `nls_cp437` + `nls_iso8859-1` at init, so sticks formatted with the `exfatprogs` default (#243) actually mount on boot.
+- **`init --direct-install` arg forwarding** ([#376](https://github.com/aegis-boot/aegis-boot/pull/376)) — `quickstart` passes `--direct-install` through to `init` cleanly; previously the flag was silently dropped.
+
+### Not yet shipped (deferred to next milestones)
+
+- **Windows native release binary** — Phase B of [#365](https://github.com/aegis-boot/aegis-boot/issues/365). Drive enumeration + `Get-Disk` logic landed in earlier releases; raw-disk writing + code signing are the gates. Winget manifest scaffold ships in this release ([#370](https://github.com/aegis-boot/aegis-boot/pull/370)) but the real publish is Phase B.
+- **#181 Phase 2b (destructive executor)** — rotation planner ships; the executor that actually writes to the ESP is Phase 2b, gated on OVMF E2E validation of the full backup → stage → verify → rotate → rollback cycle.
+- **#367 Phase D (cross-platform bundle trust anchor)** — unblocked by ADR 0002 acceptance; implementation tracks post-v0.16.0.
+- **Real-hardware multi-vendor shakedown** — [#51](https://github.com/aegis-boot/aegis-boot/issues/51) v1.0.0 gate. QEMU + OVMF passes on every release; Framework / ThinkPad / Dell direct-boot reports are the v1.0.0 threshold.
+
 ## [0.15.0] — 2026-04-20
 
 Doc-automation milestone release. Closes epic [#286](https://github.com/aegis-boot/aegis-boot/issues/286) (7-phase auto-generation + drift-checks for every user-facing doc) and the operator-UX sweep umbrella [#310](https://github.com/aegis-boot/aegis-boot/issues/310). 12 committed JSON Schemas for every `aegis-boot --json` surface. First community hardware-compat submission surfaced four bugs, all fixed. New local cross-distro test harness. CI grew from 17 → 22 drift-checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-bootctl"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aegis-wire-formats",
  "hex",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-wire-formats"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "schemars",
  "serde",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "kexec-loader"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -738,7 +738,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aegis-wire-formats",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["crates/iso-parser/fuzz"]
 # Release-cut flow: bump this one line + amend CHANGELOG, tag.
 # CI's doc-version drift-check (Phase 1c) greps an allowlist of
 # user-facing doc files and fails if any version literal diverges.
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["filesystem", "embedded"]
 [lib]
 
 [dependencies]
-iso-parser = { path = "../iso-parser", version = "0.15" }
+iso-parser = { path = "../iso-parser", version = "0.16" }
 thiserror.workspace = true
 serde = { workspace = true }
 tracing.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -12,7 +12,7 @@ name = "rescue-tui"
 path = "src/main.rs"
 
 [dependencies]
-aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.15" }
+aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
 iso-probe = { path = "../iso-probe" }
 kexec-loader = { path = "../kexec-loader" }
 thiserror.workspace = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -485,7 +485,7 @@ Every other USB-imaging tool is silent after flash. The attestation receipt is t
 ```json
 {
   "schema_version": 1,
-  "tool_version": "0.15.0",
+  "tool_version": "0.16.0",
   "flashed_at": "2026-04-16T12:34:56Z",
   "operator": "william",
   "host": {
@@ -818,7 +818,7 @@ aegis-boot tour --help
 
 ## Versioning
 
-`aegis-boot --version` reports the workspace version (currently `0.15.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.16.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
 `aegis-boot --version --json` emits the same info as a stable envelope for scripted install verification or Homebrew-style version matching:
 
@@ -826,7 +826,7 @@ aegis-boot tour --help
 {
   "schema_version": 1,
   "tool": "aegis-boot",
-  "version": "0.15.0"
+  "version": "0.16.0"
 }
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,7 +64,7 @@ macOS x86_64 (Intel) and Windows native builds remain deferred — see [#365](ht
 Sanity check:
 
 ```bash
-aegis-boot --version       # → aegis-boot v0.15.0
+aegis-boot --version       # → aegis-boot v0.16.0
 aegis-boot doctor          # 0–100 health score for host + stick
 ```
 
@@ -170,7 +170,7 @@ If the firmware refuses to show the USB entry, your boot mode might be CSM/Legac
 `rescue-tui` shows your ISOs with verification status:
 
 ```
-aegis-boot v0.15.0    SB:enforcing  TPM:available
+aegis-boot v0.16.0    SB:enforcing  TPM:available
 
   ▸ ubuntu-24.04.2-live-server-amd64.iso        1.6 GiB  [✓ sha256]
     alpine-3.20.3-x86_64.iso                     198 MiB  [no verify]

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -90,7 +90,7 @@ EXAMPLES:
   aegis-boot bug-report --output report.json --format json
   aegis-boot bug-report --include-stick /media/$USER/AEGIS_ISOS
 
-(aegis-boot v0.15.0)
+(aegis-boot v0.16.0)
 ```
 
 ## `aegis-boot compat`
@@ -211,11 +211,11 @@ aegis-boot fetch-image — download + verify a pre-built aegis-boot image
 
 USAGE:
   aegis-boot fetch-image                               # latest release, cosign auto-verify
-  aegis-boot fetch-image --version v0.15.0             # pin to a specific release
+  aegis-boot fetch-image --version v0.16.0             # pin to a specific release
   aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL
 
   --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)
-  --version TAG   Pin to a specific release tag (e.g. v0.15.0)
+  --version TAG   Pin to a specific release tag (e.g. v0.16.0)
   --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)
   --sha256 HEX    Required sha256; mismatch deletes the download + exits 1
   --no-cosign     Skip the cosign keyless signature check (air-gap, offline)


### PR DESCRIPTION
First release under the aegis-boot GitHub org. 41 commits since v0.15.0; consensus vote APPROVED at 83.3% supermajority.

See [CHANGELOG.md](./CHANGELOG.md#0160--2026-04-22) for the full scope.

## Headline

- **Direct-install pipeline** (#274) shipped end-to-end with signed attestation manifests (#349 Phase 3b)
- **Operator UX**: `quickstart` + `init` + catalog-slug `add` (#352)
- **macOS arm64** release binary + Homebrew bottle (#365 Phase A1/A3)
- **Org move**: `williamzujkowski/aegis-*` → `aegis-boot/` with OIDC identity bridge
- **Crates.io**: 8 placeholders, team-owned, Trusted Publishing (no long-lived token)
- **ADR 0002 ACCEPTED** (Key Management): minisign + Key Epoch counter + historical anchors + rotation rehearsal
- **Update subcommand**: Phase 1 eligibility + Phase 2a rotation planner

## Validation (local)

- `cargo fmt --check` clean
- `cargo clippy -p aegis-bootctl --all-targets -- -D warnings` clean
- `cargo test -p aegis-bootctl --locked` 459 passed
- `cli-docgen --check` OK
- `constants-docgen --check` OK
- `schema-docgen --check` OK
- `check-doc-version.sh` OK (0.16.0 across all drift-checked files)

## Release flow (after merge)

1. Tag `v0.16.0` on main
2. Push tag → triggers `.github/workflows/release.yml` (cosign-signed binaries)
3. Tag push also triggers `.github/workflows/crates-publish.yml` → enters `release` environment → you approve in UI → OIDC-minted token publishes 6 library crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)