### PR TITLE
fix(ci): idempotent crates publish — skip on duplicate version

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -55,8 +55,12 @@ jobs:
   publish:
     name: cargo publish (trusted)
     runs-on: ubuntu-latest
-    # Environment gate: the `release` environment requires maintainer
-    # approval + is tag-scoped to `v*`. See
+    # Environment gate: the `release` environment is tag-scoped to
+    # `v*` (only signed v* tag pushes can enter — branches cannot
+    # publish). Required-reviewer rule was removed 2026-04-22 to
+    # enable autonomous bug-fix releases; the tag-only deployment
+    # policy + branch protection on main + cosign-keyless artifact
+    # signing are the remaining safety net. See
     # github.com/aegis-boot/aegis-boot/settings/environments/release.
     environment: release
     # OIDC token required for rust-lang/crates-io-auth-action.
@@ -92,34 +96,34 @@ jobs:
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'aegis-wire-formats' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p aegis-wire-formats --locked
+        run: ./scripts/publish-if-new.sh aegis-wire-formats
 
       - name: publish iso-parser
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'iso-parser' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p iso-parser --locked
+        run: ./scripts/publish-if-new.sh iso-parser
 
       - name: publish iso-probe
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'iso-probe' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p iso-probe --locked
+        run: ./scripts/publish-if-new.sh iso-probe
 
       - name: publish kexec-loader
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'kexec-loader' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p kexec-loader --locked
+        run: ./scripts/publish-if-new.sh kexec-loader
 
       - name: publish aegis-fitness
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'aegis-fitness' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p aegis-fitness --locked
+        run: ./scripts/publish-if-new.sh aegis-fitness
 
       - name: publish aegis-bootctl
         if: ${{ github.event_name == 'push' || inputs.crate == 'all' || inputs.crate == 'aegis-bootctl' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
-        run: cargo publish -p aegis-bootctl --locked
+        run: ./scripts/publish-if-new.sh aegis-bootctl

--- a/scripts/publish-if-new.sh
+++ b/scripts/publish-if-new.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# publish-if-new.sh — idempotent `cargo publish` wrapper.
+#
+# Compares the workspace version (from $WORKSPACE_VERSION env or
+# `Cargo.toml [workspace.package].version`) against the highest
+# version of $1 currently on crates.io. If they match, exits 0
+# with a clean "already published" log line. Otherwise runs
+# `cargo publish -p $1 --locked` and propagates its exit code.
+#
+# Why this exists: the trusted-publishing release workflow
+# publishes 6 crates in one job. If a previous re-trigger (or a
+# parallel manual publish) already pushed one of them at the
+# current version, the next run's `cargo publish` for THAT crate
+# returns a 400-ish "version already exists" error and — without
+# this wrapper — fails the step, cascade-skipping all subsequent
+# crate publishes.
+#
+# This wrapper turns the "already at this version" case into a
+# clean no-op so the workflow can keep going. Any OTHER cargo
+# publish failure (network, auth, validation) still fails
+# loudly with the original cargo exit code.
+#
+# Usage:
+#   ./scripts/publish-if-new.sh <crate-name>
+#
+# Exit codes:
+#   0  published OR already at workspace version (idempotent OK)
+#   N  cargo publish failed for any other reason (propagated)
+#   2  usage error (missing crate name argument)
+
+set -euo pipefail
+
+CRATE="${1:-}"
+if [[ -z "$CRATE" ]]; then
+    echo "publish-if-new: usage: $0 <crate-name>" >&2
+    exit 2
+fi
+
+# Workspace version: prefer explicit env (CI sets this) so we don't
+# have to re-parse Cargo.toml inside a runner where awk + grep can
+# get tripped by inline comments.
+if [[ -z "${WORKSPACE_VERSION:-}" ]]; then
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+    WORKSPACE_VERSION="$(
+        awk '
+            /^\[workspace\.package\]/ { f=1; next }
+            f && /^\[/                 { exit }
+            f && /^version = /         {
+                gsub(/^version = "|"$/, "", $0)
+                print
+                exit
+            }
+        ' "$REPO_ROOT/Cargo.toml"
+    )"
+fi
+
+if [[ -z "$WORKSPACE_VERSION" ]]; then
+    echo "publish-if-new: ERROR — could not parse workspace version" >&2
+    exit 2
+fi
+
+# Query crates.io for the current max version of CRATE. The HTTP
+# 404 case (crate not yet published at all) returns "" → we'll
+# always publish. Any other JSON-parse failure also returns "" so
+# we err on the side of attempting the publish.
+LIVE_VERSION="$(
+    curl --silent --fail --show-error \
+        --header 'User-Agent: aegis-boot publish-if-new wrapper' \
+        "https://crates.io/api/v1/crates/${CRATE}" \
+        2>/dev/null \
+        | python3 -c 'import sys, json; d=json.load(sys.stdin); print(d.get("crate", {}).get("max_version", ""))' \
+        2>/dev/null \
+        || echo ""
+)"
+
+echo "publish-if-new: ${CRATE} — workspace=${WORKSPACE_VERSION}, live=${LIVE_VERSION:-<not on registry>}"
+
+if [[ -n "$LIVE_VERSION" && "$LIVE_VERSION" == "$WORKSPACE_VERSION" ]]; then
+    echo "publish-if-new: ${CRATE} v${WORKSPACE_VERSION} is already on crates.io — skipping (idempotent OK)."
+    exit 0
+fi
+
+echo "publish-if-new: publishing ${CRATE} v${WORKSPACE_VERSION}..."
+exec cargo publish -p "$CRATE" --locked


### PR DESCRIPTION
Workflow design bug surfaced by the v0.16.0 publish flow: when one crate is already at the workspace version (e.g. a previous re-trigger succeeded for that crate), `cargo publish` returns 'version already exists' and — without continue-on-error — kills the rest of the job. The first half-successful run is then impossible to re-trigger without manual workaround.

## Fix

- **scripts/publish-if-new.sh** — wrapper that queries crates.io for the crate's live max version and skips with exit 0 + clear log if it matches the workspace version. Real publish failures (auth, network, validation) still fail loudly; only the duplicate-version case is intercepted.
- **.github/workflows/crates-publish.yml** — every `cargo publish -p X --locked` step swapped for `./scripts/publish-if-new.sh X`. Also refreshed the now-obsolete 'requires maintainer approval' comment (reviewer gate lifted earlier today).

## Test plan

- [x] Local: `./scripts/publish-if-new.sh aegis-wire-formats` → "already on crates.io — skipping" (exit 0)
- [ ] CI: re-trigger crates-publish with crate=all on v0.16.0 — wire-formats skips cleanly, remaining 5 publish (assuming TP configs in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)