### PR TITLE
fix(publish): aegis-bootctl path-deps + man-template staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ crates/*/fuzz/artifacts/
 *.cdx.json
 .security-discoveries.jsonl
 test-isos/
+
+# Per-crate staging files copied from workspace root by
+# scripts/publish-if-new.sh ahead of `cargo publish` (and trap-
+# cleaned on script exit). Listed here as belt-and-braces so a
+# trap-skipped local test run can't accidentally land them in a
+# commit.
+crates/aegis-cli/CHANGELOG.md
+crates/aegis-cli/man/

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -12,6 +12,21 @@ license.workspace = true
 repository.workspace = true
 description = "Operator CLI for aegis-boot — flash, add, list, verify"
 
+# Files included in the published tarball. Default cargo behavior
+# packages everything under `crates/aegis-cli/`; we explicitly include
+# the staged man template + CHANGELOG that scripts/publish-if-new.sh
+# copies in pre-publish (build.rs reads them at package-build time
+# via the `first_existing` fallback). Without this, `cargo publish`
+# packages the crate and build.rs panics on missing `../../man/...`.
+include = [
+    "src/**/*",
+    "build.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "man/aegis-boot.1.in",
+    "CHANGELOG.md",
+]
+
 [[bin]]
 name = "aegis-boot"
 path = "src/main.rs"
@@ -42,11 +57,11 @@ docgen = []
 [dependencies]
 serde = { workspace = true }
 serde_json = "1.0"
-iso-probe = { path = "../iso-probe" }
+iso-probe = { path = "../iso-probe", version = "0.16" }
 # Signed attestation manifest types extracted for Phase 4a of #286.
 # This crate is the Rust + JSON Schema source of truth for the
 # on-disk aegis-boot-manifest.json wire format.
-aegis-wire-formats = { path = "../aegis-wire-formats" }
+aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
 # Atomic random-name temp files for write_sidecar_via_sudo's
 # stage-then-copy path. Use the runtime dep (not the dev-dep) so the
 # staging path is not predictable — closes the TOCTOU window semgrep

--- a/crates/aegis-cli/build.rs
+++ b/crates/aegis-cli/build.rs
@@ -24,11 +24,33 @@
 //! rendered man page embedded.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 fn main() {
-    let template_path = Path::new("../../man/aegis-boot.1.in");
-    let changelog_path = Path::new("../../CHANGELOG.md");
+    // Locate the man template + CHANGELOG. In a workspace build,
+    // they live two levels up at `../../man/aegis-boot.1.in` and
+    // `../../CHANGELOG.md`. In a `cargo publish`-packaged tarball,
+    // those parent dirs DON'T exist (the package only contains
+    // this crate's tree), so we fall back to package-local copies
+    // populated via `package.include` in Cargo.toml. See the
+    // include_workspace_inputs.sh helper for the publish-time
+    // staging step.
+    let template_path = first_existing(&[
+        Path::new("../../man/aegis-boot.1.in"),
+        Path::new("man/aegis-boot.1.in"),
+    ])
+    .unwrap_or_else(|| {
+        panic!(
+            "could not locate aegis-boot.1.in template (tried ../../man/ + man/). \
+             For `cargo publish`, ensure the man template + CHANGELOG were staged \
+             into the crate dir before packaging — see scripts/publish-if-new.sh."
+        )
+    });
+    let changelog_path = first_existing(&[
+        Path::new("../../CHANGELOG.md"),
+        Path::new("CHANGELOG.md"),
+    ])
+    .unwrap_or_else(|| PathBuf::from("../../CHANGELOG.md"));
     let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR must be set by cargo");
     let out_path = Path::new(&out_dir).join("aegis-boot.1");
 
@@ -38,17 +60,27 @@ fn main() {
     println!("cargo:rerun-if-changed={}", template_path.display());
     println!("cargo:rerun-if-changed={}", changelog_path.display());
 
-    let template = fs::read_to_string(template_path)
+    let template = fs::read_to_string(&template_path)
         .unwrap_or_else(|e| panic!("read man template {}: {e}", template_path.display()));
 
     let version = std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION must be set");
-    let date = latest_release_date(changelog_path);
+    let date = latest_release_date(&changelog_path);
 
     let rendered = template
         .replace("@VERSION@", &version)
         .replace("@DATE@", &date);
 
     fs::write(&out_path, rendered).unwrap_or_else(|e| panic!("write {}: {e}", out_path.display()));
+}
+
+/// Return the first path from `candidates` that exists, or `None` if
+/// none do. Used by `main` to locate the man template + CHANGELOG
+/// across both the workspace-relative and package-local layouts.
+fn first_existing(candidates: &[&Path]) -> Option<PathBuf> {
+    candidates
+        .iter()
+        .find(|p| p.exists())
+        .map(|p| p.to_path_buf())
 }
 
 /// Parse the top-most released-version date from `CHANGELOG.md`.

--- a/scripts/publish-if-new.sh
+++ b/scripts/publish-if-new.sh
@@ -83,5 +83,27 @@ if [[ -n "$LIVE_VERSION" && "$LIVE_VERSION" == "$WORKSPACE_VERSION" ]]; then
     exit 0
 fi
 
+# Stage workspace-rooted artifacts into per-crate subdirs that need
+# them at package time. `cargo publish` packages ONLY the crate dir,
+# so anything build.rs reads from `../../` must be copied in first.
+# Each crate's build.rs is responsible for falling back to the
+# package-local copy (see crates/aegis-cli/build.rs::first_existing).
+case "$CRATE" in
+    aegis-bootctl)
+        SCRIPT_DIR="${SCRIPT_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)}"
+        REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+        crate_dir="$REPO_ROOT/crates/aegis-cli"
+        # Man-template + CHANGELOG: build.rs reads these to render
+        # the embedded man page. Stage into crate-local paths the
+        # build.rs `first_existing` fallback knows about.
+        mkdir -p "$crate_dir/man"
+        cp "$REPO_ROOT/man/aegis-boot.1.in" "$crate_dir/man/aegis-boot.1.in"
+        cp "$REPO_ROOT/CHANGELOG.md"        "$crate_dir/CHANGELOG.md"
+        # Cleanup on script exit so a workspace re-build after the
+        # publish doesn't see stale staged copies.
+        trap 'rm -rf "$crate_dir/man" "$crate_dir/CHANGELOG.md"' EXIT
+        ;;
+esac
+
 echo "publish-if-new: publishing ${CRATE} v${WORKSPACE_VERSION}..."
-exec cargo publish -p "$CRATE" --locked
+exec cargo publish -p "$CRATE" --locked --allow-dirty


### PR DESCRIPTION
Two issues blocked the v0.16.0 publish of `aegis-bootctl` after the other 5 crates landed via `scripts/publish-if-new.sh`:

## Issue 1 — path-deps missing version

`iso-probe` and `aegis-wire-formats` were declared as `{ path = "../X" }` only. crates.io rejects with "all dependencies must have a version specified when publishing." Added `version = "0.16"` to both — cargo uses path locally, version in the published tarball.

## Issue 2 — `build.rs` reads workspace-rooted files

`man/aegis-boot.1.in` + `CHANGELOG.md` live two levels up. `cargo publish` packages ONLY the crate dir → build.rs panics on "No such file or directory" inside the verify-tarball step.

Three coordinated changes:

- **`build.rs`** — `first_existing()` fallback tries `../../{man,CHANGELOG.md}` (workspace) → `man/` + `CHANGELOG.md` (package-local copies)
- **`Cargo.toml`** — `[package] include = [...]` lists the staged files so they ship in the tarball
- **`scripts/publish-if-new.sh`** — pre-publish staging step copies workspace-root files into the crate dir, publishes with `--allow-dirty`, trap-cleans on exit
- **`.gitignore`** — belt-and-braces against trap-skipped local-test runs accidentally committing staged copies

## Test plan

- [x] `cargo build -p aegis-bootctl` clean
- [x] 459 tests pass
- [x] `./scripts/publish-if-new.sh aegis-bootctl` packages cleanly (upload fails on local — expected, no token)
- [ ] CI re-trigger of crates-publish.yml — wire-formats/iso-parser/iso-probe/kexec-loader/aegis-fitness skip cleanly (already at 0.16.0), aegis-bootctl publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)