### PR TITLE
feat(edition): bump workspace to edition 2024 (closes #396)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/iso-parser/fuzz"]
 # CI's doc-version drift-check (Phase 1c) greps an allowlist of
 # user-facing doc files and fails if any version literal diverges.
 version = "0.16.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/aegis-boot/aegis-boot"

--- a/crates/aegis-cli/build.rs
+++ b/crates/aegis-cli/build.rs
@@ -46,11 +46,9 @@ fn main() {
              into the crate dir before packaging — see scripts/publish-if-new.sh."
         )
     });
-    let changelog_path = first_existing(&[
-        Path::new("../../CHANGELOG.md"),
-        Path::new("CHANGELOG.md"),
-    ])
-    .unwrap_or_else(|| PathBuf::from("../../CHANGELOG.md"));
+    let changelog_path =
+        first_existing(&[Path::new("../../CHANGELOG.md"), Path::new("CHANGELOG.md")])
+            .unwrap_or_else(|| PathBuf::from("../../CHANGELOG.md"));
     let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR must be set by cargo");
     let out_path = Path::new(&out_dir).join("aegis-boot.1");
 

--- a/crates/aegis-cli/src/attest.rs
+++ b/crates/aegis-cli/src/attest.rs
@@ -45,7 +45,7 @@ use crate::detect::Drive;
 // consumers of the on-disk attestation JSON depend on
 // `aegis-wire-formats` directly with a JSON Schema pin.
 pub use aegis_wire_formats::{
-    Attestation, HostInfo, IsoRecord, TargetInfo, ATTESTATION_SCHEMA_VERSION as SCHEMA_VERSION,
+    ATTESTATION_SCHEMA_VERSION as SCHEMA_VERSION, Attestation, HostInfo, IsoRecord, TargetInfo,
 };
 
 /// One-line summary of the attestation matching a mounted stick. Used
@@ -314,7 +314,9 @@ fn print_help() {
     println!();
     println!("EXAMPLES:");
     println!("  aegis-boot attest list");
-    println!("  aegis-boot attest show ~/.local/share/aegis-boot/attestations/abc123-2026-04-16T12-34-56Z.json");
+    println!(
+        "  aegis-boot attest show ~/.local/share/aegis-boot/attestations/abc123-2026-04-16T12-34-56Z.json"
+    );
     println!("  aegis-boot attest list --json | jq '.attestations[].flashed_at'");
 }
 
@@ -744,6 +746,14 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
+    // Edition-2024 made std::env::set_var / remove_var unsafe; some
+    // tests in this module mutate process env to exercise the
+    // data_dir() resolution chain (XDG_DATA_HOME / HOME / sudo-aware
+    // fallbacks). The mutations are serialized via ENV_MUTEX, so the
+    // "not safe across threads" hazard the unsafe requirement is
+    // guarding against doesn't apply here. Scoped allow so the
+    // production-code unsafe_code = "deny" stays intact.
+    #![allow(unsafe_code)]
     use super::*;
 
     #[test]
@@ -817,12 +827,15 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var_os("XDG_DATA_HOME");
-        std::env::set_var("XDG_DATA_HOME", "/tmp/aegis-test-xdg-data");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/aegis-test-xdg-data") };
         let p = data_dir();
         assert_eq!(p, PathBuf::from("/tmp/aegis-test-xdg-data/aegis-boot"));
         match prev {
-            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-            None => std::env::remove_var("XDG_DATA_HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("XDG_DATA_HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("XDG_DATA_HOME") },
         }
     }
 
@@ -833,20 +846,26 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_xdg = std::env::var_os("XDG_DATA_HOME");
         let prev_home = std::env::var_os("HOME");
-        std::env::remove_var("XDG_DATA_HOME");
-        std::env::set_var("HOME", "/tmp/aegis-test-home2");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_DATA_HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("HOME", "/tmp/aegis-test-home2") };
         let p = data_dir();
         assert_eq!(
             p,
             PathBuf::from("/tmp/aegis-test-home2/.local/share/aegis-boot")
         );
         match prev_xdg {
-            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-            None => std::env::remove_var("XDG_DATA_HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("XDG_DATA_HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("XDG_DATA_HOME") },
         }
         match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("HOME") },
         }
     }
 

--- a/crates/aegis-cli/src/bin/constants_docgen.rs
+++ b/crates/aegis-cli/src/bin/constants_docgen.rs
@@ -357,8 +357,7 @@ mod tests {
 
     #[test]
     fn apply_markers_leaves_unknown_name_body_untouched() {
-        let input =
-            "<!-- constants:BEGIN:UNKNOWN_MARKER -->dont-touch<!-- constants:END:UNKNOWN_MARKER -->";
+        let input = "<!-- constants:BEGIN:UNKNOWN_MARKER -->dont-touch<!-- constants:END:UNKNOWN_MARKER -->";
         let (out, n) = apply_markers(input, &fixture_markers());
         assert_eq!(n, 0);
         assert_eq!(out, input, "unknown marker body should be preserved");

--- a/crates/aegis-cli/src/bug_report.rs
+++ b/crates/aegis-cli/src/bug_report.rs
@@ -254,7 +254,7 @@ fn parse_args(argv: &[String]) -> Result<Args, String> {
                     other => {
                         return Err(format!(
                             "--format must be 'markdown' or 'json', got '{other}'"
-                        ))
+                        ));
                     }
                 });
             }
@@ -495,11 +495,7 @@ fn collect_storage() -> StorageSection {
             }
             acc.push_str(chunk.trim_end());
         }
-        if acc.is_empty() {
-            None
-        } else {
-            Some(acc)
-        }
+        if acc.is_empty() { None } else { Some(acc) }
     };
     StorageSection {
         removable_drives,

--- a/crates/aegis-cli/src/compat.rs
+++ b/crates/aegis-cli/src/compat.rs
@@ -388,7 +388,9 @@ fn report_my_machine_miss(json_mode: bool) -> Result<(), u8> {
         eprintln!(
             "  On Linux, verify /sys/class/dmi/id/ has populated sys_vendor and product_name."
         );
-        eprintln!("  On non-Linux hosts, this flag is not supported — use `aegis-boot compat <query>` instead.");
+        eprintln!(
+            "  On non-Linux hosts, this flag is not supported — use `aegis-boot compat <query>` instead."
+        );
     }
     Err(2)
 }

--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -29,7 +29,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
-use crate::catalog::{find_entry, Entry, SbStatus};
+use crate::catalog::{Entry, SbStatus, find_entry};
 
 /// Entry point for `aegis-boot fetch [--out DIR] [--no-gpg] <slug>`.
 pub fn run(args: &[String]) -> ExitCode {
@@ -504,6 +504,12 @@ fn print_success(entry: &Entry, dest: &Path, iso_filename: &str) {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
+    // Edition-2024 made std::env::set_var / remove_var unsafe; some
+    // tests mutate XDG_CACHE_HOME + HOME to exercise cache-dir
+    // resolution. Serialized via ENV_MUTEX, so the "not safe across
+    // threads" unsafety requirement doesn't apply. Scoped allow so
+    // production-code unsafe_code = "deny" stays intact.
+    #![allow(unsafe_code)]
     use super::*;
 
     #[test]
@@ -575,15 +581,18 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
         // SAFETY: ENV_MUTEX serializes env-mutating tests in this module.
-        std::env::set_var("XDG_CACHE_HOME", "/tmp/aegis-test-xdg");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_CACHE_HOME", "/tmp/aegis-test-xdg") };
         let p = default_cache_dir("ubuntu-24.04-live-server");
         assert_eq!(
             p,
             PathBuf::from("/tmp/aegis-test-xdg/aegis-boot/ubuntu-24.04-live-server")
         );
         match prev_xdg {
-            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
-            None => std::env::remove_var("XDG_CACHE_HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("XDG_CACHE_HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("XDG_CACHE_HOME") },
         }
     }
 
@@ -594,20 +603,26 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
         let prev_home = std::env::var_os("HOME");
-        std::env::remove_var("XDG_CACHE_HOME");
-        std::env::set_var("HOME", "/tmp/aegis-test-home");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("HOME", "/tmp/aegis-test-home") };
         let p = default_cache_dir("alpine-3.20-standard");
         assert_eq!(
             p,
             PathBuf::from("/tmp/aegis-test-home/.cache/aegis-boot/alpine-3.20-standard")
         );
         match prev_xdg {
-            Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
-            None => std::env::remove_var("XDG_CACHE_HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("XDG_CACHE_HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("XDG_CACHE_HOME") },
         }
         match prev_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            None => unsafe { std::env::remove_var("HOME") },
         }
     }
 }

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -481,7 +481,9 @@ fn print_help() {
     println!();
     let current_ver = env!("CARGO_PKG_VERSION");
     println!("USAGE:");
-    println!("  aegis-boot fetch-image                               # latest release, cosign auto-verify");
+    println!(
+        "  aegis-boot fetch-image                               # latest release, cosign auto-verify"
+    );
     println!(
         "  aegis-boot fetch-image --version v{current_ver}             # pin to a specific release"
     );
@@ -713,9 +715,11 @@ mod tests {
             basename.starts_with("aegis-boot-abcdef01"),
             "got {basename}"
         );
-        assert!(std::path::Path::new(&basename)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("img")));
+        assert!(
+            std::path::Path::new(&basename)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("img"))
+        );
     }
 
     #[test]

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -603,8 +603,8 @@ fn flash_direct_install(drive: &Drive, out_dir: &Path) -> Result<(), FlashError>
     // as part of the stage-5 grouping for #352 UX-3; the import stays
     // scoped there.
     use crate::direct_install::{
-        format_data_partition, format_esp, partition_stick, render_grub_cfg, stage_esp,
-        EspStagingSources,
+        EspStagingSources, format_data_partition, format_esp, partition_stick, render_grub_cfg,
+        stage_esp,
     };
 
     // #352 UX-2: pre-flight deps gate. Runs BEFORE any destructive
@@ -731,8 +731,8 @@ fn write_manifest_stage(
     work_dir: &Path,
 ) -> Result<(), FlashError> {
     use crate::direct_install_manifest::{
-        build_manifest, compute_esp_file_hashes, read_device_identity, serialize_manifest,
-        MANIFEST_ESP_PATH, MANIFEST_SIG_ESP_PATH,
+        MANIFEST_ESP_PATH, MANIFEST_SIG_ESP_PATH, build_manifest, compute_esp_file_hashes,
+        read_device_identity, serialize_manifest,
     };
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1795,7 +1795,9 @@ pub(crate) enum FlashError {
     /// reachable) without `--image`, so there's no source for the
     /// image. #282. Carries the target device path so suggestions
     /// can be rendered with the exact `/dev/sdX` interpolation.
-    #[error("no image source available (not in a repo checkout and --image not supplied) for device {0}")]
+    #[error(
+        "no image source available (not in a repo checkout and --image not supplied) for device {0}"
+    )]
     NoImageSource(String),
     /// Direct-install pipeline (#274 Phase 3) failed at a specific
     /// stage. The typed `stage` lets test assertions and operator
@@ -2017,7 +2019,7 @@ impl crate::userfacing::UserFacing for FlashError {
 /// comparison. No sudo needed — the image is a regular file the
 /// operator owns.
 fn precompute_image_prefix_hash(img_path: &Path) -> Result<String, String> {
-    use crate::readback::{sha256_of_first_bytes, DEFAULT_READBACK_BYTES};
+    use crate::readback::{DEFAULT_READBACK_BYTES, sha256_of_first_bytes};
     let mut f =
         std::fs::File::open(img_path).map_err(|e| format!("open {}: {e}", img_path.display()))?;
     let (hex, consumed) = sha256_of_first_bytes(&mut f, DEFAULT_READBACK_BYTES)
@@ -2036,7 +2038,7 @@ fn precompute_image_prefix_hash(img_path: &Path) -> Result<String, String> {
 /// to read since the device is root-owned; the dd output is held in
 /// memory (~64 MB) and hashed in-process via `sha256_of_first_bytes`.
 fn readback_verify_device(device: &Path, expected_hex: &str) -> Result<(), String> {
-    use crate::readback::{sha256_of_first_bytes, DEFAULT_READBACK_BYTES};
+    use crate::readback::{DEFAULT_READBACK_BYTES, sha256_of_first_bytes};
     println!(
         "Reading back first {} MB of {} for verification...",
         DEFAULT_READBACK_BYTES / 1024 / 1024,

--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -1399,7 +1399,7 @@ mod tests {
 
     #[test]
     fn add_error_fat32_ceiling_renders_numbered_list_with_both_reflash_recipes() {
-        use crate::userfacing::{render_string, UserFacing};
+        use crate::userfacing::{UserFacing, render_string};
         let err = AddError::Fat32CeilingExceeded {
             detail: "Win11_25H2.iso is 7.9 GiB — exceeds FAT32's 4 GiB per-file ceiling. \
                      The AEGIS_ISOS partition is formatted as vfat, which cannot store \

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -22,7 +22,16 @@
 //! manually. The binary is named `aegis-boot` so operators type
 //! `aegis-boot flash /dev/sdX` etc.
 
-#![forbid(unsafe_code)]
+// Workspace-level `unsafe_code = "deny"` (Cargo.toml [workspace.lints])
+// already denies `unsafe` everywhere. Binary-level `#![forbid]` was
+// previously redundant AND hostile to narrow test-only allowlists —
+// edition 2024 made `std::env::set_var` + `remove_var` unsafe, and
+// the existing env-mutating tests in `attest.rs` + `fetch.rs`
+// legitimately need to poke process env. Downgrading `forbid` → `deny`
+// lets those specific test-site `#[allow(unsafe_code)]` tags compile
+// while keeping production-path `unsafe` denied. No new unsafe blocks
+// are introduced in non-test code.
+#![deny(unsafe_code)]
 
 mod attest;
 mod bug_report;

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -1104,7 +1104,7 @@ mod tests {
 
     #[test]
     fn update_error_ineligible_renders_structured_block_with_numbered_options() {
-        use crate::userfacing::{render_string, UserFacing};
+        use crate::userfacing::{UserFacing, render_string};
         let err = UpdateError::Ineligible {
             reason: "partition 2 label is \"\" — expected AEGIS_ISOS. \
                      This stick was not flashed by aegis-boot."

--- a/crates/aegis-cli/src/userfacing.rs
+++ b/crates/aegis-cli/src/userfacing.rs
@@ -93,10 +93,10 @@ pub trait UserFacing: std::error::Error {
 ///
 /// Returns the underlying formatter error if writing fails.
 #[allow(dead_code)] // Sibling of `render_string`. No `Display` impl uses
-                    // this yet; kept so the two render paths stay in
-                    // sync via the `display_via_render_matches_render_string`
-                    // test and become importable when `Display` integration
-                    // appears on an error wrapper.
+// this yet; kept so the two render paths stay in
+// sync via the `display_via_render_matches_render_string`
+// test and become importable when `Display` integration
+// appears on an error wrapper.
 pub fn render(err: &dyn UserFacing, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if let Some(code) = err.code() {
         writeln!(f, "error[{code}]: {}", err.summary())?;

--- a/crates/aegis-cli/src/verify.rs
+++ b/crates/aegis-cli/src/verify.rs
@@ -142,11 +142,7 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
 
     // Exit code: any Mismatch, Forged, or Unreadable is a fail. NotPresent
     // alone is OK — see module doc for the rationale.
-    if tally.any_failure() {
-        Err(1)
-    } else {
-        Ok(())
-    }
+    if tally.any_failure() { Err(1) } else { Ok(()) }
 }
 
 /// Empty-stick JSON envelope. Stable `schema_version=1`; every field

--- a/crates/aegis-wire-formats/src/lib.rs
+++ b/crates/aegis-wire-formats/src/lib.rs
@@ -1650,9 +1650,11 @@ mod tests {
                 source: "s".to_string(),
             },
         };
-        assert!(serde_json::to_string(&m)
-            .expect("ok")
-            .contains("\"verdict\":\"Mismatch\""));
+        assert!(
+            serde_json::to_string(&m)
+                .expect("ok")
+                .contains("\"verdict\":\"Mismatch\"")
+        );
 
         let u = VerifyEntry {
             name: "x".to_string(),
@@ -1661,17 +1663,21 @@ mod tests {
                 reason: "r".to_string(),
             },
         };
-        assert!(serde_json::to_string(&u)
-            .expect("ok")
-            .contains("\"verdict\":\"Unreadable\""));
+        assert!(
+            serde_json::to_string(&u)
+                .expect("ok")
+                .contains("\"verdict\":\"Unreadable\"")
+        );
 
         let n = VerifyEntry {
             name: "x".to_string(),
             verdict: VerifyVerdict::NotPresent,
         };
-        assert!(serde_json::to_string(&n)
-            .expect("ok")
-            .contains("\"verdict\":\"NotPresent\""));
+        assert!(
+            serde_json::to_string(&n)
+                .expect("ok")
+                .contains("\"verdict\":\"NotPresent\"")
+        );
     }
 
     fn sample_update_eligible() -> UpdateReport {

--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -1521,9 +1521,11 @@ mod tests {
         // Should find at least the Arch entry (might also find via other layouts that scan /boot)
         assert!(!entries.is_empty());
         assert!(entries.iter().any(|e| e.distribution == Distribution::Arch));
-        assert!(entries
-            .iter()
-            .any(|e| e.kernel.to_string_lossy().contains("vmlinuz")));
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.kernel.to_string_lossy().contains("vmlinuz"))
+        );
     }
 
     #[tokio::test]
@@ -1538,9 +1540,11 @@ mod tests {
             .unwrap();
 
         assert!(!entries.is_empty());
-        assert!(entries
-            .iter()
-            .any(|e| e.distribution == Distribution::Debian));
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.distribution == Distribution::Debian)
+        );
     }
 
     #[tokio::test]
@@ -1555,9 +1559,11 @@ mod tests {
             .unwrap();
 
         assert!(!entries.is_empty());
-        assert!(entries
-            .iter()
-            .any(|e| e.distribution == Distribution::Fedora));
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.distribution == Distribution::Fedora)
+        );
     }
 
     #[test]

--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -39,12 +39,12 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 pub use iso_parser::{BootEntry, Distribution, IsoError};
-pub use minisign::{verify_iso_signature, SignatureVerification};
+pub use minisign::{SignatureVerification, verify_iso_signature};
 pub use sidecar::{
-    load_sidecar, sidecar_path_for, to_toml as sidecar_to_toml, write_sidecar, IsoSidecar,
-    SidecarError,
+    IsoSidecar, SidecarError, load_sidecar, sidecar_path_for, to_toml as sidecar_to_toml,
+    write_sidecar,
 };
-pub use signature::{verify_iso_hash, verify_iso_hash_with_progress, HashVerification};
+pub use signature::{HashVerification, verify_iso_hash, verify_iso_hash_with_progress};
 
 /// Metadata for a single discovered ISO. Paths are relative to the (now
 /// unmounted) ISO root and become absolute once handed to [`prepare`].

--- a/crates/kexec-loader/src/syscall.rs
+++ b/crates/kexec-loader/src/syscall.rs
@@ -8,7 +8,7 @@
 use std::ffi::CStr;
 use std::io;
 
-use crate::{classify_errno, KexecError};
+use crate::{KexecError, classify_errno};
 
 // From `<linux/kexec.h>`. Hard-coded rather than pulled from a crate so the
 // trusted-path surface has zero transitive dependencies.

--- a/crates/kexec-loader/tests/dry_run_integration.rs
+++ b/crates/kexec-loader/tests/dry_run_integration.rs
@@ -26,7 +26,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use kexec_loader::{load_dry, KexecRequest};
+use kexec_loader::{KexecRequest, load_dry};
 
 fn integration_enabled() -> bool {
     std::env::var("AEGIS_INTEGRATION_ROOT").is_ok()

--- a/crates/rescue-tui/src/failure_log.rs
+++ b/crates/rescue-tui/src/failure_log.rs
@@ -27,7 +27,7 @@
 
 use std::path::{Path, PathBuf};
 
-use aegis_wire_formats::{FailureMicroreport, FAILURE_MICROREPORT_SCHEMA_VERSION};
+use aegis_wire_formats::{FAILURE_MICROREPORT_SCHEMA_VERSION, FailureMicroreport};
 use sha2::{Digest, Sha256};
 
 /// Tmpfs root where microreports land during a failure-in-flight.
@@ -464,19 +464,22 @@ mod tests {
 
         // Both json files should now be in dst, the txt file should
         // still be in src.
-        assert!(dst
-            .path()
-            .join("2026-04-20T12:00:00Z-abc123.json")
-            .is_file());
-        assert!(dst
-            .path()
-            .join("2026-04-20T12:05:00Z-def456.json")
-            .is_file());
+        assert!(
+            dst.path()
+                .join("2026-04-20T12:00:00Z-abc123.json")
+                .is_file()
+        );
+        assert!(
+            dst.path()
+                .join("2026-04-20T12:05:00Z-def456.json")
+                .is_file()
+        );
         assert!(src.path().join("unrelated.txt").is_file());
-        assert!(!src
-            .path()
-            .join("2026-04-20T12:00:00Z-abc123.json")
-            .is_file());
+        assert!(
+            !src.path()
+                .join("2026-04-20T12:00:00Z-abc123.json")
+                .is_file()
+        );
     }
 
     #[test]

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -28,10 +28,10 @@ use crossterm::cursor::MoveTo;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use crossterm::execute;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen,
+    Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
 
 use crate::state::{AppState, Screen};
 

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -4,14 +4,14 @@
 //! [`ratatui::backend::Backend`]. Tested with `TestBackend`.
 
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph, Wrap},
-    Frame,
 };
 
-use crate::state::{quirks_summary, AppState, Screen, SecureBootStatus};
+use crate::state::{AppState, Screen, SecureBootStatus, quirks_summary};
 use crate::theme::Theme;
 
 /// Render the current frame for the given state.
@@ -1220,8 +1220,8 @@ impl DistributionLabel for iso_probe::DiscoveredIso {
 mod tests {
     use super::*;
     use iso_probe::{Distribution, Quirk};
-    use ratatui::backend::TestBackend;
     use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
     use std::path::PathBuf;
 
     // ---- #274 Phase 6c: subfolder-prefix rendering ------------------------


### PR DESCRIPTION
## Summary

Bumps the workspace from Rust edition 2021 to 2024 (stabilized in 1.85.0, our MSRV). Closes #396.

## Approach

1. **Automated migrations via `cargo fix --edition`** on edition 2021 (to let cargo emit the rewrites), then flipped `[workspace.package] edition = "2024"`. 18 env-mutation test call-sites in `attest.rs` + `fetch.rs` got wrapped in `unsafe { ... }` — edition 2024 marks `std::env::set_var` + `remove_var` as unsafe.
2. **`#![forbid(unsafe_code)]` → `#![deny(unsafe_code)]`** on `crates/aegis-cli/src/main.rs`. Workspace-level `unsafe_code = "deny"` already denies `unsafe` everywhere; the binary-level `forbid` was redundant AND blocked narrow test-only `#[allow]`s. Production code path still denies `unsafe` — the change only enables scoped allows in test modules.
3. **Scoped `#![allow(unsafe_code)]`** in the `tests` modules of `attest.rs` + `fetch.rs` with inline rationale: the env mutations are serialized via `ENV_MUTEX`, so the 'not safe across threads' hazard the 2024 unsafety requirement is guarding against doesn't apply here.

## No new unsafe in production code

The workspace lint still prevents any `unsafe` outside `crates/kexec-loader/` (where the kexec FFI lives, documented + miri-checked). Test-only allows don't compile into the shipped binary.

## Validation

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --locked` — 714 tests pass across 13 crates
- `cli-docgen --check` — OK
- `constants-docgen --check` — OK
- `schema-docgen --check` — OK
- `check-doc-version.sh` — OK (still at 0.16.0)

## Closes

- #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)