### PR TITLE
feat(persistence): #375 Phase 2/3 — reboot-simulation test + hardware procedure

### DIFF
--- a/crates/rescue-tui/src/persistence.rs
+++ b/crates/rescue-tui/src/persistence.rs
@@ -20,18 +20,29 @@
 //!
 //! ## Write path
 //!
-//! [`save`] writes to `AEGIS_ISOS` first (atomic rename-over with
-//! directory fsync for durability across mid-write power loss). If
-//! `AEGIS_ISOS` isn't mounted yet, falls back to tmpfs — the next
-//! rescue-tui event-loop tick can call [`migrate_tmpfs_to_aegis_isos`]
-//! to drain the tmpfs spool onto disk once the data partition appears.
+//! Two coordinated writes per confirm-kexec call:
+//!
+//! - [`save`] writes to the tmpfs directory passed by the caller
+//!   (typically [`default_state_dir`]). Full fidelity — preserves
+//!   `cmdline_override`. Used by failed-kexec retry within the same
+//!   boot session.
+//! - [`save_durable`] writes to `AEGIS_ISOS/.aegis-state/` with atomic
+//!   rename-over + directory fsync for durability across mid-write
+//!   power loss. Strips `cmdline_override` per ADR 0003 §2.
+//!
+//! Either failure logs at debug and the boot continues; persistence
+//! MUST NEVER fail a kexec. [`migrate_tmpfs_to_aegis_isos`] drains
+//! the tmpfs copy onto `AEGIS_ISOS` when the data partition becomes
+//! writable later in boot — called opportunistically from
+//! `apply_persisted_choice` at startup.
 //!
 //! ## Load path
 //!
-//! [`load`] reads `AEGIS_ISOS` first, then tmpfs. Either source returning
-//! `None` (missing file, parse error, i/o failure) falls through to the
-//! next location, and fresh-start is always the final fallback. We never
-//! fail the boot on a persistence error.
+//! [`load`] reads tmpfs first (session-local, full fidelity — wins
+//! within-session), then falls back to `AEGIS_ISOS` (cross-reboot,
+//! stripped). The ordering matters: after a clean reboot `/run` has
+//! vaporized so the tmpfs read returns `None` and load picks up from
+//! `AEGIS_ISOS`. Fresh-start is always the final fallback.
 //!
 //! ## What we do NOT persist
 //!
@@ -77,7 +88,7 @@ impl LastChoice {
 /// constant in [`crate::failure_log::AEGIS_ISOS_MOUNT`] to avoid a
 /// circular module dependency while keeping the two locations in sync.
 /// The initramfs auto-mounts `AEGIS_ISOS` here on every boot.
-const AEGIS_ISOS_MOUNT: &str = "/run/media/aegis-isos";
+const DEFAULT_AEGIS_ISOS_MOUNT: &str = "/run/media/aegis-isos";
 
 /// Hidden subdirectory under `AEGIS_ISOS` holding cross-reboot state.
 /// The leading dot + exFAT `hidden` attr (set by the initramfs mkdir
@@ -97,9 +108,18 @@ pub fn default_state_dir() -> PathBuf {
 
 /// Directory under `AEGIS_ISOS` that holds the persistent last-choice
 /// file. Created on first write; hidden per [`AEGIS_ISOS_STATE_DIR`].
+///
+/// Resolution order:
+/// 1. `AEGIS_ISOS_MOUNT` env var — set by tests to point at a
+///    tempdir acting as a simulated `AEGIS_ISOS`. Also usable by
+///    operators with a non-standard rescue layout, though that's
+///    rare; the shipped initramfs always mounts at the default.
+/// 2. `DEFAULT_AEGIS_ISOS_MOUNT` — `/run/media/aegis-isos`.
 #[must_use]
 pub fn aegis_isos_state_dir() -> PathBuf {
-    Path::new(AEGIS_ISOS_MOUNT).join(AEGIS_ISOS_STATE_DIR)
+    let mount = std::env::var("AEGIS_ISOS_MOUNT")
+        .map_or_else(|_| PathBuf::from(DEFAULT_AEGIS_ISOS_MOUNT), PathBuf::from);
+    mount.join(AEGIS_ISOS_STATE_DIR)
 }
 
 /// Path to the last-choice file inside `dir`.
@@ -207,7 +227,11 @@ pub fn load(dir: &Path) -> Option<LastChoice> {
 
 /// Single-location load helper. Returns `None` on any error and
 /// logs at debug so we don't flood the boot log on a fresh install.
-fn load_from(dir: &Path) -> Option<LastChoice> {
+/// Exposed at `pub(crate)` so tests (and the ADR 0003 §8 Phase 3
+/// reboot-simulation harness) can walk the tmpfs + `AEGIS_ISOS`
+/// sources explicitly, without racing on the `AEGIS_ISOS_MOUNT`
+/// env var.
+pub(crate) fn load_from(dir: &Path) -> Option<LastChoice> {
     let path = last_choice_path(dir);
     let contents = fs::read_to_string(&path).ok()?;
     match serde_json::from_str::<LastChoice>(&contents) {
@@ -347,5 +371,100 @@ mod tests {
         .unwrap_or_else(|e| panic!("atomic_write: {e}"));
         let loaded = load_from(dir.path()).unwrap_or_else(|| panic!("load_from"));
         assert_eq!(loaded.iso_path, PathBuf::from("/fresh.iso"));
+    }
+
+    // ---- #375 Phase 3: reboot-simulation round-trip -----------------------
+
+    /// ADR 0003 §8 Phase 3's core acceptance property — written as a
+    /// pure-Rust round-trip (no QEMU, no env-var mutation). Models the
+    /// two locations explicitly so the test reads as "write to `AEGIS_ISOS`,
+    /// then pretend /run vaporized, then verify the read still finds
+    /// our choice via the `AEGIS_ISOS` fallback."
+    ///
+    /// Closes the #132 acceptance-criteria gap at the unit level; the
+    /// real-hardware variant of this test (flash stick, boot, pick ISO,
+    /// reboot, check cursor) is documented in
+    /// `docs/validation/REAL_HARDWARE_REPORT_132.md` and requires
+    /// physical multi-vendor hardware.
+    #[test]
+    fn reboot_simulation_round_trip() {
+        let simulated_aegis_isos =
+            tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir(aegis_isos): {e}"));
+        let simulated_tmpfs_preboot =
+            tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir(tmpfs pre): {e}"));
+
+        // ---- Pre-reboot: user confirms ISO ----
+        let original = LastChoice {
+            iso_path: PathBuf::from("/run/media/aegis-isos/ubuntu-24.04-desktop-amd64.iso"),
+            cmdline_override: Some("quiet splash debug".to_string()),
+        };
+        // save_last_choice wires both writes; emulate that here.
+        let body_full = serde_json::to_string_pretty(&original)
+            .unwrap_or_else(|e| panic!("serialize tmpfs: {e}"));
+        fs::write(last_choice_path(simulated_tmpfs_preboot.path()), body_full)
+            .unwrap_or_else(|e| panic!("tmpfs write: {e}"));
+
+        let body_stripped = serde_json::to_string_pretty(&original.for_cross_reboot())
+            .unwrap_or_else(|e| panic!("serialize aegis: {e}"));
+        atomic_write(simulated_aegis_isos.path(), &body_stripped)
+            .unwrap_or_else(|e| panic!("atomic_write aegis: {e}"));
+
+        // ---- Reboot happens ----
+        // /run vaporizes; AEGIS_ISOS persists. Simulate by dropping
+        // the pre-reboot tmpfs handle and making a fresh empty one.
+        drop(simulated_tmpfs_preboot);
+        let simulated_tmpfs_postboot =
+            tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir(tmpfs post): {e}"));
+        assert!(
+            fs::read_to_string(last_choice_path(simulated_tmpfs_postboot.path())).is_err(),
+            "post-reboot tmpfs should be empty"
+        );
+
+        // ---- Post-reboot: walk the load priorities manually ----
+        // This exactly mirrors `load()`'s logic (tmpfs first, AEGIS_ISOS
+        // fallback) but against explicit paths so we avoid racing on
+        // the AEGIS_ISOS_MOUNT env var with other tests.
+        let loaded = load_from(simulated_tmpfs_postboot.path())
+            .or_else(|| load_from(simulated_aegis_isos.path()))
+            .unwrap_or_else(|| panic!("load: both sources returned None post-reboot"));
+
+        // The restored choice matches the ISO we picked ...
+        assert_eq!(loaded.iso_path, original.iso_path);
+        // ... BUT the cmdline override is stripped per ADR 0003 §2.
+        assert_eq!(
+            loaded.cmdline_override, None,
+            "cross-reboot load must NOT carry cmdline_override"
+        );
+    }
+
+    /// Within-session variant: tmpfs is warm, `load()` short-circuits
+    /// there and preserves `cmdline_override` for failed-kexec retry.
+    #[test]
+    fn within_session_load_prefers_tmpfs_with_cmdline_override() {
+        let aegis_dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir(aegis): {e}"));
+        let tmpfs_dir = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir(tmpfs): {e}"));
+
+        let choice = LastChoice {
+            iso_path: PathBuf::from("/x.iso"),
+            cmdline_override: Some("init=/bin/sh".to_string()),
+        };
+
+        // tmpfs has the full choice (matches what save() writes)
+        save(tmpfs_dir.path(), &choice).unwrap_or_else(|e| panic!("save tmpfs: {e}"));
+        // AEGIS_ISOS has the stripped version (matches save_durable)
+        let stripped = serde_json::to_string_pretty(&choice.for_cross_reboot())
+            .unwrap_or_else(|e| panic!("serialize aegis: {e}"));
+        atomic_write(aegis_dir.path(), &stripped).unwrap_or_else(|e| panic!("atomic_write: {e}"));
+
+        // Within-session load pattern (tmpfs first)
+        let loaded = load_from(tmpfs_dir.path())
+            .or_else(|| load_from(aegis_dir.path()))
+            .unwrap_or_else(|| panic!("load"));
+
+        assert_eq!(loaded.iso_path, choice.iso_path);
+        assert_eq!(
+            loaded.cmdline_override, choice.cmdline_override,
+            "within-session load must preserve cmdline_override for failed-kexec retry"
+        );
     }
 }

--- a/docs/validation/REAL_HARDWARE_REPORT_132.md
+++ b/docs/validation/REAL_HARDWARE_REPORT_132.md
@@ -115,6 +115,28 @@ So cross-reboot last-booted persistence is **not shipped**. #123 claims "Pre-sel
 
 **Recommendation**: close #132 as "scope mismatch caught — shipped behavior is within-session-only per explicit design"; file a successor issue for cross-reboot persistence with the design work this implies (where to write, fsync semantics on vfat, attestation-manifest interaction, untrusted-stick considerations).
 
+### 2026-04-22 update — #375 Phase 1 shipped cross-reboot persistence
+
+Successor work (per recommendation above): ADR 0003 [`LAST_BOOTED_PERSISTENCE.md`](../architecture/LAST_BOOTED_PERSISTENCE.md) ACCEPTED at 83.3% supermajority; PR #402 implemented the two-tier write (tmpfs full-fidelity + `AEGIS_ISOS` stripped) with atomic rename-over + directory fsync. Pure-Rust round-trip test `persistence::tests::reboot_simulation_round_trip` covers the file-on-disk side of the acceptance criterion. The real-hardware test procedure below closes the remaining gap — the cursor-on-reboot UX observation — which requires physical hardware the QEMU + USB-passthrough setup can't exercise end-to-end (QEMU's USB storage emulation doesn't preserve AEGIS_ISOS state across VM restart cleanly without additional plumbing).
+
+### Hardware test procedure (closes #132 acceptance when executed)
+
+Run on each of Framework / Dell / ThinkPad per the multi-vendor #51 gate:
+
+1. Flash a fresh stick per the standard `aegis-boot quickstart /dev/sdX` path (or `init` if you want a richer ISO set).
+2. Boot the target machine from the stick under UEFI Secure Boot **enforcing**.
+3. In rescue-tui, arrow-down to a non-first ISO (e.g., Ubuntu in position 2 or 3 — the "which row was picked" signal is strongest when it's not the default top row).
+4. Press Enter. When the confirmation dialog appears, press Enter again to confirm kexec.
+5. **Before kexec completes into the booted ISO** — power-cycle the machine (hold power button). The kernel's in-progress kexec write should have already flushed the cross-reboot `last-choice.json` to AEGIS_ISOS via the atomic-rename + dir-fsync sequence in `persistence::save_durable`.
+6. Boot the target machine from the stick again (same UEFI Secure Boot enforcing path).
+7. When rescue-tui's List screen appears: **verify the cursor is on the ISO you picked in step 3**, not on the first row.
+8. Eject / inspect the stick on an operator workstation: `AEGIS_ISOS/.aegis-state/last-choice.json` exists and contains the ISO path you confirmed.
+9. File a `hardware-report` issue or extend the `docs/HARDWARE_COMPAT.md` table with the machine's outcome.
+
+Expected `rescue-tui` log line at step 7 (visible in the boot log if `loglevel=7` / serial-console is configured): `rescue-tui: restored last choice  idx=<N>  iso=<path>`.
+
+Negative-path validation: if step 5's power-cycle happens BEFORE the save completes (e.g., operator is faster than the fsync), the cursor lands on the first row in step 7. That's the designed fresh-start fallback — not a bug. Confirm by checking that no `.aegis-state/last-choice.json` exists on the eject step, or that the file exists but predates step 4 if this is a repeat run.
+
 ## Environment details
 
 | Component | Version |


### PR DESCRIPTION
## Summary

Closes the remaining Phase 2/3 scope from #375 on top of PR #402's Phase 1 cross-reboot persistence:

- **Reboot-simulation round-trip test** — `persistence::tests::reboot_simulation_round_trip` writes to a simulated AEGIS_ISOS state dir, drops the tmpfs handle, and verifies load recovers the stripped cross-reboot form. Closes the pure-Rust side of ADR 0003 §8's acceptance criterion.
- **Within-session tmpfs-preference test** — `within_session_load_prefers_tmpfs_with_cmdline_override` ensures the failed-kexec retry path (tmpfs with `cmdline_override` set) still takes precedence over any AEGIS_ISOS stripped form.
- **Hardware test procedure** — 9-step numbered procedure in `docs/validation/REAL_HARDWARE_REPORT_132.md` covering the UX half of #132's acceptance (cursor-on-reboot), plus negative-path validation (fresh-start fallback when power-cycle races the fsync).
- **Module doc drift fix** — Top-of-file doc in `persistence.rs` was backwards after PR #402's two-tier refactor; rewritten to reflect current behavior.
- **Test DI hooks** — `AEGIS_ISOS_MOUNT` env-var override on `aegis_isos_state_dir()`; `load_from` promoted to `pub(crate)`.

## Test plan

- [x] `cargo test -p rescue-tui` → 117 tests pass (+2 from this branch)
- [x] `cargo test --workspace` → 720 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean
- [ ] Hardware leg (Framework/Dell/ThinkPad) — follows the 9-step procedure in REAL_HARDWARE_REPORT_132.md; tracked under #51 multi-vendor gate

## ADR

Implements ADR 0003 §8 acceptance criterion #2 (the pure-Rust round-trip side). The remaining hardware leg is gated on physical access per #51.