### PR TITLE
feat(nix): #406 package aegis-bootctl as flake output + NixOS module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,12 @@ jobs:
             experimental-features = nix-command flakes
       - run: nix flake check --no-build
       - run: nix develop --command cargo --version
+      # Build the operator CLI derivation so the `packages` output
+      # stays buildable on every PR. NixOS users install via:
+      #   nix run github:aegis-boot/aegis-boot -- flash /dev/sdX
+      # Drift in cargoLock or runtime-dep list surfaces here.
+      - run: nix build .#aegis-bootctl --print-build-logs
+      - run: nix run .# -- --version
 
   # Doc version drift-check (Phase 1c of #287 / #286).
   # Reads [workspace.package].version from Cargo.toml and verifies

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ curl -sSL https://raw.githubusercontent.com/aegis-boot/aegis-boot/main/scripts/i
 brew tap aegis-boot/aegis-boot https://github.com/aegis-boot/aegis-boot
 brew install aegis-boot
 
+# OR on NixOS / with Nix installed:
+nix run github:aegis-boot/aegis-boot -- flash /dev/sdX --yes
+# Or persist: nix profile install github:aegis-boot/aegis-boot
+
 # Or pin a version: sh install.sh --version v0.15.0
 # Or skip cosign (NOT recommended): sh install.sh --no-verify
 # Build from source: see BUILDING.md.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -61,6 +61,38 @@ What works on macOS today: `aegis-boot list`, `aegis-boot doctor`, drive detecti
 
 macOS x86_64 (Intel) and Windows native builds remain deferred — see [#365](https://github.com/aegis-boot/aegis-boot/issues/365) for the full cross-platform roadmap.
 
+### NixOS / Nix
+
+aegis-boot ships a Nix flake. The `aegis-bootctl` derivation bakes the runtime tools (`sgdisk`, `mkfs.fat`, `mkfs.exfat`, `mcopy`, `curl`, `gnupg`) into the binary's PATH via `makeWrapper`, so there's nothing to install separately:
+
+```bash
+# One-shot run (no persistent install):
+nix run github:aegis-boot/aegis-boot -- flash /dev/sdX --yes
+
+# Persistent user install:
+nix profile install github:aegis-boot/aegis-boot
+aegis-boot --version
+```
+
+Or consume from a system flake:
+
+```nix
+# flake.nix
+{
+  inputs.aegis-boot.url = "github:aegis-boot/aegis-boot";
+  outputs = { self, nixpkgs, aegis-boot, ... }: {
+    nixosConfigurations.mymachine = nixpkgs.lib.nixosSystem {
+      modules = [
+        aegis-boot.nixosModules.aegis-boot
+        { programs.aegis-boot.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+The flake pins to `nixos-unstable`; downgrade to a specific channel in your own system flake if you want a frozen snapshot. Cosign verification of the binary is not currently wired through the Nix build (the flake builds from source instead of verifying a signed release artifact) — if that matters for your threat model, use the `install.sh` path + `nix-ld`.
+
 Sanity check:
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,11 @@
   description = "aegis-boot — signed UEFI Secure Boot rescue environment";
 
   inputs = {
-    # Pinned to a stable channel to avoid unstable-channel churn (saw a
-    # python311/sphinx-9.1.0 breakage on unstable mid-PR #406 development).
-    # Bump forward when the next LTS channel opens and this one goes EOL.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    # Pinned to a stable channel with rust ≥1.85 (our workspace requires
+    # edition 2024). nixos-24.11 ships rust 1.82 → too old. nixos-25.05
+    # ships rust 1.85+ and avoids the nixos-unstable python/sphinx churn
+    # we saw mid-PR #406.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   description = "aegis-boot — signed UEFI Secure Boot rescue environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Pinned to a stable channel to avoid unstable-channel churn (saw a
+    # python311/sphinx-9.1.0 breakage on unstable mid-PR #406 development).
+    # Bump forward when the next LTS channel opens and this one goes EOL.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
-  description = "Aegis-Boot - Reproducible build environment";
+  description = "aegis-boot — signed UEFI Secure Boot rescue environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -10,8 +10,70 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+
+        # Runtime tools the `aegis-boot` CLI shells out to on Linux.
+        # Baked into the binary's PATH via `makeWrapper` so NixOS users
+        # don't have to install them globally. `aegis-boot doctor`
+        # enumerates the same list — keep in sync with the doctor
+        # checks in crates/aegis-cli/src/doctor.rs.
+        runtimeDeps = with pkgs; [
+          gptfdisk      # sgdisk — GPT partitioning
+          dosfstools    # mkfs.fat — ESP
+          exfatprogs    # mkfs.exfat — AEGIS_ISOS
+          mtools        # mcopy, mmd — staging into FAT
+          curl          # aegis-boot fetch
+          gnupg         # SHA256SUMS.sig verification
+          coreutils     # sha256sum
+        ];
+
+        aegis-bootctl = pkgs.rustPlatform.buildRustPackage {
+          pname = "aegis-bootctl";
+          version = "0.16.0";
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          # Build only the operator CLI binary from the workspace.
+          # rescue-tui, initramfs bits, fuzz targets, and the
+          # docgen-only bins are out of scope for a host-side install.
+          cargoBuildFlags = [ "-p" "aegis-bootctl" "--bin" "aegis-boot" ];
+          cargoTestFlags = [ "-p" "aegis-bootctl" ];
+
+          nativeBuildInputs = with pkgs; [ makeWrapper pkg-config ];
+          buildInputs = with pkgs; [ openssl ];
+
+          # Ensure the binary finds its runtime tools without the user
+          # having to install them separately. Matches the behavior of
+          # the `doctor` check — if this wrapper changes, update
+          # doctor's error message for the matching dep.
+          postFixup = ''
+            wrapProgram $out/bin/aegis-boot \
+              --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Operator CLI for aegis-boot — flash, add, list, verify signed rescue sticks";
+            homepage = "https://github.com/aegis-boot/aegis-boot";
+            license = with licenses; [ mit asl20 ];
+            mainProgram = "aegis-boot";
+            platforms = platforms.linux;
+          };
+        };
       in
       {
+        packages = {
+          default = aegis-bootctl;
+          aegis-bootctl = aegis-bootctl;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${aegis-bootctl}/bin/aegis-boot";
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             rustc
@@ -27,17 +89,35 @@
             util-linux
             acpica-tools
             git
-          ];
-
-          RUST_VERSION = "1.85.0";
+          ] ++ runtimeDeps;
 
           shellHook = ''
-            echo "Aegis-Boot Build Environment"
+            echo "aegis-boot build environment"
             echo "================================"
             echo "Rust: $(rustc --version)"
             echo "Nixpkgs: ${nixpkgs.lib.version}"
           '';
         };
       }
-    );
+    ) // {
+      # NixOS module — users import this into their system flake to
+      # install aegis-boot declaratively alongside its runtime deps.
+      nixosModules.aegis-boot = { pkgs, lib, config, ... }:
+        let
+          cfg = config.programs.aegis-boot;
+        in
+        {
+          options.programs.aegis-boot = {
+            enable = lib.mkEnableOption "aegis-boot operator CLI";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.aegis-bootctl;
+              description = "Which aegis-bootctl derivation to install.";
+            };
+          };
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ cfg.package ];
+          };
+        };
+    };
 }


### PR DESCRIPTION
## Summary

Enables \`nix run github:aegis-boot/aegis-boot -- flash /dev/sdX\` on NixOS / any Nix-installed host. Runtime deps baked via \`makeWrapper\` so there's nothing extra to install.

## What ships

- \`packages.default = aegis-bootctl\` (buildRustPackage, workspace-aware)
- \`apps.default\` wired so \`nix run .#\` → \`aegis-boot\`
- \`nixosModules.aegis-boot\` for declarative install from a system flake
- CI's \`nix-smoke\` job now builds the derivation + runs \`--version\` — catches cargoLock drift on every PR
- Install docs updated: README one-liner + \`docs/INSTALL.md § NixOS / Nix\` (flake consumers)

## Usage

\`\`\`bash
# Ad hoc:
nix run github:aegis-boot/aegis-boot -- flash /dev/sdX --yes

# Persistent:
nix profile install github:aegis-boot/aegis-boot

# Declarative (system flake):
inputs.aegis-boot.url = \"github:aegis-boot/aegis-boot\";
# then: imports = [ aegis-boot.nixosModules.aegis-boot ];
#       programs.aegis-boot.enable = true;
\`\`\`

## Test plan

- [x] \`flake.nix\` syntax validated (CI's \`nix flake check --no-build\` is the existing gate)
- [ ] \`nix build .#aegis-bootctl\` (new CI gate — will prove first-run)
- [ ] \`nix run .# -- --version\` (new CI gate)
- [x] README + INSTALL.md additions render correctly in GitHub

## Out of scope (filed separately if/when demand)

- \`packages.rescue-stick\` (whole flashable USB image from Nix) — much larger effort, separate design
- nixpkgs upstream PR — deferred to post-v1.0 / post-real-hardware-shakedown
- aarch64-linux — drops in naturally once x86_64 works

Closes #406.