### PR TITLE
feat(deps): #258 bump MSRV 1.85→1.88 + ratatui 0.29→0.30 (clears lru advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, "1.85.0"]
+        rust: [stable, "1.88.0"]
     defaults:
       run:
         working-directory: crates/iso-parser
@@ -45,8 +45,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust
         run: |
-          rustup toolchain install 1.85.0 --profile minimal --component rustfmt,clippy
-          rustup override set 1.85.0
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt,clippy
+          rustup override set 1.88.0
           rustup target add x86_64-apple-darwin
           rustup target add x86_64-pc-windows-gnu
       - uses: Swatinem/rust-cache@v2
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Run fitness audit (threshold 80)
         # Stage 8 of dev-test.sh — repo + scripts + docs hygiene.
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --locked --version 0.5.7
       - name: Generate SBOM
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p aegis-bootctl --bin constants-docgen --features docgen --locked -- --check
 
@@ -206,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Build aegis-boot binary
         run: cargo build -p aegis-bootctl --release --locked
@@ -226,6 +226,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
-        run: rustup toolchain install 1.85.0 --profile minimal && rustup override set 1.85.0
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p aegis-wire-formats --features schema --bin aegis-wire-formats-schema-docgen --locked -- --check

--- a/.github/workflows/crates-publish-dryrun.yml
+++ b/.github/workflows/crates-publish-dryrun.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Install Rust (pinned to workspace MSRV)
         run: |
-          rustup toolchain install 1.85.0 --profile minimal
-          rustup override set 1.85.0
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup override set 1.88.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -73,8 +73,8 @@ jobs:
 
       - name: Install Rust toolchain (pinned)
         run: |
-          rustup toolchain install 1.85.0 --profile minimal --no-self-update
-          rustup default 1.85.0
+          rustup toolchain install 1.88.0 --profile minimal --no-self-update
+          rustup default 1.88.0
           rustc --version
 
       - name: Mint short-lived crates.io token (OIDC)

--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build aegis-boot CLI + rescue-tui

--- a/.github/workflows/initramfs.yml
+++ b/.github/workflows/initramfs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build rescue-tui (release)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Check loop devices are available

--- a/.github/workflows/kexec-e2e.yml
+++ b/.github/workflows/kexec-e2e.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build rescue-tui (release)

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build rescue-tui

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build rescue-tui (release)

--- a/.github/workflows/qemu-smoke.yml
+++ b/.github/workflows/qemu-smoke.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build rescue-tui (release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Rust toolchain (pinned) + musl target
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           "$HOME/.cargo/bin/rustup" target add x86_64-unknown-linux-musl
 
@@ -333,7 +333,7 @@ jobs:
       - name: Install Rust toolchain (pinned)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.85.0 --profile minimal
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           # macos-14 runners are arm64-native, so aarch64-apple-darwin
           # is installed by the rustup bootstrap above. No `rustup target

--- a/.github/workflows/sign-identity-transition.yml
+++ b/.github/workflows/sign-identity-transition.yml
@@ -46,7 +46,7 @@ jobs:
           echo "Must type 'SIGN' in the workflow_dispatch input to proceed." >&2
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,7 +16,7 @@ The build environment is **intentionally small**. The chosen runtime architectur
 
 | Layer                    | Purpose                                                  |
 | ------------------------ | -------------------------------------------------------- |
-| `Dockerfile.locked`      | Pinned Ubuntu 22.04 + Rust 1.85 + `cpio` + `sbsigntool`  |
+| `Dockerfile.locked`      | Pinned Ubuntu 22.04 + Rust 1.88 + `cpio` + `sbsigntool`  |
 | `flake.nix`              | Nix flake for declarative dev shell                      |
 | Reproducible-build CI    | Two back-to-back builds; SHA-256 of `docker save` equal  |
 
@@ -45,7 +45,7 @@ cargo build --release
 | Component     | Version      | Pin Method                 |
 | ------------- | ------------ | -------------------------- |
 | Ubuntu base   | 22.04        | SHA-256 digest             |
-| Rust          | 1.85.0       | Exact version via rustup   |
+| Rust          | 1.88.0       | Exact version via rustup   |
 | build-essential | 12.9ubuntu3 | APT version pin           |
 | git           | 2.34.1       | APT version pin            |
 | cpio          | 2.13         | APT version pin            |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,12 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -147,6 +141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +169,24 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -232,6 +253,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +292,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -295,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,9 +392,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -455,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -476,6 +552,17 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
 ]
 
 [[package]]
@@ -506,6 +593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +612,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -534,11 +636,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -587,6 +689,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,12 +739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +765,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -691,23 +808,65 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags",
- "cassowary",
  "compact_str",
- "crossterm",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -741,7 +900,7 @@ name = "rescue-tui"
 version = "0.16.0"
 dependencies = [
  "aegis-wire-formats",
- "crossterm",
+ "crossterm 0.28.1",
  "hex",
  "iso-probe",
  "kexec-loader",
@@ -774,6 +933,15 @@ checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1024,23 +1192,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -1102,6 +1269,27 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
@@ -1245,20 +1433,14 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["crates/iso-parser/fuzz"]
 # user-facing doc files and fails if any version literal diverges.
 version = "0.16.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/aegis-boot/aegis-boot"
 

--- a/Dockerfile.locked
+++ b/Dockerfile.locked
@@ -45,7 +45,7 @@ RUN sed -i 's/^# deb \(.*universe\)/deb \1/' /etc/apt/sources.list && \
 
 ENV RUSTUP_HOME=/opt/rust/rustup
 ENV CARGO_HOME=/opt/rust/cargo
-ENV RUST_VERSION=1.85.0
+ENV RUST_VERSION=1.88.0
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y \

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Full developer loop: [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md).
 
 ## Build environment
 
-- Rust 1.85.0 (pinned in `Dockerfile.locked`, enforced via `rust-version` in every `Cargo.toml`)
+- Rust 1.88.0 (pinned in `Dockerfile.locked`, enforced via `rust-version` in every `Cargo.toml`)
 - Ubuntu 22.04 base (Docker) or a Nix flake
 - No EDK II / UEFI toolchain — we use shim + signed distro kernels instead
 

--- a/crates/iso-parser/fuzz/Cargo.toml
+++ b/crates/iso-parser/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "iso-parser-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/iso-parser/src/lib.rs
+++ b/crates/iso-parser/src/lib.rs
@@ -492,16 +492,16 @@ impl IsoEnvironment for OsIsoEnvironment {
                         &mount_point.to_string_lossy(),
                     ])
                     .output();
-                if let Ok(mo) = mount_out {
-                    if mo.status.success() {
-                        debug!(
-                            "Mounted {} via losetup {} -> {:?}",
-                            iso_path.display(),
-                            loop_dev,
-                            mount_point
-                        );
-                        return Ok(mount_point);
-                    }
+                if let Ok(mo) = mount_out
+                    && mo.status.success()
+                {
+                    debug!(
+                        "Mounted {} via losetup {} -> {:?}",
+                        iso_path.display(),
+                        loop_dev,
+                        mount_point
+                    );
+                    return Ok(mount_point);
                 }
                 // losetup succeeded but mount failed — detach.
                 let _ = Command::new("losetup").args(["-d", &loop_dev]).output();
@@ -687,15 +687,18 @@ impl<E: IsoEnvironment> IsoParser<E> {
                 // Skip certain directories
                 let name = entry.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-                if !name.starts_with('.') && name != "proc" && name != "sys" && name != "dev" {
-                    if let Ok(mut sub_isos) = self.find_iso_files(entry_path) {
-                        isos.append(&mut sub_isos);
-                    }
+                if !name.starts_with('.')
+                    && name != "proc"
+                    && name != "sys"
+                    && name != "dev"
+                    && let Ok(mut sub_isos) = self.find_iso_files(entry_path)
+                {
+                    isos.append(&mut sub_isos);
                 }
-            } else if let Some(ext) = entry.extension().and_then(|s| s.to_str()) {
-                if ext.eq_ignore_ascii_case("iso") {
-                    isos.push(entry.clone());
-                }
+            } else if let Some(ext) = entry.extension().and_then(|s| s.to_str())
+                && ext.eq_ignore_ascii_case("iso")
+            {
+                isos.push(entry.clone());
             }
         }
 

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -19,7 +19,7 @@ thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
 serde_json = "1.0"
-ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.28"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
 sha2 = "0.10"

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -250,7 +250,12 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
 fn event_loop<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     state: &mut AppState,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    // Required by ratatui 0.30: Backend::Error is no longer 'static by
+    // default, but we box it into a trait-object error that needs to be.
+    <B as ratatui::backend::Backend>::Error: 'static,
+{
     // Active verify-now worker (#89). None when no verification is in
     // flight; Some(rx) while the worker thread is streaming progress.
     let mut active_verify: Option<Receiver<VerifyMsg>> = None;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,7 +108,7 @@ Splitting the two means: the operator can swap ISO sets without touching the sig
 ## Build pipeline
 
 ```
-   source ──► cargo build (Rust 1.85, pinned)
+   source ──► cargo build (Rust 1.88, pinned)
             └─► rescue-tui binary
 
    rescue-tui + busybox + /init script + ldd-resolved libs

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -24,7 +24,7 @@ curl -sSL https://raw.githubusercontent.com/aegis-boot/aegis-boot/main/scripts/i
 brew tap aegis-boot/aegis-boot https://github.com/aegis-boot/aegis-boot
 brew install aegis-boot
 
-# Option C — build from source (any platform with Rust 1.85+)
+# Option C — build from source (any platform with Rust 1.88+)
 cargo install --git https://github.com/aegis-boot/aegis-boot --bin aegis-boot --path crates/aegis-cli
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   description = "aegis-boot — signed UEFI Secure Boot rescue environment";
 
   inputs = {
-    # Pinned to a stable channel with rust ≥1.85 (our workspace requires
-    # edition 2024). nixos-24.11 ships rust 1.82 → too old. nixos-25.05
-    # ships rust 1.85+ and avoids the nixos-unstable python/sphinx churn
-    # we saw mid-PR #406.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    # Pinned to a stable channel with rust ≥1.88 (our MSRV). Rust 1.88
+    # released 2025-06-23, so nixos-25.05 may ship 1.87 — use 25.11
+    # (frozen Nov 2025) which ships 1.88+. Avoids nixos-unstable churn
+    # (python/sphinx breakage observed mid-PR #406).
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/scripts/check-doc-version.sh
+++ b/scripts/check-doc-version.sh
@@ -11,7 +11,7 @@
 # the check.
 #
 # Why per-file patterns (not a broad repo-wide grep): a naive regex
-# like `v?\d+\.\d+\.\d+` flags Rust toolchain version (1.85.0),
+# like `v?\d+\.\d+\.\d+` flags Rust toolchain version (1.88.0),
 # Ubuntu ISO versions (24.04.2), kernel versions (6.17.0), historical
 # aegis-boot references ("--version v0.12.0"), and forward-looking
 # milestones ("gates v1.0.0"). All false positives.


### PR DESCRIPTION
## Summary

Clears the last open dependabot alert (low-severity lru \`IterMut\` stacked-borrows, transitive via ratatui 0.29) by bumping the ratatui stack to 0.30. Forces MSRV 1.85 → 1.88 (driven by \`time 0.3.47\` in ratatui 0.30's tree, not a new language-feature need).

## What changed

- **Workspace:** \`rust-version = \"1.88\"\` (from 1.85). Rust 1.88 is ~10 months old; this is accepting an upstream-forced bump, not chasing new syntax.
- **ratatui:** \`0.29 → 0.30\` in \`crates/rescue-tui/Cargo.toml\`.
- **Backend trait fix:** ratatui 0.30 dropped the \`'static\` default on \`<B as Backend>::Error\`. Added \`where <B as Backend>::Error: 'static\` to \`rescue-tui::event_loop\`. This is the only generic Backend call site — all other Terminal uses are concrete \`CrosstermBackend\`.
- **21 files updated** to reference 1.88: CI workflows (11), Dockerfile, BUILDING.md, README.md, ARCHITECTURE.md, INSTALL.md, flake.nix, check-doc-version.sh, iso-parser/fuzz.
- **flake.nix:** \`nixos-25.05 → nixos-25.11\` (rust 1.88 released 2025-06-23, so 25.05 may ship 1.87).
- **CHANGELOG.md:** left alone — historical references, not current state.

## Dependabot alert

\`\`\`
Dependabot #1 (low):
  lru v0.12.5 → fix in 0.16.3
  path: lru → ratatui v0.29.0 → rescue-tui
\`\`\`

After merge, ratatui 0.30 pulls current lru (via its 0.30 internals), clearing the advisory.

## Test plan

- [x] \`cargo build --workspace\` under 1.88.0 — clean
- [x] \`cargo test --workspace\` under 1.88.0 — 720 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [ ] CI matrix: Test (1.88.0) + Test (stable) pass
- [ ] Nix flake smoke-build still works on nixos-25.11

## Scope

Runtime behavior unchanged — ratatui 0.30 is an API/trait refactor release, not a visual-behavior release. rescue-tui's visual output is identical.

Closes #258.