### PR TITLE
chore(deps): refresh dev/compat deps to latest stable (crossterm 0.29, tokio 1.52, python312)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,22 +160,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -186,7 +170,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -334,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -603,12 +587,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -845,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core",
 ]
@@ -900,7 +878,7 @@ name = "rescue-tui"
 version = "0.16.0"
 dependencies = [
  "aegis-wire-formats",
- "crossterm 0.28.1",
+ "crossterm",
  "hex",
  "iso-probe",
  "kexec-loader",
@@ -946,19 +924,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -966,8 +931,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1237,8 +1202,8 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1293,9 +1258,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "pin-project-lite",
  "tokio-macros",

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -20,7 +20,7 @@ tracing.workspace = true
 serde = { workspace = true }
 serde_json = "1.0"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
-crossterm = "0.28"
+crossterm = "0.29"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
 sha2 = "0.10"
 hex = "0.4"

--- a/flake.nix
+++ b/flake.nix
@@ -87,8 +87,8 @@
             gcc
             pkg-config
             openssl
-            python311
-            python311Packages.pip
+            python312
+            python312Packages.pip
             nasm
             util-linux
             acpica-tools


### PR DESCRIPTION
## Summary

Low-risk dep-refresh pass for the \"latest stable LTS\" sweep. No API breaks, no major-version churn.

## Changed

- \`tokio\` 1.51 → 1.52 (patch; dev-dep in iso-parser)
- \`crossterm\` 0.28 → 0.29 in rescue-tui direct pin — **ratatui 0.30 already transitive-pulls 0.29, so the 0.28 pin forced a dup in the lockfile**. Resolves.
- \`python311\` → \`python312\` in \`flake.nix\` devShell — aligns with nixos-25.11 channel's current stable.
- Cargo.lock cleanup: 55 lines → 13 lines diff as duplicate crossterm stack collapses.

## Intentionally not bumped

Each is a major-version / breaking change that deserves its own PR + testing window:

- \`sha2\` 0.10 → 0.11 — wire-format / on-disk hash format stability
- \`schemars\` 0.8 → 1.2 — \`aegis-wire-formats\` public API change
- \`toml\` 0.8 → 1.1 — parser v2 opt-in semantics differ from v1
- \`indicatif\` 0.17 → 0.18 — progress-bar style API changed

Tracking issue to follow for those.

## Test plan

- [x] \`cargo build --workspace\` on 1.88.0 — clean
- [x] \`cargo test --workspace\` on 1.88.0 — 720 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

## Notes

Follow-up to PR #408 (MSRV 1.88 + ratatui 0.30). Part of the 2026-04-22 \"ensure we're using latest stable LTS for all dependencies\" maintenance pass.