### PR TITLE
chore(deps): #411 bump indicatif 0.17→0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -443,14 +454,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.3",
  "portable-atomic",
- "web-time",
+ "unit-prefix",
 ]
 
 [[package]]
@@ -680,12 +690,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -932,7 +936,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1133,7 +1137,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
- "console",
+ "console 0.15.11",
  "similar",
 ]
 
@@ -1203,7 +1207,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1420,6 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,16 +1542,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -77,7 +77,7 @@ thiserror = { workspace = true }
 # renders a bytes/sec + ETA bar. macOS dd doesn't emit progress on
 # stderr, so the bar is Linux-only; macOS falls back to the original
 # silent .status() call.
-indicatif = { version = "0.17", default-features = false }
+indicatif = { version = "0.18", default-features = false }
 # Signed attestation manifest for direct-install (#274 PR3, #277).
 # Ed25519-based minisign in pure Rust — no sigtool shellout, no PATH
 # dependency. Used to sign `::/aegis-boot-manifest.json` on flashed


### PR DESCRIPTION
## Summary

First of 4 major-version dep bumps tracked in #411. Lowest-risk because \`indicatif\` is only wired into the \`aegis-boot flash\` progress bar and our usage sits inside the subset of API that's stable across 0.17→0.18.

## Changed

- \`indicatif\` 0.17.11 → 0.18.4 in \`crates/aegis-cli/Cargo.toml\`
- \`Cargo.lock\` — \`number_prefix\` → \`unit-prefix\`, \`web-time\` dropped

## Usage check

\`crates/aegis-cli/src/flash.rs\` uses:
- \`ProgressBar::new\`
- \`ProgressStyle::with_template\` with \`.unwrap_or_else(|_| ProgressStyle::default_bar())\` fallback
- \`pb.inc\`, \`pb.finish_and_clear\`

All are stable API across the major. No call-site changes needed.

## Test plan

- [x] \`cargo test -p aegis-bootctl\` — 459 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

## Next up (per #411)

- \`toml\` 0.8 → 1.1 (medium risk — iso-probe config loader)
- \`schemars\` 0.8 → 1.2 (high risk — public wire-format schemas)
- \`sha2\` 0.10 → 0.11 (high risk — on-disk hash stability, last)