### PR TITLE
chore(deps): #411 bump toml 0.8→1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,11 +1063,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1283,44 +1283,41 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1656,12 +1653,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -26,7 +26,7 @@ minisign-verify = "0.2"
 # Operator-curated metadata sidecar (#246). default-features = false
 # drops the indexmap/serde_spanned tree we don't use; we only need
 # `parse` (deserialize) and `display` (serialize back to TOML).
-toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+toml = { version = "1.1", default-features = false, features = ["parse", "display", "serde"] }
 
 [dev-dependencies]
 tempfile = "3.14"


### PR DESCRIPTION
## Summary

Second of 4 major-version bumps tracked in #411 (indicatif shipped in #412). toml 1.0 was a workspace restructure — parser/writer/datetime split into dedicated 1.x crates — but the public \`toml::from_str\` / \`toml::to_string_pretty\` surface we consume stayed stable.

## Changed

- \`toml\` 0.8.23 → 1.1.2 in \`crates/iso-probe/Cargo.toml\`
- Features: added \`\"serde\"\` (toml 1.x split \"parse\" into \"parse\" + \"serde\")
- \`Cargo.lock\` — serde_spanned, toml_datetime, winnow all bumped to 1.x; new toml_parser and toml_writer crates pulled

## Consumer

Only \`crates/iso-probe/src/sidecar.rs\` uses toml:

- \`toml::from_str(&body)\` → sidecar load
- \`toml::to_string_pretty(sidecar)\` → sidecar write
- \`toml::de::Error\` / \`toml::ser::Error\` → error variant types

All stable across 0.8 → 1.1.

## Test plan

- [x] \`cargo test -p iso-probe\` — 50 pass (sidecar round-trip included)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo build --workspace\` — clean

## Next up (#411)

- \`schemars\` 0.8 → 1.2 (high risk — wire-format public API)
- \`sha2\` 0.10 → 0.11 (high risk — on-disk hash stability)