### PR TITLE
chore(deps): #411 bump schemars 0.8→1.2 (regenerates committed schemas)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,11 +982,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -974,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/aegis-wire-formats/Cargo.toml
+++ b/crates/aegis-wire-formats/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0"
 thiserror = { workspace = true }
 # schemars picks the latest stable. 0.8 is the long-established
 # release with a settled API + a broad reverse-dependency ecosystem.
-schemars = { version = "0.8", optional = true, default-features = false, features = ["derive"] }
+schemars = { version = "1", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/docs/reference/schemas/aegis-attestation.schema.json
+++ b/docs/reference/schemas/aegis-attestation.schema.json
@@ -1,89 +1,74 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Attestation",
-  "description": "One flash + zero-or-more ISO additions, captured as a single JSON document on the host. Stored under `$XDG_DATA_HOME/aegis-boot/attestations/` (or `~/.local/share/aegis-boot/attestations/` if `XDG_DATA_HOME` is unset). The `aegis-boot attest list` / `attest show` commands read these back for chain-of-custody queries.\n\nv0 ships unsigned — the trust anchor is \"the operator ran this command on this host, the timestamps + hashes are the evidence.\" TPM PCR attestation + signing lands under epic [#139](https://github.com/aegis-boot/aegis-boot/issues/139) as additive fields; the current schema is forward-compatible (consumers ignore unknown fields).",
+  "description": "One flash + zero-or-more ISO additions, captured as a single\nJSON document on the host. Stored under\n`$XDG_DATA_HOME/aegis-boot/attestations/` (or\n`~/.local/share/aegis-boot/attestations/` if `XDG_DATA_HOME` is\nunset). The `aegis-boot attest list` / `attest show` commands\nread these back for chain-of-custody queries.\n\nv0 ships unsigned — the trust anchor is \"the operator ran this\ncommand on this host, the timestamps + hashes are the evidence.\"\nTPM PCR attestation + signing lands under epic\n[#139](https://github.com/aegis-boot/aegis-boot/issues/139)\nas additive fields; the current schema is forward-compatible\n(consumers ignore unknown fields).",
   "type": "object",
-  "required": [
-    "flashed_at",
-    "host",
-    "isos",
-    "operator",
-    "schema_version",
-    "target",
-    "tool_version"
-  ],
   "properties": {
     "flashed_at": {
-      "description": "RFC 3339 / ISO 8601 timestamp of the flash operation. Generated via the host's `date -u +%FT%TZ` so the crate does not pull a chrono dep.",
+      "description": "RFC 3339 / ISO 8601 timestamp of the flash operation.\nGenerated via the host's `date -u +%FT%TZ` so the crate\ndoes not pull a chrono dep.",
       "type": "string"
     },
     "host": {
       "description": "Host environment captured at flash time.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/HostInfo"
-        }
-      ]
+      "$ref": "#/$defs/HostInfo"
     },
     "isos": {
-      "description": "ISO records appended on each successful `aegis-boot add`. Empty immediately after flash; grows over the stick's lifetime.",
+      "description": "ISO records appended on each successful `aegis-boot add`.\nEmpty immediately after flash; grows over the stick's\nlifetime.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/IsoRecord"
+        "$ref": "#/$defs/IsoRecord"
       }
     },
     "operator": {
-      "description": "The user that ran `aegis-boot flash` — captured from `$SUDO_USER` if set, else `$USER`.",
+      "description": "The user that ran `aegis-boot flash` — captured from\n`$SUDO_USER` if set, else `$USER`.",
       "type": "string"
     },
     "schema_version": {
       "description": "Wire-format version. See [`ATTESTATION_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "target": {
       "description": "Target stick captured at flash time.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/TargetInfo"
-        }
-      ]
+      "$ref": "#/$defs/TargetInfo"
     },
     "tool_version": {
-      "description": "`aegis-boot` binary version that produced this record (e.g. `\"aegis-boot 0.14.1\"`).",
+      "description": "`aegis-boot` binary version that produced this record\n(e.g. `\"aegis-boot 0.14.1\"`).",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "flashed_at",
+    "operator",
+    "host",
+    "target",
+    "isos"
+  ],
+  "$defs": {
     "HostInfo": {
       "description": "Host environment fingerprint at flash time.",
       "type": "object",
-      "required": [
-        "kernel",
-        "secure_boot"
-      ],
       "properties": {
         "kernel": {
           "description": "`uname -r` output.",
           "type": "string"
         },
         "secure_boot": {
-          "description": "Secure Boot state: one of `\"enforcing\"`, `\"disabled\"`, or `\"unknown\"`.",
+          "description": "Secure Boot state: one of `\"enforcing\"`, `\"disabled\"`, or\n`\"unknown\"`.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "kernel",
+        "secure_boot"
+      ]
     },
     "IsoRecord": {
-      "description": "One `aegis-boot add` operation appended to the stick's attestation record.",
+      "description": "One `aegis-boot add` operation appended to the stick's\nattestation record.",
       "type": "object",
-      "required": [
-        "added_at",
-        "filename",
-        "sha256",
-        "sidecars",
-        "size_bytes"
-      ],
       "properties": {
         "added_at": {
           "description": "RFC 3339 / ISO 8601 timestamp of when the ISO was added.",
@@ -98,7 +83,7 @@
           "type": "string"
         },
         "sidecars": {
-          "description": "Sidecar filenames recorded alongside the ISO (e.g. a `.aegis.toml` operator-label file).",
+          "description": "Sidecar filenames recorded alongside the ISO (e.g. a\n`.aegis.toml` operator-label file).",
           "type": "array",
           "items": {
             "type": "string"
@@ -108,28 +93,27 @@
           "description": "ISO size in bytes.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "filename",
+        "sha256",
+        "size_bytes",
+        "sidecars",
+        "added_at"
+      ]
     },
     "TargetInfo": {
       "description": "Target stick fingerprint at flash time.",
       "type": "object",
-      "required": [
-        "device",
-        "disk_guid",
-        "image_sha256",
-        "image_size_bytes",
-        "model",
-        "size_bytes"
-      ],
       "properties": {
         "device": {
           "description": "Device node path (e.g. `/dev/sda`).",
           "type": "string"
         },
         "disk_guid": {
-          "description": "GPT disk GUID, captured from `sgdisk -p` after `partprobe`. May be empty if sgdisk fails or the drive isn't partitioned.",
+          "description": "GPT disk GUID, captured from `sgdisk -p` after `partprobe`.\nMay be empty if sgdisk fails or the drive isn't partitioned.",
           "type": "string"
         },
         "image_sha256": {
@@ -137,10 +121,10 @@
           "type": "string"
         },
         "image_size_bytes": {
-          "description": "Size in bytes of the image body (for sanity-checking the sha256 over the correct length).",
+          "description": "Size in bytes of the image body (for sanity-checking the\nsha256 over the correct length).",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         },
         "model": {
           "description": "Vendor + model string from `/sys/block/sdX/device/{vendor,model}`.",
@@ -150,9 +134,17 @@
           "description": "Raw device size in bytes, rounded to the nearest 512B sector.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "device",
+        "model",
+        "size_bytes",
+        "image_sha256",
+        "image_size_bytes",
+        "disk_guid"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-attest-list.schema.json
+++ b/docs/reference/schemas/aegis-boot-attest-list.schema.json
@@ -1,73 +1,61 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttestListReport",
-  "description": "Envelope emitted by `aegis-boot attest list --json`. Scans the host's attestation directory, attempts to parse each file, and reports either a parsed summary or a parse-error placeholder per entry. Enables monitoring / fleet tools to audit chain-of-custody across all flashed sticks on a host.",
+  "description": "Envelope emitted by `aegis-boot attest list --json`. Scans the\nhost's attestation directory, attempts to parse each file, and\nreports either a parsed summary or a parse-error placeholder per\nentry. Enables monitoring / fleet tools to audit chain-of-custody\nacross all flashed sticks on a host.",
   "type": "object",
-  "required": [
-    "attestations",
-    "attestations_dir",
-    "count",
-    "schema_version",
-    "tool_version"
-  ],
   "properties": {
     "attestations": {
-      "description": "One entry per file found. See [`AttestListEntry`] for the success/error shape selection.",
+      "description": "One entry per file found. See [`AttestListEntry`] for the\nsuccess/error shape selection.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/AttestListEntry"
+        "$ref": "#/$defs/AttestListEntry"
       }
     },
     "attestations_dir": {
-      "description": "Host filesystem path of the attestations directory scanned (typically `$XDG_DATA_HOME/aegis-boot/attestations/`).",
+      "description": "Host filesystem path of the attestations directory scanned\n(typically `$XDG_DATA_HOME/aegis-boot/attestations/`).",
       "type": "string"
     },
     "count": {
       "description": "Number of files scanned (including parse-failure entries).",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "schema_version": {
       "description": "Wire-format version. See [`ATTEST_LIST_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool_version": {
       "description": "`aegis-boot` binary version that produced this envelope.",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "attestations_dir",
+    "count",
+    "attestations"
+  ],
+  "$defs": {
     "AttestListEntry": {
-      "description": "One entry in an [`AttestListReport`]. Two mutually-exclusive wire shapes via serde's `untagged` tagging:\n\n* **Success** — a successful parse, reporting the manifest's headline fields. The `error` field is absent. * **Error** — the file existed but could not be parsed. Only `manifest_path` + `error` are emitted; the summary fields are absent.\n\nSchemars emits this as a JSON Schema `oneOf` so consumers know to branch on the presence of the `error` field.",
+      "description": "One entry in an [`AttestListReport`]. Two mutually-exclusive\nwire shapes via serde's `untagged` tagging:\n\n* **Success** — a successful parse, reporting the manifest's\n  headline fields. The `error` field is absent.\n* **Error** — the file existed but could not be parsed. Only\n  `manifest_path` + `error` are emitted; the summary fields\n  are absent.\n\nSchemars emits this as a JSON Schema `oneOf` so consumers know\nto branch on the presence of the `error` field.",
       "anyOf": [
         {
           "description": "Parsed manifest summary.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/AttestListSuccess"
-            }
-          ]
+          "$ref": "#/$defs/AttestListSuccess"
         },
         {
           "description": "Placeholder for a file that existed but failed to parse.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/AttestListError"
-            }
-          ]
+          "$ref": "#/$defs/AttestListError"
         }
       ]
     },
     "AttestListError": {
-      "description": "Parse-failure entry inside an [`AttestListReport`]. Consumer decision: show the operator which file failed + why, so they can audit / repair / delete.",
+      "description": "Parse-failure entry inside an [`AttestListReport`]. Consumer\ndecision: show the operator which file failed + why, so they\ncan audit / repair / delete.",
       "type": "object",
-      "required": [
-        "error",
-        "manifest_path"
-      ],
       "properties": {
         "error": {
           "description": "Human-readable error message from the parser.",
@@ -77,22 +65,15 @@
           "description": "Host filesystem path of the unparseable file.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "manifest_path",
+        "error"
+      ]
     },
     "AttestListSuccess": {
-      "description": "Successfully-parsed attestation summary inside an [`AttestListReport`]. Deliberately a strict subset of the full [`Attestation`] — enough to drive a dashboard without requiring consumers to re-parse each file. Full detail is one `aegis-boot attest show <path>` away.",
+      "description": "Successfully-parsed attestation summary inside an\n[`AttestListReport`]. Deliberately a strict subset of the full\n[`Attestation`] — enough to drive a dashboard without requiring\nconsumers to re-parse each file. Full detail is one\n`aegis-boot attest show <path>` away.",
       "type": "object",
-      "required": [
-        "disk_guid",
-        "flashed_at",
-        "iso_count",
-        "manifest_path",
-        "operator",
-        "schema_version",
-        "target_device",
-        "target_model",
-        "tool_version"
-      ],
       "properties": {
         "disk_guid": {
           "description": "GPT disk GUID from the attestation's target info.",
@@ -106,7 +87,7 @@
           "description": "Number of [`IsoRecord`] entries inside the attestation.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "manifest_path": {
           "description": "Host filesystem path of the attestation manifest file.",
@@ -117,10 +98,10 @@
           "type": "string"
         },
         "schema_version": {
-          "description": "Schema version declared inside the attestation manifest (see [`ATTESTATION_SCHEMA_VERSION`]).",
+          "description": "Schema version declared inside the attestation manifest\n(see [`ATTESTATION_SCHEMA_VERSION`]).",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "target_device": {
           "description": "`target.device` from the attestation (e.g. `/dev/sda`).",
@@ -134,7 +115,18 @@
           "description": "`tool_version` field from the attestation manifest.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "manifest_path",
+        "schema_version",
+        "tool_version",
+        "flashed_at",
+        "operator",
+        "target_device",
+        "target_model",
+        "disk_guid",
+        "iso_count"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-cli-error.schema.json
+++ b/docs/reference/schemas/aegis-boot-cli-error.schema.json
@@ -1,12 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CliError",
-  "description": "Generic error envelope emitted when a subcommand fails before it can produce its subcommand-specific `--json` envelope. Examples: `aegis-boot list --json` before mount-resolution succeeds; `aegis-boot verify --json` before a stick is found.\n\nKept deliberately minimal (just `schema_version` + `error`) so scripted consumers can parse it without knowing which subcommand was called. Shared across subcommands because the pre-dispatch failure path is semantically identical.",
+  "description": "Generic error envelope emitted when a subcommand fails before\nit can produce its subcommand-specific `--json` envelope.\nExamples: `aegis-boot list --json` before mount-resolution\nsucceeds; `aegis-boot verify --json` before a stick is found.\n\nKept deliberately minimal (just `schema_version` + `error`) so\nscripted consumers can parse it without knowing which\nsubcommand was called. Shared across subcommands because the\npre-dispatch failure path is semantically identical.",
   "type": "object",
-  "required": [
-    "error",
-    "schema_version"
-  ],
   "properties": {
     "error": {
       "description": "Human-readable error message.",
@@ -16,7 +12,11 @@
       "description": "Wire-format version. See [`CLI_ERROR_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     }
-  }
+  },
+  "required": [
+    "schema_version",
+    "error"
+  ]
 }

--- a/docs/reference/schemas/aegis-boot-compat-submit.schema.json
+++ b/docs/reference/schemas/aegis-boot-compat-submit.schema.json
@@ -1,19 +1,11 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CompatSubmitReport",
-  "description": "Envelope emitted by `aegis-boot compat --submit --json` — the draft-a-hardware-report flow. Collects DMI identity + builds a pre-filled GitHub issue URL the operator can open to file a report. Independent schema from [`CompatReport`] because the consumer contracts diverge: lookup drives scripted decisions, submit drives an operator workflow.",
+  "description": "Envelope emitted by `aegis-boot compat --submit --json` — the\ndraft-a-hardware-report flow. Collects DMI identity + builds a\npre-filled GitHub issue URL the operator can open to file a\nreport. Independent schema from [`CompatReport`] because the\nconsumer contracts diverge: lookup drives scripted decisions,\nsubmit drives an operator workflow.",
   "type": "object",
-  "required": [
-    "firmware",
-    "model",
-    "schema_version",
-    "submit_url",
-    "tool",
-    "vendor"
-  ],
   "properties": {
     "firmware": {
-      "description": "DMI BIOS label (vendor + version + date). Empty if unavailable.",
+      "description": "DMI BIOS label (vendor + version + date). Empty if\nunavailable.",
       "type": "string"
     },
     "model": {
@@ -24,19 +16,27 @@
       "description": "Wire-format version. See [`COMPAT_SUBMIT_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "submit_url": {
-      "description": "Pre-filled GitHub issue URL with `vendor`, `model`, `firmware`, and `aegis-version` query-string parameters set from DMI.",
+      "description": "Pre-filled GitHub issue URL with `vendor`, `model`,\n`firmware`, and `aegis-version` query-string parameters\nset from DMI.",
       "type": "string"
     },
     "tool": {
-      "description": "Always `\"aegis-boot\"`. Deliberately named `tool` (not `tool_version`) to match the existing wire format; this envelope carries the draft template, not a version pin.",
+      "description": "Always `\"aegis-boot\"`. Deliberately named `tool` (not\n`tool_version`) to match the existing wire format; this\nenvelope carries the draft template, not a version pin.",
       "type": "string"
     },
     "vendor": {
       "description": "DMI `sys_vendor`. Empty string if unavailable.",
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "schema_version",
+    "tool",
+    "submit_url",
+    "vendor",
+    "model",
+    "firmware"
+  ]
 }

--- a/docs/reference/schemas/aegis-boot-compat.schema.json
+++ b/docs/reference/schemas/aegis-boot-compat.schema.json
@@ -1,64 +1,41 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CompatReport",
-  "description": "Envelope emitted by `aegis-boot compat --json`. Untagged wrapper around 4 mutually-exclusive shapes: full catalog, single match, miss (query matched no DB entry), or my-machine-miss (DMI lookup couldn't resolve an identity).\n\nDispatch by field presence: * `entries` → [`CompatReport::Catalog`] * `entry` → [`CompatReport::Single`] * `report_url` + `error` (no entries/entry) → [`CompatReport::Miss`] * `error` without `report_url` → [`CompatReport::MyMachineMiss`]\n\nThe separate `CompatSubmitReport` carries the `--submit` flow's own shape and schema version.",
+  "description": "Envelope emitted by `aegis-boot compat --json`. Untagged\nwrapper around 4 mutually-exclusive shapes: full catalog,\nsingle match, miss (query matched no DB entry), or\nmy-machine-miss (DMI lookup couldn't resolve an identity).\n\nDispatch by field presence:\n* `entries` → [`CompatReport::Catalog`]\n* `entry` → [`CompatReport::Single`]\n* `report_url` + `error` (no entries/entry) → [`CompatReport::Miss`]\n* `error` without `report_url` → [`CompatReport::MyMachineMiss`]\n\nThe separate `CompatSubmitReport` carries the `--submit` flow's\nown shape and schema version.",
   "anyOf": [
     {
       "description": "Full catalog listing. Emitted with no query argument.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CompatCatalogReport"
-        }
-      ]
+      "$ref": "#/$defs/CompatCatalogReport"
     },
     {
-      "description": "Single match. Emitted when the query resolved exactly one DB entry.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CompatSingleReport"
-        }
-      ]
+      "description": "Single match. Emitted when the query resolved exactly one\nDB entry.",
+      "$ref": "#/$defs/CompatSingleReport"
     },
     {
-      "description": "Miss. Emitted when the query didn't match any DB entry (but the query was well-formed).",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CompatMissReport"
-        }
-      ]
+      "description": "Miss. Emitted when the query didn't match any DB entry\n(but the query was well-formed).",
+      "$ref": "#/$defs/CompatMissReport"
     },
     {
-      "description": "My-machine miss. Emitted when `--my-machine` or `--submit` couldn't resolve DMI identity (non-Linux host, placeholder values). Exit code on the CLI side is 2 (host-environment issue) vs the Miss case's 1 (DB coverage gap).",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CompatMyMachineMissReport"
-        }
-      ]
+      "description": "My-machine miss. Emitted when `--my-machine` or\n`--submit` couldn't resolve DMI identity (non-Linux host,\nplaceholder values). Exit code on the CLI side is 2\n(host-environment issue) vs the Miss case's 1 (DB coverage\ngap).",
+      "$ref": "#/$defs/CompatMyMachineMissReport"
     }
   ],
-  "definitions": {
+  "$defs": {
     "CompatCatalogReport": {
       "description": "Full-catalog variant of [`CompatReport`].",
       "type": "object",
-      "required": [
-        "count",
-        "entries",
-        "report_url",
-        "schema_version",
-        "tool_version"
-      ],
       "properties": {
         "count": {
           "description": "Number of entries in the DB. Equals `entries.len()`.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "entries": {
           "description": "All entries in DB declaration order.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CompatEntry"
+            "$ref": "#/$defs/CompatEntry"
           }
         },
         "report_url": {
@@ -69,31 +46,27 @@
           "description": "Wire-format version. See [`COMPAT_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "tool_version": {
           "description": "`aegis-boot` binary version that produced this envelope.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "tool_version",
+        "report_url",
+        "count",
+        "entries"
+      ]
     },
     "CompatEntry": {
-      "description": "One hardware-compatibility DB row. Mirrors `docs/HARDWARE_COMPAT.md`; every entry corresponds to a real operator report (or the QEMU reference environment).",
+      "description": "One hardware-compatibility DB row. Mirrors\n`docs/HARDWARE_COMPAT.md`; every entry corresponds to a real\noperator report (or the QEMU reference environment).",
       "type": "object",
-      "required": [
-        "boot_key",
-        "date",
-        "firmware",
-        "level",
-        "model",
-        "notes",
-        "reported_by",
-        "sb_state",
-        "vendor"
-      ],
       "properties": {
         "boot_key": {
-          "description": "Boot-menu key for this firmware (`\"F12\"`, `\"Esc\"`, etc.). `\"n/a\"` for reference / virtualized environments.",
+          "description": "Boot-menu key for this firmware (`\"F12\"`, `\"Esc\"`, etc.).\n`\"n/a\"` for reference / virtualized environments.",
           "type": "string"
         },
         "date": {
@@ -105,7 +78,7 @@
           "type": "string"
         },
         "level": {
-          "description": "Confidence level: `\"verified\"`, `\"partial\"`, or `\"reference\"`.",
+          "description": "Confidence level: `\"verified\"`, `\"partial\"`, or\n`\"reference\"`.",
           "type": "string"
         },
         "model": {
@@ -113,7 +86,7 @@
           "type": "string"
         },
         "notes": {
-          "description": "Free-text operator notes (quirks, BIOS tweaks, fast-boot caveats). May be empty for a clean boot.",
+          "description": "Free-text operator notes (quirks, BIOS tweaks,\nfast-boot caveats). May be empty for a clean boot.",
           "type": "array",
           "items": {
             "type": "string"
@@ -124,23 +97,29 @@
           "type": "string"
         },
         "sb_state": {
-          "description": "Secure Boot state at the time of the report (typically `\"enforcing\"` or `\"disabled\"`).",
+          "description": "Secure Boot state at the time of the report\n(typically `\"enforcing\"` or `\"disabled\"`).",
           "type": "string"
         },
         "vendor": {
           "description": "Vendor (e.g. `\"Lenovo\"`, `\"Framework\"`, `\"QEMU\"`).",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "vendor",
+        "model",
+        "firmware",
+        "sb_state",
+        "boot_key",
+        "level",
+        "reported_by",
+        "date",
+        "notes"
+      ]
     },
     "CompatMissReport": {
-      "description": "Miss variant of [`CompatReport`] — the query was well-formed but didn't match any DB entry. Carries `report_url` so the operator can file a new entry; deliberately omits `tool_version` to match the existing wire format.",
+      "description": "Miss variant of [`CompatReport`] — the query was well-formed but\ndidn't match any DB entry. Carries `report_url` so the operator\ncan file a new entry; deliberately omits `tool_version` to match\nthe existing wire format.",
       "type": "object",
-      "required": [
-        "error",
-        "report_url",
-        "schema_version"
-      ],
       "properties": {
         "error": {
           "description": "Human-readable error (`\"no platform matching '<query>'\"`).",
@@ -154,47 +133,42 @@
           "description": "Wire-format version. See [`COMPAT_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "report_url",
+        "error"
+      ]
     },
     "CompatMyMachineMissReport": {
-      "description": "My-machine-miss variant of [`CompatReport`] — `--my-machine` or `--submit` couldn't auto-fill the query from DMI. Minimal envelope (just `schema_version` + `error`) to match the existing wire format.",
+      "description": "My-machine-miss variant of [`CompatReport`] — `--my-machine` or\n`--submit` couldn't auto-fill the query from DMI. Minimal\nenvelope (just `schema_version` + `error`) to match the existing\nwire format.",
       "type": "object",
-      "required": [
-        "error",
-        "schema_version"
-      ],
       "properties": {
         "error": {
-          "description": "Human-readable error (`\"--my-machine: DMI fields unavailable (…)\"`).",
+          "description": "Human-readable error\n(`\"--my-machine: DMI fields unavailable (…)\"`).",
           "type": "string"
         },
         "schema_version": {
           "description": "Wire-format version. See [`COMPAT_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "error"
+      ]
     },
     "CompatSingleReport": {
       "description": "Single-entry variant of [`CompatReport`].",
       "type": "object",
-      "required": [
-        "entry",
-        "report_url",
-        "schema_version",
-        "tool_version"
-      ],
       "properties": {
         "entry": {
           "description": "The matched DB entry.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/CompatEntry"
-            }
-          ]
+          "$ref": "#/$defs/CompatEntry"
         },
         "report_url": {
           "description": "URL operators visit to file a new hardware report.",
@@ -204,13 +178,19 @@
           "description": "Wire-format version. See [`COMPAT_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "tool_version": {
           "description": "`aegis-boot` binary version that produced this envelope.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "tool_version",
+        "report_url",
+        "entry"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-doctor.schema.json
+++ b/docs/reference/schemas/aegis-boot-doctor.schema.json
@@ -1,65 +1,60 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "DoctorReport",
-  "description": "Envelope emitted by `aegis-boot doctor --json`. Reports host + stick health as a rollup score + per-check rows. The monitoring / CI consumer target — a non-zero `has_any_fail` is the signal to surface to an operator.",
+  "description": "Envelope emitted by `aegis-boot doctor --json`. Reports host +\nstick health as a rollup score + per-check rows. The monitoring /\nCI consumer target — a non-zero `has_any_fail` is the signal to\nsurface to an operator.",
   "type": "object",
-  "required": [
-    "band",
-    "has_any_fail",
-    "rows",
-    "schema_version",
-    "score",
-    "tool_version"
-  ],
   "properties": {
     "band": {
-      "description": "Human-readable score band: typically `\"EXCELLENT\"`, `\"GOOD\"`, `\"FAIR\"`, or `\"POOR\"`. Exact thresholds are an implementation detail of the CLI; consumers should treat these as opaque labels paired with the numeric `score`.",
+      "description": "Human-readable score band: typically `\"EXCELLENT\"`,\n`\"GOOD\"`, `\"FAIR\"`, or `\"POOR\"`. Exact thresholds are an\nimplementation detail of the CLI; consumers should treat\nthese as opaque labels paired with the numeric `score`.",
       "type": "string"
     },
     "has_any_fail": {
-      "description": "True iff any row's `verdict` is `\"FAIL\"`. The minimal rollup bit for monitoring: operator attention required.",
+      "description": "True iff any row's `verdict` is `\"FAIL\"`. The minimal\nrollup bit for monitoring: operator attention required.",
       "type": "boolean"
     },
     "next_action": {
-      "description": "Operator-facing remediation hint pulled from the first `FAIL` row's `next_action` text. `None` when no row failed or none carried a remedy.",
+      "description": "Operator-facing remediation hint pulled from the first\n`FAIL` row's `next_action` text. `None` when no row failed\nor none carried a remedy.",
       "type": [
         "string",
         "null"
       ]
     },
     "rows": {
-      "description": "One entry per check run. Order is check-declaration order inside `doctor.rs` — stable across invocations on the same host.",
+      "description": "One entry per check run. Order is check-declaration order\ninside `doctor.rs` — stable across invocations on the same\nhost.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/DoctorRow"
+        "$ref": "#/$defs/DoctorRow"
       }
     },
     "schema_version": {
       "description": "Wire-format version. See [`DOCTOR_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "score": {
-      "description": "Aggregate score (0–100). PASS = 1.0, WARN = 0.7, FAIL = 0.0; skipped rows are excluded from the denominator.",
+      "description": "Aggregate score (0–100). PASS = 1.0, WARN = 0.7, FAIL =\n0.0; skipped rows are excluded from the denominator.",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool_version": {
       "description": "`aegis-boot` binary version that produced this envelope.",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "score",
+    "band",
+    "has_any_fail",
+    "rows"
+  ],
+  "$defs": {
     "DoctorRow": {
       "description": "One check result in a [`DoctorReport`].",
       "type": "object",
-      "required": [
-        "detail",
-        "name",
-        "verdict"
-      ],
       "properties": {
         "detail": {
           "description": "Single-line detail (filepath, value, or error message).",
@@ -70,10 +65,15 @@
           "type": "string"
         },
         "verdict": {
-          "description": "Verdict label — `\"PASS\"`, `\"WARN\"`, `\"FAIL\"`, or `\"SKIP\"`. String (not enum) because the CLI's verdict vocabulary is intentionally loose: new verdicts can be added without a `schema_version` bump so long as consumers treat unknown values as \"don't block on this.\"",
+          "description": "Verdict label — `\"PASS\"`, `\"WARN\"`, `\"FAIL\"`, or `\"SKIP\"`.\nString (not enum) because the CLI's verdict vocabulary is\nintentionally loose: new verdicts can be added without a\n`schema_version` bump so long as consumers treat unknown\nvalues as \"don't block on this.\"",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "verdict",
+        "name",
+        "detail"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-failure-microreport.schema.json
+++ b/docs/reference/schemas/aegis-boot-failure-microreport.schema.json
@@ -1,30 +1,19 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FailureMicroreport",
-  "description": "Tier-A anonymous failure microreport — written by `rescue-tui` / initramfs to `AEGIS_ISOS/aegis-boot-logs/<ts>-<hash>.json` when a classifiable boot failure occurs, so the operator can later include the log in an `aegis-boot bug-report` bundle (#342 Phase 2).\n\n**Anonymous by construction.** Every field is either an aegis-boot version, a loosely-bucketed machine-family hint, or an opaque content hash. No hostname, no DMI serial, no full error text. Matches [ABRT's uReport] (<https://fedoraproject.org/wiki/Features/SimplifiedCrashReporting>) pattern: safe to ship without operator review, useful for failure-class correlation across a fleet.\n\nTier B (full structured log, consent-gated) lands in a later phase with a distinct `schema_version` track.",
+  "description": "Tier-A anonymous failure microreport — written by `rescue-tui`\n/ initramfs to `AEGIS_ISOS/aegis-boot-logs/<ts>-<hash>.json`\nwhen a classifiable boot failure occurs, so the operator can\nlater include the log in an `aegis-boot bug-report` bundle\n(#342 Phase 2).\n\n**Anonymous by construction.** Every field is either an\naegis-boot version, a loosely-bucketed machine-family hint, or\nan opaque content hash. No hostname, no DMI serial, no full\nerror text. Matches [ABRT's uReport]\n(<https://fedoraproject.org/wiki/Features/SimplifiedCrashReporting>)\npattern: safe to ship without operator review, useful for\nfailure-class correlation across a fleet.\n\nTier B (full structured log, consent-gated) lands in a later\nphase with a distinct `schema_version` track.",
   "type": "object",
-  "required": [
-    "aegis_boot_version",
-    "bios_year",
-    "boot_step_reached",
-    "collected_at",
-    "failure_class",
-    "failure_hash",
-    "schema_version",
-    "tier",
-    "vendor_family"
-  ],
   "properties": {
     "aegis_boot_version": {
       "description": "`aegis-boot` version string that produced this log.",
       "type": "string"
     },
     "bios_year": {
-      "description": "Four-digit year extracted from the DMI `bios_date` (e.g. `\"2024\"`). Year-granularity is coarse enough to preserve anonymity on any laptop model older than a few months.",
+      "description": "Four-digit year extracted from the DMI `bios_date` (e.g.\n`\"2024\"`). Year-granularity is coarse enough to preserve\nanonymity on any laptop model older than a few months.",
       "type": "string"
     },
     "boot_step_reached": {
-      "description": "Classified boot stage the failure occurred at. One of: `\"pre_kernel\"`, `\"kernel_init\"`, `\"initramfs\"`, `\"rescue_tui\"`, `\"kexec_handoff\"`.",
+      "description": "Classified boot stage the failure occurred at. One of:\n`\"pre_kernel\"`, `\"kernel_init\"`, `\"initramfs\"`,\n`\"rescue_tui\"`, `\"kexec_handoff\"`.",
       "type": "string"
     },
     "collected_at": {
@@ -32,26 +21,37 @@
       "type": "string"
     },
     "failure_class": {
-      "description": "Classified failure code. String (not enum) so new classifications can be added without a `schema_version` bump. Consumer convention: treat unknown codes as `\"unclassified\"`.",
+      "description": "Classified failure code. String (not enum) so new\nclassifications can be added without a `schema_version`\nbump. Consumer convention: treat unknown codes as\n`\"unclassified\"`.",
       "type": "string"
     },
     "failure_hash": {
-      "description": "Opaque hash (`sha256:<64-hex>`) of the full raw error text. Lets a maintainer match two field reports as \"same failure\" without either operator sharing the raw text.",
+      "description": "Opaque hash (`sha256:<64-hex>`) of the full raw error text.\nLets a maintainer match two field reports as \"same failure\"\nwithout either operator sharing the raw text.",
       "type": "string"
     },
     "schema_version": {
       "description": "Wire-format version. See [`FAILURE_MICROREPORT_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tier": {
-      "description": "Tier marker. Always `\"A\"` in this envelope; reserved for `\"B\"` when the consent-gated full-log tier ships.",
+      "description": "Tier marker. Always `\"A\"` in this envelope; reserved for\n`\"B\"` when the consent-gated full-log tier ships.",
       "type": "string"
     },
     "vendor_family": {
-      "description": "Lowercased first token of the DMI `sys_vendor` field (e.g. `\"framework\"`, `\"lenovo\"`, `\"dell\"`). Vendor-granularity only — enough to correlate per-vendor bugs without identifying the operator.",
+      "description": "Lowercased first token of the DMI `sys_vendor` field (e.g.\n`\"framework\"`, `\"lenovo\"`, `\"dell\"`). Vendor-granularity\nonly — enough to correlate per-vendor bugs without\nidentifying the operator.",
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "schema_version",
+    "tier",
+    "collected_at",
+    "aegis_boot_version",
+    "vendor_family",
+    "bios_year",
+    "boot_step_reached",
+    "failure_class",
+    "failure_hash"
+  ]
 }

--- a/docs/reference/schemas/aegis-boot-list.schema.json
+++ b/docs/reference/schemas/aegis-boot-list.schema.json
@@ -1,21 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ListReport",
-  "description": "Envelope emitted by `aegis-boot list --json`. Reports the ISOs discovered on a stick's AEGIS_ISOS data partition, plus the attestation summary if one was recorded at flash time.",
+  "description": "Envelope emitted by `aegis-boot list --json`. Reports the ISOs\ndiscovered on a stick's AEGIS_ISOS data partition, plus the\nattestation summary if one was recorded at flash time.",
   "type": "object",
-  "required": [
-    "count",
-    "isos",
-    "mount_path",
-    "schema_version",
-    "tool_version"
-  ],
   "properties": {
     "attestation": {
-      "description": "Chain-of-custody summary from the matching attestation record, or null if no attestation was found (operator flashed on a different host, or pre-v0.13.0 stick).",
+      "description": "Chain-of-custody summary from the matching attestation\nrecord, or null if no attestation was found (operator\nflashed on a different host, or pre-v0.13.0 stick).",
       "anyOf": [
         {
-          "$ref": "#/definitions/ListAttestationSummary"
+          "$ref": "#/$defs/ListAttestationSummary"
         },
         {
           "type": "null"
@@ -23,53 +16,54 @@
       ]
     },
     "count": {
-      "description": "Number of ISOs observed. Redundant with `isos.len()` but useful for consumers that only read the header.",
+      "description": "Number of ISOs observed. Redundant with `isos.len()` but\nuseful for consumers that only read the header.",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "isos": {
       "description": "Per-ISO details. See [`ListIsoSummary`].",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/ListIsoSummary"
+        "$ref": "#/$defs/ListIsoSummary"
       }
     },
     "mount_path": {
-      "description": "Filesystem mount path the stick was resolved to (e.g. `/run/media/alice/AEGIS_ISOS`).",
+      "description": "Filesystem mount path the stick was resolved to (e.g.\n`/run/media/alice/AEGIS_ISOS`).",
       "type": "string"
     },
     "schema_version": {
       "description": "Wire-format version. See [`LIST_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool_version": {
       "description": "`aegis-boot` binary version that produced this envelope.",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "mount_path",
+    "count",
+    "isos"
+  ],
+  "$defs": {
     "ListAttestationSummary": {
-      "description": "Compact attestation summary embedded in [`ListReport`]. Derived from the stored [`Attestation`] record; smaller than the full attestation (no device fingerprint, no host kernel string) so the list envelope stays lightweight.",
+      "description": "Compact attestation summary embedded in [`ListReport`]. Derived\nfrom the stored [`Attestation`] record; smaller than the full\nattestation (no device fingerprint, no host kernel string) so\nthe list envelope stays lightweight.",
       "type": "object",
-      "required": [
-        "flashed_at",
-        "isos_recorded",
-        "manifest_path",
-        "operator"
-      ],
       "properties": {
         "flashed_at": {
           "description": "RFC 3339 timestamp of the flash operation.",
           "type": "string"
         },
         "isos_recorded": {
-          "description": "Count of ISOs recorded in the attestation. Note this can differ from [`ListReport::count`] — the attestation tracks ISOs that were added via `aegis-boot add`, while the list count scans the actual partition. A mismatch is a signal that someone hand-copied an ISO rather than using the CLI.",
+          "description": "Count of ISOs recorded in the attestation. Note this can\ndiffer from [`ListReport::count`] — the attestation tracks\nISOs that were added via `aegis-boot add`, while the list\ncount scans the actual partition. A mismatch is a signal\nthat someone hand-copied an ISO rather than using the CLI.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "manifest_path": {
           "description": "Filesystem path of the host-side attestation manifest.",
@@ -79,34 +73,34 @@
           "description": "Operator that ran `aegis-boot flash`.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "flashed_at",
+        "operator",
+        "isos_recorded",
+        "manifest_path"
+      ]
     },
     "ListIsoSummary": {
-      "description": "Per-ISO detail in [`ListReport`]. The `display_name` + `description` fields come from an optional `<iso>.aegis.toml` operator-label sidecar (#246); they are always present in the wire format (as `null` when absent) so consumers see a stable shape.",
+      "description": "Per-ISO detail in [`ListReport`]. The `display_name` +\n`description` fields come from an optional `<iso>.aegis.toml`\noperator-label sidecar (#246); they are always present in the\nwire format (as `null` when absent) so consumers see a stable\nshape.",
       "type": "object",
-      "required": [
-        "has_minisig",
-        "has_sha256",
-        "name",
-        "size_bytes"
-      ],
       "properties": {
         "description": {
-          "description": "Operator-curated description from `<iso>.aegis.toml`, or null when the sidecar is absent.",
+          "description": "Operator-curated description from `<iso>.aegis.toml`, or\nnull when the sidecar is absent.",
           "type": [
             "string",
             "null"
           ]
         },
         "display_name": {
-          "description": "Operator-curated display name from `<iso>.aegis.toml`, or null when the sidecar is absent. Intentionally NOT omitted when null — consumers depend on a stable field set.",
+          "description": "Operator-curated display name from `<iso>.aegis.toml`, or\nnull when the sidecar is absent. Intentionally NOT omitted\nwhen null — consumers depend on a stable field set.",
           "type": [
             "string",
             "null"
           ]
         },
         "folder": {
-          "description": "Subfolder path relative to the data-partition mount, or `null` when the ISO sits at the root. `\"ubuntu-24.04\"` for a single level, `\"ubuntu/24.04\"` for nested (forward-slash separator regardless of host OS — the stick filesystem is exFAT, which normalizes to `/`). Added in v0.16.0 (#274 Phase 6a) as an additive optional field; v0.15.x consumers that ignore unknown keys see no behavior change, and the `name` field remains a basename for scripts that joined it directly.",
+          "description": "Subfolder path relative to the data-partition mount, or `null`\nwhen the ISO sits at the root. `\"ubuntu-24.04\"` for a single\nlevel, `\"ubuntu/24.04\"` for nested (forward-slash separator\nregardless of host OS — the stick filesystem is exFAT, which\nnormalizes to `/`). Added in v0.16.0 (#274 Phase 6a) as an\nadditive optional field; v0.15.x consumers that ignore\nunknown keys see no behavior change, and the `name` field\nremains a basename for scripts that joined it directly.",
           "type": [
             "string",
             "null"
@@ -121,16 +115,22 @@
           "type": "boolean"
         },
         "name": {
-          "description": "ISO basename (no directory component). Consumers that join `mount_path + name` will get the root-of-stick path, which is only valid when `folder` is null. For sticks with subfolder layouts (#274 Phase 6), join `mount_path + folder + name`. Kept as basename — separate from `folder` — so downstream automation that shelled out to `basename(1)` on the old flat layout keeps working.",
+          "description": "ISO basename (no directory component). Consumers that join\n`mount_path + name` will get the root-of-stick path, which is\nonly valid when `folder` is null. For sticks with subfolder\nlayouts (#274 Phase 6), join `mount_path + folder + name`.\nKept as basename — separate from `folder` — so downstream\nautomation that shelled out to `basename(1)` on the old flat\nlayout keeps working.",
           "type": "string"
         },
         "size_bytes": {
           "description": "ISO size in bytes.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "name",
+        "size_bytes",
+        "has_sha256",
+        "has_minisig"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-manifest.schema.json
+++ b/docs/reference/schemas/aegis-boot-manifest.schema.json
@@ -1,78 +1,68 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Manifest",
-  "description": "Top-level manifest body. Serialized field order matches the declaration order below — relied on for canonical JSON stability (the signature is computed over `serde_json::to_vec(&Manifest)`).\n\nThe Rust field is `sequence` (clippy prefers not to prefix the struct name); the JSON wire field stays `manifest_sequence` per the [#277] schema lock via `#[serde(rename)]`.\n\n[#277]: https://github.com/aegis-boot/aegis-boot/issues/277",
+  "description": "Top-level manifest body. Serialized field order matches the\ndeclaration order below — relied on for canonical JSON stability\n(the signature is computed over `serde_json::to_vec(&Manifest)`).\n\nThe Rust field is `sequence` (clippy prefers not to prefix the\nstruct name); the JSON wire field stays `manifest_sequence` per\nthe [#277] schema lock via `#[serde(rename)]`.\n\n[#277]: https://github.com/aegis-boot/aegis-boot/issues/277",
   "type": "object",
-  "required": [
-    "allowed_files_closed_set",
-    "device",
-    "esp_files",
-    "expected_pcrs",
-    "manifest_sequence",
-    "schema_version",
-    "tool_version"
-  ],
   "properties": {
     "allowed_files_closed_set": {
-      "description": "When `true`, the verifier treats [`Self::esp_files`] as exhaustive — the presence of any additional file on the ESP is itself a violation. Always `true` in PR3; left as a field so future phases can ship an evolutionary \"extended\" manifest without breaking consumers.",
+      "description": "When `true`, the verifier treats [`Self::esp_files`] as\nexhaustive — the presence of any additional file on the ESP\nis itself a violation. Always `true` in PR3; left as a\nfield so future phases can ship an evolutionary \"extended\"\nmanifest without breaking consumers.",
       "type": "boolean"
     },
     "device": {
       "description": "Device identity captured at flash time.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Device"
-        }
-      ]
+      "$ref": "#/$defs/Device"
     },
     "esp_files": {
-      "description": "Closed set of files on the ESP. Verifier rejects the stick if any ESP file is not listed here or is missing / has a different sha256 than recorded. Six entries today, one per line in the signed-chain layout established by Phase 2b of [#274](https://github.com/aegis-boot/aegis-boot/issues/274).",
+      "description": "Closed set of files on the ESP. Verifier rejects the stick\nif any ESP file is not listed here or is missing / has a\ndifferent sha256 than recorded. Six entries today, one per\nline in the signed-chain layout established by Phase 2b of\n[#274](https://github.com/aegis-boot/aegis-boot/issues/274).",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/EspFileEntry"
+        "$ref": "#/$defs/EspFileEntry"
       }
     },
     "expected_pcrs": {
-      "description": "Reserved for E6 / Phase 3 TPM attestation. Left empty by PR3; once E6 locks the PCR selection this vector grows populated rows.",
+      "description": "Reserved for E6 / Phase 3 TPM attestation. Left empty by\nPR3; once E6 locks the PCR selection this vector grows\npopulated rows.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/PcrEntry"
+        "$ref": "#/$defs/PcrEntry"
       }
     },
     "manifest_sequence": {
-      "description": "Monotonic-per-flash sequence number. Defends against rollback to an older validly-signed manifest without relying on a secure RTC. Verifiers track the highest sequence they've ever seen for a given device fingerprint and reject manifests whose sequence is strictly less.",
+      "description": "Monotonic-per-flash sequence number. Defends against\nrollback to an older validly-signed manifest without\nrelying on a secure RTC. Verifiers track the highest\nsequence they've ever seen for a given device fingerprint\nand reject manifests whose sequence is strictly less.",
       "type": "integer",
       "format": "uint64",
-      "minimum": 0.0
+      "minimum": 0
     },
     "schema_version": {
       "description": "Wire-format version. See [`SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool_version": {
-      "description": "`aegis-boot` binary version that produced the manifest (e.g. `\"aegis-boot 0.14.1\"`). Informational — not a trust anchor.",
+      "description": "`aegis-boot` binary version that produced the manifest\n(e.g. `\"aegis-boot 0.14.1\"`). Informational — not a trust\nanchor.",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "manifest_sequence",
+    "device",
+    "esp_files",
+    "allowed_files_closed_set",
+    "expected_pcrs"
+  ],
+  "$defs": {
     "DataPartition": {
       "description": "Identity of the AEGIS_ISOS data partition (partition 2).",
       "type": "object",
-      "required": [
-        "fs_uuid",
-        "label",
-        "partuuid",
-        "type_guid"
-      ],
       "properties": {
         "fs_uuid": {
           "description": "Filesystem UUID.",
           "type": "string"
         },
         "label": {
-          "description": "Filesystem label — always `AEGIS_ISOS` for aegis-boot sticks.",
+          "description": "Filesystem label — always `AEGIS_ISOS` for aegis-boot\nsticks.",
           "type": "string"
         },
         "partuuid": {
@@ -80,28 +70,24 @@
           "type": "string"
         },
         "type_guid": {
-          "description": "GPT partition-type GUID — Microsoft Basic Data for exfat/fat32, Linux Filesystem for ext4.",
+          "description": "GPT partition-type GUID — Microsoft Basic Data for\nexfat/fat32, Linux Filesystem for ext4.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "partuuid",
+        "type_guid",
+        "fs_uuid",
+        "label"
+      ]
     },
     "Device": {
-      "description": "Device identity captured at flash time. All values come from the freshly-written GPT (`blkid` + `sgdisk -p`); the verifier re-reads them at runtime and asserts equality.",
+      "description": "Device identity captured at flash time. All values come from the\nfreshly-written GPT (`blkid` + `sgdisk -p`); the verifier\nre-reads them at runtime and asserts equality.",
       "type": "object",
-      "required": [
-        "data",
-        "disk_guid",
-        "esp",
-        "partition_count"
-      ],
       "properties": {
         "data": {
-          "description": "Data partition identity — `AEGIS_ISOS` label, exfat by default, fat32 or ext4 opt-in.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/DataPartition"
-            }
-          ]
+          "description": "Data partition identity — `AEGIS_ISOS` label, exfat by\ndefault, fat32 or ext4 opt-in.",
+          "$ref": "#/$defs/DataPartition"
         },
         "disk_guid": {
           "description": "GPT disk GUID.",
@@ -109,31 +95,28 @@
         },
         "esp": {
           "description": "ESP partition identity — first partition by design.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/EspPartition"
-            }
-          ]
+          "$ref": "#/$defs/EspPartition"
         },
         "partition_count": {
-          "description": "Total partition count observed at flash time. aegis-boot lays down exactly two partitions (ESP + AEGIS_ISOS); a verifier reading three or more partitions on the same disk rejects the stick.",
+          "description": "Total partition count observed at flash time. aegis-boot\nlays down exactly two partitions (ESP + AEGIS_ISOS); a\nverifier reading three or more partitions on the same disk\nrejects the stick.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "disk_guid",
+        "partition_count",
+        "esp",
+        "data"
+      ]
     },
     "EspFileEntry": {
       "description": "A single file on the ESP with its content hash and size.",
       "type": "object",
-      "required": [
-        "path",
-        "sha256",
-        "size_bytes"
-      ],
       "properties": {
         "path": {
-          "description": "Mtools-style `::/`-rooted path on the ESP (e.g. `::/EFI/BOOT/BOOTX64.EFI`). The verifier lowercases both sides before comparison because FAT32 is case-insensitive.",
+          "description": "Mtools-style `::/`-rooted path on the ESP (e.g.\n`::/EFI/BOOT/BOOTX64.EFI`). The verifier lowercases both\nsides before comparison because FAT32 is case-insensitive.",
           "type": "string"
         },
         "sha256": {
@@ -141,29 +124,27 @@
           "type": "string"
         },
         "size_bytes": {
-          "description": "File size in bytes. Redundant with sha256 but cheap to check first — a size mismatch lets the verifier reject without reading the full body.",
+          "description": "File size in bytes. Redundant with sha256 but cheap to\ncheck first — a size mismatch lets the verifier reject\nwithout reading the full body.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "path",
+        "sha256",
+        "size_bytes"
+      ]
     },
     "EspPartition": {
       "description": "Identity of the ESP partition (partition 1).",
       "type": "object",
-      "required": [
-        "first_lba",
-        "fs_uuid",
-        "last_lba",
-        "partuuid",
-        "type_guid"
-      ],
       "properties": {
         "first_lba": {
           "description": "First absolute LBA of the partition's extent on disk.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         },
         "fs_uuid": {
           "description": "FAT32 volume serial number (`blkid -o value -s UUID`).",
@@ -173,26 +154,28 @@
           "description": "Last absolute LBA of the partition's extent on disk.",
           "type": "integer",
           "format": "uint64",
-          "minimum": 0.0
+          "minimum": 0
         },
         "partuuid": {
           "description": "GPT PARTUUID (per-partition unique identifier).",
           "type": "string"
         },
         "type_guid": {
-          "description": "GPT partition-type GUID. For the ESP this is `C12A7328-F81F-11D2-BA4B-00A0C93EC93B`.",
+          "description": "GPT partition-type GUID. For the ESP this is\n`C12A7328-F81F-11D2-BA4B-00A0C93EC93B`.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "partuuid",
+        "type_guid",
+        "fs_uuid",
+        "first_lba",
+        "last_lba"
+      ]
     },
     "PcrEntry": {
-      "description": "Expected TPM PCR value at an aegis-boot stick's first post-boot measurement. Empty in PR3; populated once E6 locks the PCR selection.",
+      "description": "Expected TPM PCR value at an aegis-boot stick's first post-boot\nmeasurement. Empty in PR3; populated once E6 locks the PCR\nselection.",
       "type": "object",
-      "required": [
-        "bank",
-        "digest_hex",
-        "pcr_index"
-      ],
       "properties": {
         "bank": {
           "description": "Hash bank — `sha256`, `sha384`, etc.",
@@ -206,9 +189,14 @@
           "description": "PCR index (0..23 for most banks).",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "pcr_index",
+        "bank",
+        "digest_hex"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-recommend.schema.json
+++ b/docs/reference/schemas/aegis-boot-recommend.schema.json
@@ -1,83 +1,60 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "RecommendReport",
-  "description": "Envelope emitted by `aegis-boot recommend --json`. Untagged wrapper around three mutually-exclusive shapes: a full catalog listing, a single-entry response, or a miss. Consumers branch on the presence of `entries` / `entry` / `error`.\n\nThe miss shape intentionally omits `tool_version` — matches the existing wire format. Future schema bumps can unify the three shapes; Phase 4b-6 preserves the current contract.",
+  "description": "Envelope emitted by `aegis-boot recommend --json`. Untagged\nwrapper around three mutually-exclusive shapes: a full catalog\nlisting, a single-entry response, or a miss. Consumers branch\non the presence of `entries` / `entry` / `error`.\n\nThe miss shape intentionally omits `tool_version` — matches\nthe existing wire format. Future schema bumps can unify the\nthree shapes; Phase 4b-6 preserves the current contract.",
   "anyOf": [
     {
-      "description": "Full catalog listing. Emitted when `aegis-boot recommend --json` is called with no slug.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/RecommendCatalogReport"
-        }
-      ]
+      "description": "Full catalog listing. Emitted when `aegis-boot recommend\n--json` is called with no slug.",
+      "$ref": "#/$defs/RecommendCatalogReport"
     },
     {
-      "description": "Single-entry response. Emitted when the slug matched one catalog entry exactly.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/RecommendSingleReport"
-        }
-      ]
+      "description": "Single-entry response. Emitted when the slug matched one\ncatalog entry exactly.",
+      "$ref": "#/$defs/RecommendSingleReport"
     },
     {
       "description": "Miss — the slug didn't match any entry.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/RecommendMissReport"
-        }
-      ]
+      "$ref": "#/$defs/RecommendMissReport"
     }
   ],
-  "definitions": {
+  "$defs": {
     "RecommendCatalogReport": {
       "description": "Full-catalog variant of [`RecommendReport`].",
       "type": "object",
-      "required": [
-        "count",
-        "entries",
-        "schema_version",
-        "tool_version"
-      ],
       "properties": {
         "count": {
           "description": "Total entries in the catalog. Equals `entries.len()`.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "entries": {
-          "description": "All catalog entries in the order `CATALOG` defines them (typically alphabetical by slug).",
+          "description": "All catalog entries in the order `CATALOG` defines them\n(typically alphabetical by slug).",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/RecommendEntry"
+            "$ref": "#/$defs/RecommendEntry"
           }
         },
         "schema_version": {
           "description": "Wire-format version. See [`RECOMMEND_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "tool_version": {
           "description": "`aegis-boot` binary version that produced this envelope.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "tool_version",
+        "count",
+        "entries"
+      ]
     },
     "RecommendEntry": {
-      "description": "One curated catalog entry. Used in both [`RecommendCatalogReport::entries`] and [`RecommendSingleReport::entry`].",
+      "description": "One curated catalog entry. Used in both\n[`RecommendCatalogReport::entries`] and\n[`RecommendSingleReport::entry`].",
       "type": "object",
-      "required": [
-        "arch",
-        "iso_url",
-        "name",
-        "purpose",
-        "sb",
-        "sha256_url",
-        "sig_url",
-        "size_mib",
-        "slug"
-      ],
       "properties": {
         "arch": {
           "description": "CPU architecture (`\"amd64\"`, `\"arm64\"`, …).",
@@ -92,11 +69,11 @@
           "type": "string"
         },
         "purpose": {
-          "description": "One-line operator-facing purpose (e.g. `\"Standard server install media\"`).",
+          "description": "One-line operator-facing purpose (e.g. `\"Standard server\ninstall media\"`).",
           "type": "string"
         },
         "sb": {
-          "description": "Secure Boot status string — one of `\"signed:<vendor>\"` (e.g. `\"signed:canonical\"`), `\"unsigned-needs-mok\"`, or `\"unknown\"`.",
+          "description": "Secure Boot status string — one of `\"signed:<vendor>\"` (e.g.\n`\"signed:canonical\"`), `\"unsigned-needs-mok\"`, or\n`\"unknown\"`.",
           "type": "string"
         },
         "sha256_url": {
@@ -104,28 +81,35 @@
           "type": "string"
         },
         "sig_url": {
-          "description": "HTTPS URL of the detached signature over the SHA256SUMS file (typically a GPG `.gpg`).",
+          "description": "HTTPS URL of the detached signature over the SHA256SUMS file\n(typically a GPG `.gpg`).",
           "type": "string"
         },
         "size_mib": {
-          "description": "ISO size in mebibytes (rounded to nearest; informational for download-time estimates, not a strict guarantee). `u32` accommodates up to ~4 PiB — plenty of headroom for any realistic ISO.",
+          "description": "ISO size in mebibytes (rounded to nearest; informational\nfor download-time estimates, not a strict guarantee).\n`u32` accommodates up to ~4 PiB — plenty of headroom for\nany realistic ISO.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "slug": {
-          "description": "Short stable identifier (e.g. `\"ubuntu-24.04-live-server\"`). Used by `aegis-boot fetch <slug>` to resolve a URL set.",
+          "description": "Short stable identifier (e.g. `\"ubuntu-24.04-live-server\"`).\nUsed by `aegis-boot fetch <slug>` to resolve a URL set.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "slug",
+        "name",
+        "arch",
+        "size_mib",
+        "iso_url",
+        "sha256_url",
+        "sig_url",
+        "sb",
+        "purpose"
+      ]
     },
     "RecommendMissReport": {
-      "description": "Miss variant of [`RecommendReport`] — no catalog entry matched the given slug. The envelope is deliberately asymmetric from the success variants (no `tool_version`) to match the existing wire format; tightening to always emit `tool_version` would be an additive (non-breaking) future change.",
+      "description": "Miss variant of [`RecommendReport`] — no catalog entry matched\nthe given slug. The envelope is deliberately asymmetric from\nthe success variants (no `tool_version`) to match the existing\nwire format; tightening to always emit `tool_version` would be\nan additive (non-breaking) future change.",
       "type": "object",
-      "required": [
-        "error",
-        "schema_version"
-      ],
       "properties": {
         "error": {
           "description": "Human-readable error (\"no catalog entry matching '<slug>'\").",
@@ -135,38 +119,38 @@
           "description": "Wire-format version. See [`RECOMMEND_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "error"
+      ]
     },
     "RecommendSingleReport": {
       "description": "Single-entry variant of [`RecommendReport`].",
       "type": "object",
-      "required": [
-        "entry",
-        "schema_version",
-        "tool_version"
-      ],
       "properties": {
         "entry": {
           "description": "The matched catalog entry.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/RecommendEntry"
-            }
-          ]
+          "$ref": "#/$defs/RecommendEntry"
         },
         "schema_version": {
           "description": "Wire-format version. See [`RECOMMEND_SCHEMA_VERSION`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "tool_version": {
           "description": "`aegis-boot` binary version that produced this envelope.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "schema_version",
+        "tool_version",
+        "entry"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-update.schema.json
+++ b/docs/reference/schemas/aegis-boot-update.schema.json
@@ -1,75 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "UpdateReport",
-  "description": "Envelope emitted by `aegis-boot update --json`. Phase 1 of #181 is eligibility-check-only: answers \"would a non-destructive signed-chain rotation apply cleanly to this stick?\" — the actual rotation is Phase 2. The envelope's outer fields (`schema_version`, `tool_version`, `device`) are common; the [`eligibility`] flattened enum carries the variant-specific body.",
+  "description": "Envelope emitted by `aegis-boot update --json`. Phase 1 of #181\nis eligibility-check-only: answers \"would a non-destructive\nsigned-chain rotation apply cleanly to this stick?\" — the actual\nrotation is Phase 2. The envelope's outer fields\n(`schema_version`, `tool_version`, `device`) are common; the\n[`eligibility`] flattened enum carries the variant-specific\nbody.",
   "type": "object",
-  "oneOf": [
-    {
-      "description": "The stick could accept an in-place signed-chain rotation. Reports the disk GUID (matches the ESP partition table's `.disk_guid`), the host-side attestation that would be updated, and the new signed chain the host would write.",
-      "type": "object",
-      "required": [
-        "attestation_path",
-        "disk_guid",
-        "eligibility",
-        "host_chain"
-      ],
-      "properties": {
-        "attestation_path": {
-          "description": "Host filesystem path of the attestation manifest that the rotation will update.",
-          "type": "string"
-        },
-        "disk_guid": {
-          "description": "GPT disk GUID of the stick (matches the attestation manifest's `device.disk_guid`).",
-          "type": "string"
-        },
-        "eligibility": {
-          "type": "string",
-          "enum": [
-            "ELIGIBLE"
-          ]
-        },
-        "esp_diff": {
-          "description": "Per-file diff between the current ESP contents and what a fresh flash would produce. Phase 1 of #181: informational only — eligibility does not depend on the diff. Empty when the ESP could not be read (e.g. missing `mtype`, partition unreadable); in that case the operator still gets the [`host_chain`] preview.\n\nAdded in `schema_version = 2`. `serde(default)` + `skip_serializing_if = \"Vec::is_empty\"` make the bump additive: v1 payloads parse as v2 with an empty vec.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/UpdateFileDiff"
-          }
-        },
-        "host_chain": {
-          "description": "Ordered signed-chain files the host would install if the operator re-ran flash today (shim / grub / kernel / initrd). Each carries either `sha256` (success) or `error` (could not be hashed / located).",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/UpdateChainEntry"
-          }
-        }
-      }
-    },
-    {
-      "description": "The stick cannot accept a rotation. Carries the operator- readable reason (device not removable, no attestation on this host, signed-chain source missing, …).",
-      "type": "object",
-      "required": [
-        "eligibility",
-        "reason"
-      ],
-      "properties": {
-        "eligibility": {
-          "type": "string",
-          "enum": [
-            "INELIGIBLE"
-          ]
-        },
-        "reason": {
-          "description": "Explanation of why the rotation was refused.",
-          "type": "string"
-        }
-      }
-    }
-  ],
-  "required": [
-    "device",
-    "schema_version",
-    "tool_version"
-  ],
   "properties": {
     "device": {
       "description": "Device node path operated on (e.g. `/dev/sda`).",
@@ -79,110 +12,173 @@
       "description": "Wire-format version. See [`UPDATE_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool_version": {
       "description": "`aegis-boot` binary version that produced this envelope.",
       "type": "string"
     }
   },
-  "definitions": {
-    "UpdateChainEntry": {
-      "description": "One signed-chain entry in an [`UpdateEligibility::Eligible`] response. Two mutually-exclusive wire shapes via untagged-enum dispatch on the presence of `sha256` vs `error`.",
+  "oneOf": [
+    {
+      "description": "The stick could accept an in-place signed-chain rotation.\nReports the disk GUID (matches the ESP partition table's\n`.disk_guid`), the host-side attestation that would be\nupdated, and the new signed chain the host would write.",
       "type": "object",
-      "anyOf": [
-        {
-          "description": "File was hashed successfully.",
-          "type": "object",
-          "required": [
-            "sha256"
-          ],
-          "properties": {
-            "sha256": {
-              "description": "Lowercase hex sha256 of the file.",
-              "type": "string"
-            }
+      "properties": {
+        "attestation_path": {
+          "description": "Host filesystem path of the attestation manifest that\nthe rotation will update.",
+          "type": "string"
+        },
+        "disk_guid": {
+          "description": "GPT disk GUID of the stick (matches the attestation\nmanifest's `device.disk_guid`).",
+          "type": "string"
+        },
+        "eligibility": {
+          "type": "string",
+          "const": "ELIGIBLE"
+        },
+        "esp_diff": {
+          "description": "Per-file diff between the current ESP contents and what\na fresh flash would produce. Phase 1 of #181:\ninformational only — eligibility does not depend on the\ndiff. Empty when the ESP could not be read (e.g.\nmissing `mtype`, partition unreadable); in that case the\noperator still gets the [`host_chain`] preview.\n\nAdded in `schema_version = 2`. `serde(default)` +\n`skip_serializing_if = \"Vec::is_empty\"` make the bump\nadditive: v1 payloads parse as v2 with an empty vec.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UpdateFileDiff"
           }
         },
-        {
-          "description": "File could not be hashed (missing, permission denied, read error). `reason` is operator-facing.",
-          "type": "object",
-          "required": [
-            "error"
-          ],
-          "properties": {
-            "error": {
-              "description": "Human-readable error.",
-              "type": "string"
-            }
+        "host_chain": {
+          "description": "Ordered signed-chain files the host would install if\nthe operator re-ran flash today (shim / grub /\nkernel / initrd). Each carries either `sha256` (success)\nor `error` (could not be hashed / located).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UpdateChainEntry"
           }
         }
-      ],
+      },
       "required": [
-        "path",
-        "role"
-      ],
+        "eligibility",
+        "disk_guid",
+        "attestation_path",
+        "host_chain"
+      ]
+    },
+    {
+      "description": "The stick cannot accept a rotation. Carries the operator-\nreadable reason (device not removable, no attestation on\nthis host, signed-chain source missing, …).",
+      "type": "object",
+      "properties": {
+        "eligibility": {
+          "type": "string",
+          "const": "INELIGIBLE"
+        },
+        "reason": {
+          "description": "Explanation of why the rotation was refused.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "eligibility",
+        "reason"
+      ]
+    }
+  ],
+  "required": [
+    "schema_version",
+    "tool_version",
+    "device"
+  ],
+  "$defs": {
+    "UpdateChainEntry": {
+      "description": "One signed-chain entry in an [`UpdateEligibility::Eligible`]\nresponse. Two mutually-exclusive wire shapes via untagged-enum\ndispatch on the presence of `sha256` vs `error`.",
+      "type": "object",
       "properties": {
         "path": {
           "description": "Host filesystem path of the source file.",
           "type": "string"
         },
         "role": {
-          "description": "Role in the signed chain: `shim`, `grub`, `kernel`, or `initrd`.",
+          "description": "Role in the signed chain: `shim`, `grub`, `kernel`, or\n`initrd`.",
           "type": "string"
         }
-      }
+      },
+      "anyOf": [
+        {
+          "description": "File was hashed successfully.",
+          "type": "object",
+          "properties": {
+            "sha256": {
+              "description": "Lowercase hex sha256 of the file.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "sha256"
+          ]
+        },
+        {
+          "description": "File could not be hashed (missing, permission denied,\nread error). `reason` is operator-facing.",
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Human-readable error.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ],
+      "required": [
+        "role",
+        "path"
+      ]
     },
     "UpdateFileDiff": {
-      "description": "Per-file diff row between what's currently on the stick's ESP and what a fresh `mkusb` / direct-install flash would write. One row per canonical ESP destination (see `direct_install::ESP_DEST_*`).\n\nSemantics of the hash/error pairs:\n\n* `current_sha256` is `None` when the ESP file couldn't be read (file absent, `mtype` missing, permission denied); in that case `current_error` carries the operator-facing reason. * `fresh_sha256` is `None` when the host-side source couldn't be hashed (package not installed, kernel glob missed, etc); `fresh_error` carries the reason. * `would_change` is the Phase-1 verdict the operator cares about: `true` only when both hashes are present AND they differ. When either hash is absent the comparison is inconclusive and `would_change` is `false` — the operator sees the error field and knows the answer isn't \"yes it would change\", it's \"we couldn't tell\".\n\nAdded in `UPDATE_SCHEMA_VERSION = 2` (Phase 1 of #181).",
+      "description": "Per-file diff row between what's currently on the stick's ESP\nand what a fresh `mkusb` / direct-install flash would write.\nOne row per canonical ESP destination (see\n`direct_install::ESP_DEST_*`).\n\nSemantics of the hash/error pairs:\n\n* `current_sha256` is `None` when the ESP file couldn't be read\n  (file absent, `mtype` missing, permission denied); in that\n  case `current_error` carries the operator-facing reason.\n* `fresh_sha256` is `None` when the host-side source couldn't\n  be hashed (package not installed, kernel glob missed, etc);\n  `fresh_error` carries the reason.\n* `would_change` is the Phase-1 verdict the operator cares\n  about: `true` only when both hashes are present AND they\n  differ. When either hash is absent the comparison is\n  inconclusive and `would_change` is `false` — the operator\n  sees the error field and knows the answer isn't \"yes it\n  would change\", it's \"we couldn't tell\".\n\nAdded in `UPDATE_SCHEMA_VERSION = 2` (Phase 1 of #181).",
       "type": "object",
-      "required": [
-        "esp_path",
-        "role",
-        "would_change"
-      ],
       "properties": {
         "current_error": {
-          "description": "Operator-readable error explaining why `current_sha256` is absent. `None` when the read succeeded.",
+          "description": "Operator-readable error explaining why `current_sha256`\nis absent. `None` when the read succeeded.",
           "type": [
             "string",
             "null"
           ]
         },
         "current_sha256": {
-          "description": "Lowercase hex sha256 of the file currently on the stick's ESP. `None` when unreadable.",
+          "description": "Lowercase hex sha256 of the file currently on the stick's\nESP. `None` when unreadable.",
           "type": [
             "string",
             "null"
           ]
         },
         "esp_path": {
-          "description": "Destination path on the ESP, e.g. `/EFI/BOOT/BOOTX64.EFI` (no `::` mtools prefix — stripped for consumers that want an operator-readable path).",
+          "description": "Destination path on the ESP, e.g. `/EFI/BOOT/BOOTX64.EFI`\n(no `::` mtools prefix — stripped for consumers that want\nan operator-readable path).",
           "type": "string"
         },
         "fresh_error": {
-          "description": "Operator-readable error explaining why `fresh_sha256` is absent. `None` when the hash succeeded.",
+          "description": "Operator-readable error explaining why `fresh_sha256` is\nabsent. `None` when the hash succeeded.",
           "type": [
             "string",
             "null"
           ]
         },
         "fresh_sha256": {
-          "description": "Lowercase hex sha256 of what a fresh flash would install. `None` when the host-side source couldn't be hashed.",
+          "description": "Lowercase hex sha256 of what a fresh flash would install.\n`None` when the host-side source couldn't be hashed.",
           "type": [
             "string",
             "null"
           ]
         },
         "role": {
-          "description": "Role in the signed chain: `shim`, `grub`, `grub_cfg_boot`, `grub_cfg_ubuntu`, `kernel`, `initrd`. One entry per canonical destination (the two `grub.cfg` targets get separate rows because `mkusb.sh` writes both).",
+          "description": "Role in the signed chain: `shim`, `grub`, `grub_cfg_boot`,\n`grub_cfg_ubuntu`, `kernel`, `initrd`. One entry per\ncanonical destination (the two `grub.cfg` targets get\nseparate rows because `mkusb.sh` writes both).",
           "type": "string"
         },
         "would_change": {
-          "description": "`true` when both hashes are present and differ. `false` when they match, OR when either hash is absent (see struct docs for the rationale).",
+          "description": "`true` when both hashes are present and differ. `false`\nwhen they match, OR when either hash is absent (see struct\ndocs for the rationale).",
           "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "role",
+        "esp_path",
+        "would_change"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-verify.schema.json
+++ b/docs/reference/schemas/aegis-boot-verify.schema.json
@@ -1,21 +1,14 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "VerifyReport",
-  "description": "Envelope emitted by `aegis-boot verify --json`. Re-verifies every ISO on a stick against its sidecar checksum and reports a per-ISO verdict plus a summary tally. Used by CI / monitoring to audit that a stick's ISOs haven't bit-rotted, been replaced, or lost their sha256 sidecars.",
+  "description": "Envelope emitted by `aegis-boot verify --json`. Re-verifies\nevery ISO on a stick against its sidecar checksum and reports\na per-ISO verdict plus a summary tally. Used by CI / monitoring\nto audit that a stick's ISOs haven't bit-rotted, been replaced,\nor lost their sha256 sidecars.",
   "type": "object",
-  "required": [
-    "isos",
-    "mount_path",
-    "schema_version",
-    "summary",
-    "tool_version"
-  ],
   "properties": {
     "isos": {
-      "description": "Per-ISO verdict. Always present (even as `[]` for an empty stick) so consumers see a stable field set.",
+      "description": "Per-ISO verdict. Always present (even as `[]` for an empty\nstick) so consumers see a stable field set.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/VerifyEntry"
+        "$ref": "#/$defs/VerifyEntry"
       }
     },
     "mount_path": {
@@ -26,60 +19,61 @@
       "description": "Wire-format version. See [`VERIFY_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "summary": {
       "description": "Aggregate tally + overall pass/fail.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/VerifySummary"
-        }
-      ]
+      "$ref": "#/$defs/VerifySummary"
     },
     "tool_version": {
       "description": "`aegis-boot` binary version that produced this envelope.",
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "schema_version",
+    "tool_version",
+    "mount_path",
+    "summary",
+    "isos"
+  ],
+  "$defs": {
     "VerifyEntry": {
-      "description": "One ISO's verdict inside a [`VerifyReport`]. The `verdict` field is the discriminator; variant-specific fields follow via `#[serde(flatten)]`. Consumer contract: branch on `verdict`, expect the fields documented for that variant.\n\nWire shape examples:\n\n```text {\"name\": \"ubuntu.iso\", \"verdict\": \"Verified\", \"digest\": \"…\", \"source\": \"sidecar\"} {\"name\": \"debian.iso\", \"verdict\": \"Mismatch\", \"actual\": \"…\", \"expected\": \"…\", \"source\": \"sidecar\"} {\"name\": \"alpine.iso\", \"verdict\": \"Unreadable\", \"source\": \"sidecar\", \"reason\": \"permission denied\"} {\"name\": \"fedora.iso\", \"verdict\": \"NotPresent\"} ```",
+      "description": "One ISO's verdict inside a [`VerifyReport`]. The `verdict`\nfield is the discriminator; variant-specific fields follow via\n`#[serde(flatten)]`. Consumer contract: branch on `verdict`,\nexpect the fields documented for that variant.\n\nWire shape examples:\n\n```text\n{\"name\": \"ubuntu.iso\", \"verdict\": \"Verified\", \"digest\": \"…\", \"source\": \"sidecar\"}\n{\"name\": \"debian.iso\", \"verdict\": \"Mismatch\", \"actual\": \"…\", \"expected\": \"…\", \"source\": \"sidecar\"}\n{\"name\": \"alpine.iso\", \"verdict\": \"Unreadable\", \"source\": \"sidecar\", \"reason\": \"permission denied\"}\n{\"name\": \"fedora.iso\", \"verdict\": \"NotPresent\"}\n```",
       "type": "object",
+      "properties": {
+        "name": {
+          "description": "ISO filename.",
+          "type": "string"
+        }
+      },
       "oneOf": [
         {
           "description": "sha256 of the ISO matches the sidecar's recorded digest.",
           "type": "object",
-          "required": [
-            "digest",
-            "source",
-            "verdict"
-          ],
           "properties": {
             "digest": {
               "description": "Computed sha256 (lowercase hex).",
               "type": "string"
             },
             "source": {
-              "description": "Where the expected digest came from (e.g. `\"sidecar\"` for the on-partition `.sha256` file).",
+              "description": "Where the expected digest came from (e.g. `\"sidecar\"`\nfor the on-partition `.sha256` file).",
               "type": "string"
             },
             "verdict": {
               "type": "string",
-              "enum": [
-                "Verified"
-              ]
+              "const": "Verified"
             }
-          }
+          },
+          "required": [
+            "verdict",
+            "digest",
+            "source"
+          ]
         },
         {
-          "description": "sha256 of the ISO does NOT match the sidecar — either media corruption or a replaced/tampered file. Trust-chain breaking.",
+          "description": "sha256 of the ISO does NOT match the sidecar — either\nmedia corruption or a replaced/tampered file. Trust-chain\nbreaking.",
           "type": "object",
-          "required": [
-            "actual",
-            "expected",
-            "source",
-            "verdict"
-          ],
           "properties": {
             "actual": {
               "description": "Computed sha256 of the ISO on disk.",
@@ -95,110 +89,104 @@
             },
             "verdict": {
               "type": "string",
-              "enum": [
-                "Mismatch"
-              ]
+              "const": "Mismatch"
             }
-          }
+          },
+          "required": [
+            "verdict",
+            "actual",
+            "expected",
+            "source"
+          ]
         },
         {
           "description": "The ISO file exists but couldn't be opened / hashed.",
           "type": "object",
-          "required": [
-            "reason",
-            "source",
-            "verdict"
-          ],
           "properties": {
             "reason": {
               "description": "Human-readable explanation (permission, I/O error).",
               "type": "string"
             },
             "source": {
-              "description": "Where the expected digest came from (so the operator knows which sidecar to reconcile against after restoring access to the file).",
+              "description": "Where the expected digest came from (so the operator\nknows which sidecar to reconcile against after\nrestoring access to the file).",
               "type": "string"
             },
             "verdict": {
               "type": "string",
-              "enum": [
-                "Unreadable"
-              ]
+              "const": "Unreadable"
             }
-          }
+          },
+          "required": [
+            "verdict",
+            "source",
+            "reason"
+          ]
         },
         {
-          "description": "An ISO referenced elsewhere (e.g. in the attestation manifest's `isos` list) is not on the partition.",
+          "description": "An ISO referenced elsewhere (e.g. in the attestation\nmanifest's `isos` list) is not on the partition.",
           "type": "object",
-          "required": [
-            "verdict"
-          ],
           "properties": {
             "verdict": {
               "type": "string",
-              "enum": [
-                "NotPresent"
-              ]
+              "const": "NotPresent"
             }
-          }
+          },
+          "required": [
+            "verdict"
+          ]
         }
       ],
       "required": [
         "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "ISO filename.",
-          "type": "string"
-        }
-      }
+      ]
     },
     "VerifySummary": {
-      "description": "Tally of per-ISO verdicts in a [`VerifyReport`]. `any_failure` is the summary bit downstream tooling (CI, dashboards) branches on.",
+      "description": "Tally of per-ISO verdicts in a [`VerifyReport`]. `any_failure`\nis the summary bit downstream tooling (CI, dashboards)\nbranches on.",
       "type": "object",
-      "required": [
-        "any_failure",
-        "mismatch",
-        "not_present",
-        "total",
-        "unreadable",
-        "verified"
-      ],
       "properties": {
         "any_failure": {
-          "description": "True iff at least one of `mismatch`, `unreadable`, or `not_present` is non-zero. The overall stick-health bit.",
+          "description": "True iff at least one of `mismatch`, `unreadable`, or\n`not_present` is non-zero. The overall stick-health bit.",
           "type": "boolean"
         },
         "mismatch": {
-          "description": "Count with `verdict: \"Mismatch\"` — sha256 differed from sidecar. A serious trust-chain signal; consumer should surface aggressively.",
+          "description": "Count with `verdict: \"Mismatch\"` — sha256 differed from\nsidecar. A serious trust-chain signal; consumer should\nsurface aggressively.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "not_present": {
-          "description": "Count with `verdict: \"NotPresent\"` — referenced in an attestation manifest but missing from the partition.",
+          "description": "Count with `verdict: \"NotPresent\"` — referenced in an\nattestation manifest but missing from the partition.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "total": {
           "description": "Total ISOs scanned. Equals the length of [`VerifyReport::isos`].",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "unreadable": {
-          "description": "Count with `verdict: \"Unreadable\"` — file exists but couldn't be opened / read (permission, bad media).",
+          "description": "Count with `verdict: \"Unreadable\"` — file exists but\ncouldn't be opened / read (permission, bad media).",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         },
         "verified": {
           "description": "Count with `verdict: \"Verified\"`.",
           "type": "integer",
           "format": "uint32",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "total",
+        "verified",
+        "mismatch",
+        "unreadable",
+        "not_present",
+        "any_failure"
+      ]
     }
   }
 }

--- a/docs/reference/schemas/aegis-boot-version.schema.json
+++ b/docs/reference/schemas/aegis-boot-version.schema.json
@@ -1,27 +1,27 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Version",
-  "description": "Envelope emitted by `aegis-boot --version --json`. Lets scripted consumers (install-one-liner assertions, Homebrew formula tests, ansible-verified installs) parse the version without regex on the human-readable string.",
+  "description": "Envelope emitted by `aegis-boot --version --json`. Lets scripted\nconsumers (install-one-liner assertions, Homebrew formula tests,\nansible-verified installs) parse the version without regex on\nthe human-readable string.",
   "type": "object",
-  "required": [
-    "schema_version",
-    "tool",
-    "version"
-  ],
   "properties": {
     "schema_version": {
       "description": "Wire-format version. See [`VERSION_SCHEMA_VERSION`].",
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "tool": {
-      "description": "Always `\"aegis-boot\"` for this CLI — field exists to make a future migration to a multi-tool repo (where the same envelope shape might be emitted by a sibling binary) a zero-schema-bump operation.",
+      "description": "Always `\"aegis-boot\"` for this CLI — field exists to make a\nfuture migration to a multi-tool repo (where the same\nenvelope shape might be emitted by a sibling binary) a\nzero-schema-bump operation.",
       "type": "string"
     },
     "version": {
-      "description": "Semver string matching the workspace version (`Cargo.toml` `[workspace.package].version`). Does NOT include a `v` prefix — `\"0.14.1\"`, not `\"v0.14.1\"`.",
+      "description": "Semver string matching the workspace version (`Cargo.toml`\n`[workspace.package].version`). Does NOT include a `v`\nprefix — `\"0.14.1\"`, not `\"v0.14.1\"`.",
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "schema_version",
+    "tool",
+    "version"
+  ]
 }


### PR DESCRIPTION
## Summary

Third of 4 major-version bumps from #411 (\`indicatif\` landed in #412; \`toml\` in #413). Bumps \`aegis-wire-formats\`'s schemars dep from 0.8 → 1.2 and regenerates all 13 committed JSON Schemas.

## ⚠️ Breaking change for external schema consumers

The committed schemas under [\`docs/reference/schemas/\`](../tree/main/docs/reference/schemas) now declare:

\`\`\`json
\"\$schema\": \"https://json-schema.org/draft/2020-12/schema\"
\`\`\`

(Previously \`\"http://json-schema.org/draft-07/schema#\"\`.) Consumers pinned to draft-07 validators will need to either accept both drafts or upgrade.

**Semver implication:** \`aegis-wire-formats\` is at 0.16.0 — we're in 0.x land where minor bumps can break. I've kept the crate version at 0.16 for this commit; the next public-API release of aegis-wire-formats should bump appropriately and note this in its changelog.

Other cosmetic diffs:
- docstring newlines preserved (was collapsed to single-line — improvement)
- \`required\` array moved to end of object (cosmetic ordering)
- \`minimum: 0.0\` → \`minimum: 0\` for integer types

**Runtime behavior:** unchanged. Library consumers using \`aegis-wire-formats\` without the \`schema\` feature don't pull schemars at all and see no effect.

## Feature-gate integrity

\`schemars\` stays \`optional = true\` with \`dep:schemars\` gating, so default consumers still don't pull it into the build tree.

## Test plan

- [x] \`cargo build -p aegis-wire-formats --features schema\` — clean
- [x] \`cargo test -p aegis-wire-formats --features schema\` — 48 pass
- [x] \`cargo clippy --workspace --all-targets --features schema -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`schema-docgen --check\` — 13/13 OK

## Remaining (#411)

- \`sha2\` 0.10 → 0.11 — last, highest risk (on-disk hash format stability)