### PR TITLE
chore(deps): #411 bump sha2 0.10→0.11 (closes #411 — 4/4 major bumps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "minisign",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
 ]
@@ -73,6 +73,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,7 +119,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -152,6 +161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +180,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -204,6 +228,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -284,9 +317,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -425,7 +469,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -516,7 +569,7 @@ dependencies = [
  "minisign-verify",
  "pollster",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "toml",
@@ -726,7 +779,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -909,7 +962,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "tracing",
@@ -1019,7 +1072,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1098,8 +1151,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -69,7 +69,7 @@ aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
 tempfile = "3.14"
 # sha2 + hex are already transitive deps via iso-probe; surfaced
 # directly here for the post-write readback verifier (#244 PR1).
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 thiserror = { workspace = true }
 # Per-stage progress UI during dd (#244 PR3). Captures dd's

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -20,7 +20,7 @@ thiserror.workspace = true
 serde = { workspace = true }
 tracing.workspace = true
 pollster = "0.4"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 minisign-verify = "0.2"
 # Operator-curated metadata sidecar (#246). default-features = false

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.29"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #411. Fourth and final major-version bump: \`sha2\` 0.10.9 → 0.11.0. Shipped alongside #412 (indicatif 0.18), #413 (toml 1.1), and #414 (schemars 1.2).

## Changed

- \`sha2\` 0.10 → 0.11 in 3 \`Cargo.toml\`s (aegis-cli, iso-probe, rescue-tui)
- \`Cargo.lock\` — new \`crypto-common 0.2\`, \`digest 0.11\`, \`hybrid-array\` pulled alongside existing 0.1/0.10 (minisign still transitively uses 0.10, coexists fine)

## Why low-risk in practice

SHA-256 is a **standardized algorithm**. Output bytes are byte-stable by specification. A version bump of the Rust crate that wraps it cannot change the hex strings we persist to attestations, sidecars, or failure microreports. The test suite includes hash-output fixture tests (e.g., \`crates/iso-probe/src/signature.rs\` tests \`hash_matches\` against known hashes) — if 0.11 produced different output, they'd fail.

Tests pass: **720 / 720**.

## Call-site audit

All of our \`Sha256\` uses follow the \`Digest\` trait pattern:

\`\`\`rust
let mut hasher = Sha256::new();
hasher.update(bytes);
let digest = hasher.finalize();
\`\`\`

This is identical across 0.10 and 0.11 — the only \`Digest\` trait method set we rely on.

## Test plan

- [x] \`cargo build --workspace\` on 1.88.0 — clean
- [x] \`cargo test --workspace\` — 720 pass (includes hash-fixture tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

## #411 checklist

- [x] \`indicatif\` 0.17 → 0.18 (#412)
- [x] \`toml\` 0.8 → 1.1 (#413)
- [x] \`schemars\` 0.8 → 1.2 (#414)
- [x] \`sha2\` 0.10 → 0.11 (this PR)

Closes #411.