### PR TITLE
feat(#93): SysRq help overlay — full REISUB sequence

### DIFF
--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -495,9 +495,10 @@ fn status_glyph(iso: &iso_probe::DiscoveredIso) -> &'static str {
 }
 
 fn draw_help_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
-    // Center a 60x18 panel.
-    let w = area.width.min(70);
-    let h = area.height.min(20);
+    // Centered panel. Grew from 70x20 to 80x32 when the SysRq
+    // cheatsheet expanded to the full REISUB sequence (#93).
+    let w = area.width.min(80);
+    let h = area.height.min(32);
     let x = area.x + (area.width.saturating_sub(w)) / 2;
     let y = area.y + (area.height.saturating_sub(h)) / 2;
     let panel = Rect::new(x, y, w, h);
@@ -533,9 +534,13 @@ fn draw_help_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Line::from("   default · monochrome · high-contrast · okabe-ito · aegis"),
         Line::from(""),
         Line::from(" Emergency escape hatches (kernel SysRq)"),
-        Line::from("   Alt+SysRq+b   reboot now"),
+        Line::from("   REISUB = safe forced reboot; hit each slowly, in order."),
+        Line::from("   Alt+SysRq+r   raw keyboard mode (reclaim from X/Wayland)"),
+        Line::from("   Alt+SysRq+e   SIGTERM all processes except init"),
+        Line::from("   Alt+SysRq+i   SIGKILL all processes except init"),
         Line::from("   Alt+SysRq+s   sync disks"),
-        Line::from("   Alt+SysRq+e   SIGTERM all userspace"),
+        Line::from("   Alt+SysRq+u   remount all filesystems readonly"),
+        Line::from("   Alt+SysRq+b   reboot now"),
         Line::from(""),
         Line::from(Span::styled(
             " Esc or ? to dismiss",


### PR DESCRIPTION
Closes the SysRq-cheatsheet line-item from #93 P1.

## Before
\`\`\`
 Emergency escape hatches (kernel SysRq)
   Alt+SysRq+b   reboot now
   Alt+SysRq+s   sync disks
   Alt+SysRq+e   SIGTERM all userspace
\`\`\`

## After
\`\`\`
 Emergency escape hatches (kernel SysRq)
   REISUB = safe forced reboot; hit each slowly, in order.
   Alt+SysRq+r   raw keyboard mode (reclaim from X/Wayland)
   Alt+SysRq+e   SIGTERM all processes except init
   Alt+SysRq+i   SIGKILL all processes except init
   Alt+SysRq+s   sync disks
   Alt+SysRq+u   remount all filesystems readonly
   Alt+SysRq+b   reboot now
\`\`\`

Key order matters — REISUB hit out of order defeats the \"safe forced reboot\" property (e.g., \`b\` before \`s\` = unsynced disks).

## Sizing

Panel grew from 70×20 to 80×32 so the full cheatsheet fits without wrap-clipping on an 80-col serial console. \`area.height.min(32)\` still caps to terminal size — smaller terminals still clip the bottom, but the panel no longer lies about what fits.

## Why R+I+U were already missing

Only B/S/E shipped originally (#85 first pass). R and U are the workflow-critical ones when a graphics driver has stolen the keyboard; I rescues when E's SIGTERM-handlers ignore the signal. The full sequence is the canonical recovery recipe.

## Verification

- \`kernel.sysrq=1\` already enabled by \`scripts/build-initramfs.sh:404\`
- \`cargo test -p rescue-tui\` — 117 pass
- \`cargo clippy -p rescue-tui --all-targets -- -D warnings\` — clean
- \`cargo fmt --all --check\` — clean

## Scope note

Does not touch:
- \`build-initramfs.sh\` (sysrq enablement already there)
- Other #93 items (brltty/espeakup, keyboard-layout audit, pcspkr beeps) — filed under the epic, each is its own follow-up