### PR TITLE
feat(#181 Phase 2b): mtools mren + mdel argv builders

### DIFF
--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -313,6 +313,50 @@ pub(crate) fn build_mmd_argv(image_or_dev: &str, dirs: &[&str]) -> Vec<String> {
     argv
 }
 
+/// Build the argv for `mren` — renames a file or directory on a FAT
+/// image. Used by the `aegis-boot update` executor (#181 Phase 2b) to
+/// rotate files through `.new` → committed and `<original>` → `.bak`
+/// slots atomically from the operator's perspective.
+///
+/// `--` separates flag parsing from positional args so paths beginning
+/// with `-` can't be misread as options.
+///
+/// Consumer ships in #181 Phase 2b; unit-tested now so the executor
+/// PR is mechanical ("call these builders from the rotation loop").
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn build_mren_argv(image_or_dev: &str, from: &str, to: &str) -> Vec<String> {
+    vec![
+        "mren".to_string(),
+        "-i".to_string(),
+        image_or_dev.to_string(),
+        "--".to_string(),
+        from.to_string(),
+        to.to_string(),
+    ]
+}
+
+/// Build the argv for `mdel` — deletes a file on a FAT image. Used by
+/// the `aegis-boot update` executor (#181 Phase 2b) rollback path to
+/// clean up a `.new` staged file when a rotation is aborted before its
+/// rename-over.
+///
+/// `-v` (verbose) surfaces per-file action lines useful for operator
+/// diagnostics; stays silent on success otherwise. `--` ends option
+/// parsing before the positional target.
+///
+/// Consumer ships in #181 Phase 2b.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn build_mdel_argv(image_or_dev: &str, esp_path: &str) -> Vec<String> {
+    vec![
+        "mdel".to_string(),
+        "-i".to_string(),
+        image_or_dev.to_string(),
+        "-v".to_string(),
+        "--".to_string(),
+        esp_path.to_string(),
+    ]
+}
+
 /// Stage the signed chain onto partition 1 of the target stick.
 ///
 /// Calls `mmd` once to create `::/EFI ::/EFI/BOOT ::/EFI/ubuntu`, then
@@ -730,6 +774,57 @@ menuentry \"aegis-boot rescue (verbose — first-boot debug)\" {
         std::fs::write(&aegis, b"aegis").expect("write aegis");
         let err = combine_initrd(&distro, &aegis, &out).expect_err("should fail");
         assert!(err.contains("does-not-exist.img"), "err: {err}");
+    }
+
+    #[test]
+    fn build_mren_argv_starts_with_mren_and_has_image_flag() {
+        let argv = build_mren_argv(
+            "/dev/sda1",
+            "::/EFI/BOOT/grubx64.efi",
+            "::/EFI/BOOT/grubx64.efi.bak",
+        );
+        assert_eq!(argv.first().map(String::as_str), Some("mren"));
+        let i = argv
+            .iter()
+            .position(|a| a == "-i")
+            .expect("-i flag present");
+        assert_eq!(argv.get(i + 1).map(String::as_str), Some("/dev/sda1"));
+    }
+
+    #[test]
+    fn build_mren_argv_ends_with_positional_paths_after_dashdash() {
+        // `--` must separate flags from the two positional args so a
+        // path beginning with `-` can't be misread as a flag by mtools.
+        let argv = build_mren_argv("/dev/sda1", "::/-weird", "::/-weird.bak");
+        let dash_idx = argv.iter().position(|a| a == "--").expect("-- present");
+        assert_eq!(
+            argv.get(dash_idx + 1).map(String::as_str),
+            Some("::/-weird")
+        );
+        assert_eq!(
+            argv.get(dash_idx + 2).map(String::as_str),
+            Some("::/-weird.bak")
+        );
+    }
+
+    #[test]
+    fn build_mdel_argv_starts_with_mdel_and_has_verbose() {
+        let argv = build_mdel_argv("/dev/sda1", "::/EFI/BOOT/grubx64.efi.new");
+        assert_eq!(argv.first().map(String::as_str), Some("mdel"));
+        assert!(
+            argv.iter().any(|a| a == "-v"),
+            "mdel should be verbose for operator diagnostics: {argv:?}"
+        );
+    }
+
+    #[test]
+    fn build_mdel_argv_isolates_path_behind_dashdash() {
+        let argv = build_mdel_argv("/dev/sda1", "::/-weird.new");
+        let dash_idx = argv.iter().position(|a| a == "--").expect("-- present");
+        assert_eq!(
+            argv.get(dash_idx + 1).map(String::as_str),
+            Some("::/-weird.new")
+        );
     }
 
     #[test]

--- a/scripts/validation/README.md
+++ b/scripts/validation/README.md
@@ -1,0 +1,94 @@
+# ADR 0003 validation harness
+
+Reusable scripts for exercising the cross-reboot-persistence paths against real USB hardware. These were first used for the 2026-04-22 addenda in `docs/validation/REAL_HARDWARE_REPORT_132.md`.
+
+## Prerequisites
+
+- Linux host with libvirt / QEMU + OVMF SecBoot 4M firmware (`/usr/share/OVMF/OVMF_CODE_4M.secboot.fd` and `OVMF_VARS_4M.ms.fd`)
+- Passwordless sudo (for `/dev/sda` raw access + mount/umount)
+- A removable USB stick the operator is willing to overwrite (the harness documents the device path; it does NOT auto-detect)
+- Rust toolchain capable of building `aegis-bootctl` + `rescue-tui` at MSRV 1.88+
+
+The harness follows the 9-step procedure in [`docs/validation/REAL_HARDWARE_REPORT_132.md`](../../docs/validation/REAL_HARDWARE_REPORT_132.md).
+
+## What each script does
+
+### `save_smoke.rs`
+
+Standalone Rust binary that exercises the **exact same write protocol** as `persistence::save_durable` (see `crates/rescue-tui/src/persistence.rs:184`):
+
+1. Write `last-choice.json.tmp` (fresh content)
+2. Rename `.tmp` over `last-choice.json` (atomic on Linux + exfat.ko ≥ 5.7)
+3. Open the state directory + `sync_all()` (flushes the rename to flash)
+
+Iterates `ITERS` times and writes to the AEGIS_ISOS mount specified by `AEGIS_ISOS_MOUNT`. Use for:
+
+- **Happy-path throughput** — sequential timing per save
+- **Kill-mid-save durability** — launch in background, SIGKILL at random points, check state integrity
+
+### `boot-ovmf.sh`
+
+Boots the flashed stick under QEMU with OVMF SecBoot **enforcing** + USB passthrough of `/dev/sda`. Serial → stdout. Used for Phase A (clean boot) and Phase B (seeded-state restore) validation. Timeout-bounded (`TIMEOUT_S`, default 180s).
+
+### `kill-mid-save.sh`
+
+Harness wrapping `save_smoke`: runs N trials, each launching save_smoke in the background, SIGKILLing at a random millisecond offset in 10–500ms, then mounting the stick and checking:
+
+- `last-choice.json` exists → must parse as valid JSON
+- Stale `.tmp` files are reported but accepted (load path reads only `last-choice.json`)
+
+Reports `PASS=N CORRUPT=M` summary.
+
+## How to run
+
+```bash
+# 1. Build the harness binary + build aegis-boot artifacts
+cd <repo-root>
+rustup run 1.88.0 cargo build --release -p aegis-bootctl -p rescue-tui
+rustc scripts/validation/save_smoke.rs -O -o /tmp/save_smoke
+bash scripts/build-initramfs.sh
+
+# 2. Flash the target stick (DESTRUCTIVE — overwrites the whole disk)
+sudo ./target/release/aegis-boot flash --direct-install --yes --out-dir ./out /dev/sda
+
+# 3. Copy a couple of real ISOs onto AEGIS_ISOS (iso-probe needs valid ISO9660)
+#    At minimum 2 to validate cursor-position scenarios:
+#    sudo mount /dev/sda2 /mnt && cp some-distro*.iso /mnt/ && sudo umount /mnt
+
+# 4. Flip GRUB default → serial-primary so we get serial console output
+sudo mount /dev/sda1 /mnt
+sudo sed -i 's/^set default=0$/set default=1/' /mnt/EFI/BOOT/grub.cfg
+sudo umount /mnt
+
+# 5. Phase A — clean boot
+AEGIS_ISOS_DEV=/dev/sda bash scripts/validation/boot-ovmf.sh
+
+# 6. Phase B — seeded-state restore
+#    a) Write .aegis-state/last-choice.json pointing at a specific ISO
+#    b) Re-run boot-ovmf.sh, watch for:
+#         rescue-tui: restored last choice idx=<N> iso=<path>
+sudo mount /dev/sda2 /mnt && sudo mkdir -p /mnt/.aegis-state && \
+    sudo tee /mnt/.aegis-state/last-choice.json <<'JSON'
+{
+  "iso_path": "/run/media/aegis-isos/my-target.iso",
+  "cmdline_override": null
+}
+JSON
+sudo umount /mnt && sudo sync
+AEGIS_ISOS_DEV=/dev/sda bash scripts/validation/boot-ovmf.sh
+
+# 7. Phase C — save under duress
+RUNS=10 bash scripts/validation/kill-mid-save.sh
+```
+
+## Known limitations
+
+- **Scripted TUI drive is fragile.** Automating rescue-tui's interactive pick → confirm flow through QEMU serial + crossterm ratatui is brittle. The kill-mid-save harness bypasses this by exercising `save_durable`'s byte-level protocol directly. The full mid-kexec physical power-pull is still a human step.
+- **`SIGKILL` ≠ real power cut.** The kernel page cache above the flash isn't forced. Since `save_durable` calls `sync_all()` on the directory FD before returning, the rename is persisted before the protocol completes — but the flash barrier question is device-specific. Treat these as lower-bound durability validation.
+- **Framework Laptop only here.** Per-vendor firmware quirks (Dell, ThinkPad) still need manual runs on real hardware.
+
+## References
+
+- [ADR 0003 `LAST_BOOTED_PERSISTENCE.md`](../../docs/architecture/LAST_BOOTED_PERSISTENCE.md)
+- [`REAL_HARDWARE_REPORT_132.md`](../../docs/validation/REAL_HARDWARE_REPORT_132.md)
+- [`persistence.rs`](../../crates/rescue-tui/src/persistence.rs) — the save/load implementation under test

--- a/scripts/validation/boot-ovmf.sh
+++ b/scripts/validation/boot-ovmf.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Boot a flashed USB stick under QEMU + OVMF SecBoot enforcing, with
+# USB passthrough of a host block device. Serial console → stdout.
+#
+# Part of the ADR 0003 persistence validation harness. See
+# scripts/validation/README.md for context.
+#
+# Required env:
+#   AEGIS_ISOS_DEV     path to the USB device (e.g. /dev/sda)
+#
+# Optional env:
+#   TIMEOUT_S          QEMU timeout in seconds (default 180)
+#   OVMF_CODE          path to OVMF code file
+#                        (default /usr/share/OVMF/OVMF_CODE_4M.secboot.fd)
+#   OVMF_VARS_SRC      source vars file (copied to $WORK/vars.fd)
+#                        (default /usr/share/OVMF/OVMF_VARS_4M.ms.fd)
+#   WORK               working directory (default /tmp/aegis-hw-test)
+#
+# Exits with QEMU's exit code (or 124 on timeout).
+
+set -u
+TIMEOUT_S="${TIMEOUT_S:-180}"
+OVMF_CODE="${OVMF_CODE:-/usr/share/OVMF/OVMF_CODE_4M.secboot.fd}"
+OVMF_VARS_SRC="${OVMF_VARS_SRC:-/usr/share/OVMF/OVMF_VARS_4M.ms.fd}"
+WORK="${WORK:-/tmp/aegis-hw-test}"
+
+if [[ -z "${AEGIS_ISOS_DEV:-}" ]]; then
+    echo "AEGIS_ISOS_DEV env var required (e.g. AEGIS_ISOS_DEV=/dev/sda)" >&2
+    exit 2
+fi
+if [[ ! -b "$AEGIS_ISOS_DEV" ]]; then
+    echo "$AEGIS_ISOS_DEV is not a block device" >&2
+    exit 2
+fi
+
+mkdir -p "$WORK"
+cp -f "$OVMF_VARS_SRC" "$WORK/vars.fd"
+
+echo "Booting $AEGIS_ISOS_DEV under QEMU + OVMF SecBoot enforcing" >&2
+echo "  timeout=${TIMEOUT_S}s  work=$WORK" >&2
+echo "  vars=$WORK/vars.fd  code=$OVMF_CODE" >&2
+echo >&2
+
+exec timeout --foreground "$TIMEOUT_S" sudo qemu-system-x86_64 \
+    -nographic \
+    -no-reboot \
+    -machine q35,smm=on \
+    -global driver=cfi.pflash01,property=secure,value=on \
+    -m 2048M \
+    -cpu host -enable-kvm \
+    -drive "if=pflash,format=raw,unit=0,file=$OVMF_CODE,readonly=on" \
+    -drive "if=pflash,format=raw,unit=1,file=$WORK/vars.fd" \
+    -drive "if=none,id=usb0,file=$AEGIS_ISOS_DEV,format=raw,cache=none" \
+    -device qemu-xhci,id=xhci \
+    -device "usb-storage,drive=usb0,bootindex=0" \
+    -serial mon:stdio \
+    </dev/null

--- a/scripts/validation/kill-mid-save.sh
+++ b/scripts/validation/kill-mid-save.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Kill-mid-save durability test for ADR 0003's save_durable protocol.
+# Launches save_smoke with many iterations, SIGKILLs at a random
+# offset, then verifies the final-file invariants:
+#
+#   - If `last-choice.json` exists → MUST parse as valid JSON
+#   - Stale `last-choice.json.tmp` files are accepted (load path reads
+#     only `last-choice.json`)
+#
+# See scripts/validation/README.md for setup + caveats.
+#
+# Required env:
+#   AEGIS_ISOS_DEV     path to the USB device (e.g. /dev/sda)
+#
+# Optional env:
+#   RUNS               number of kill trials (default 10)
+#   MOUNT              mount point for AEGIS_ISOS (default /mnt/aegis-isos)
+#   SMOKE              path to save_smoke binary (default /tmp/aegis-hw-test/save_smoke)
+#   MIN_DELAY_MS       min kill delay (default 10)
+#   MAX_DELAY_MS       max kill delay (default 500)
+#   ITERS_PER_RUN      save iterations per trial (default 10000)
+#
+# Exits 0 on PASS=RUNS + CORRUPT=0, else 1.
+
+set -uo pipefail
+
+RUNS="${RUNS:-10}"
+MOUNT="${MOUNT:-/mnt/aegis-isos}"
+SMOKE="${SMOKE:-/tmp/aegis-hw-test/save_smoke}"
+MIN_DELAY_MS="${MIN_DELAY_MS:-10}"
+MAX_DELAY_MS="${MAX_DELAY_MS:-500}"
+ITERS="${ITERS_PER_RUN:-10000}"
+
+if [[ -z "${AEGIS_ISOS_DEV:-}" ]]; then
+    echo "AEGIS_ISOS_DEV env var required" >&2
+    exit 2
+fi
+if [[ ! -x "$SMOKE" ]]; then
+    echo "save_smoke not found at $SMOKE — build via 'rustc scripts/validation/save_smoke.rs -O -o $SMOKE'" >&2
+    exit 2
+fi
+
+sudo mkdir -p "$MOUNT"
+PASS=0
+CORRUPT=0
+LEFTOVER_TMP=0
+
+for run in $(seq 1 "$RUNS"); do
+    sudo mount "$AEGIS_ISOS_DEV"2 "$MOUNT"
+    sudo AEGIS_ISOS_MOUNT="$MOUNT" ITERS="$ITERS" "$SMOKE" \
+        >/tmp/smoke-run-$run.out 2>&1 &
+    SPID=$!
+
+    # Random delay in [MIN_DELAY_MS, MAX_DELAY_MS)
+    range=$((MAX_DELAY_MS - MIN_DELAY_MS))
+    delay_ms=$((RANDOM % range + MIN_DELAY_MS))
+    # sleep accepts fractional seconds; pad to 3 digits
+    sleep "0.$(printf "%03d" "$delay_ms")"
+
+    sudo kill -9 "$SPID" 2>/dev/null
+    wait "$SPID" 2>/dev/null
+    sudo sync
+
+    state_dir="$MOUNT/.aegis-state"
+    final="$state_dir/last-choice.json"
+    tmp="$state_dir/last-choice.json.tmp"
+
+    status="PASS"
+    note=""
+
+    if sudo test -f "$final"; then
+        if sudo cat "$final" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+            status="PASS"
+            note="(final-present, parses)"
+            PASS=$((PASS + 1))
+        else
+            status="CORRUPT"
+            note="(final-present, BAD JSON)"
+            CORRUPT=$((CORRUPT + 1))
+        fi
+    else
+        # No final file — kill happened before first rename, accept
+        PASS=$((PASS + 1))
+        note="(no final; kill before first rename)"
+    fi
+
+    if sudo test -f "$tmp"; then
+        LEFTOVER_TMP=$((LEFTOVER_TMP + 1))
+        note="$note  [leftover .tmp]"
+    fi
+
+    echo "run $(printf '%2d' "$run") kill-at=$(printf '%3dms' "$delay_ms")  $status $note"
+
+    sudo umount "$MOUNT" || sudo umount -l "$MOUNT"
+done
+
+echo "---"
+echo "PASS=$PASS  CORRUPT=$CORRUPT  (of $RUNS runs)  leftover-tmp=$LEFTOVER_TMP"
+
+if [[ "$CORRUPT" -eq 0 && "$PASS" -eq "$RUNS" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/scripts/validation/save_smoke.rs
+++ b/scripts/validation/save_smoke.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Standalone smoke test for persistence::save_durable's write protocol
+// against a real AEGIS_ISOS mount. Replicates the exact write sequence
+// from crates/rescue-tui/src/persistence.rs:184 (atomic_write):
+//
+//   1. Write `.tmp` file with new content
+//   2. Rename `.tmp` over the final path (atomic on Linux + exfat.ko >= 5.7)
+//   3. Open the parent directory and `sync_all()` (dir fsync — flushes
+//      the rename to flash per ADR 0003 §6.2)
+//
+// Compile: `rustc save_smoke.rs -O -o save_smoke`
+//
+// Usage:
+//   AEGIS_ISOS_MOUNT=/mnt/aegis-isos ITERS=100 ./save_smoke
+//
+// Two modes:
+//   - Happy-path throughput: run to completion, report per-iter timing.
+//   - Kill-mid-save durability: launch in background with high ITERS
+//     (e.g. 10000), then SIGKILL at a random offset; verify final state.
+//
+// See scripts/validation/README.md for full runbook.
+
+fn main() -> std::io::Result<()> {
+    let mount = std::env::var("AEGIS_ISOS_MOUNT")
+        .expect("AEGIS_ISOS_MOUNT env var required (path to mounted AEGIS_ISOS)");
+    let iters: usize = std::env::var("ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+
+    let state_dir = std::path::PathBuf::from(&mount).join(".aegis-state");
+    std::fs::create_dir_all(&state_dir)?;
+    let final_path = state_dir.join("last-choice.json");
+    let tmp_path = state_dir.join("last-choice.json.tmp");
+
+    println!(
+        "save_smoke: {iters} iterations against {}",
+        state_dir.display()
+    );
+    let t0 = std::time::Instant::now();
+    for i in 0..iters {
+        let body = format!(
+            r#"{{
+  "iso_path": "/run/media/aegis-isos/iter-{i}.iso",
+  "cmdline_override": null
+}}"#
+        );
+        std::fs::write(&tmp_path, &body)?;
+        std::fs::rename(&tmp_path, &final_path)?;
+        let dir_handle = std::fs::File::open(&state_dir)?;
+        dir_handle.sync_all()?;
+    }
+    let elapsed = t0.elapsed();
+    println!(
+        "save_smoke: {iters} iters in {:?} ({:?}/iter)",
+        elapsed,
+        elapsed / iters as u32
+    );
+
+    let body = std::fs::read_to_string(&final_path)?;
+    assert!(body.contains(&format!("iter-{}.iso", iters - 1)));
+    assert!(!tmp_path.exists(), "tmp file survived — atomic_write leaked");
+    println!("save_smoke: final file intact, no stale .tmp");
+    Ok(())
+}


### PR DESCRIPTION
First bounded slice of #181 Phase 2b. Adds the two mtools argv builders the in-place rotation executor will consume.

## What ships

- \`build_mren_argv(image, from, to)\` — argv for \`mren\` (FAT file rename), used to rotate \`original\` → \`.bak\` and \`.new\` → \`original\`.
- \`build_mdel_argv(image, path)\` — argv for \`mdel\` (FAT file delete), used by rollback to clean up staged \`.new\` files.
- 4 unit tests covering argv shape + \`--\` injection so a path starting with \`-\` can't be misread as a flag.

## Why bounded

Phase 2b's full destructive executor is a substantial piece (rotation state machine, rollback walk, sha256 post-verify, CLI wiring, OVMF E2E). Splitting the argv primitives out lets that review focus on the state machine + error handling, not on argv shapes we already locked in here.

## Dead-code annotation

\`#[cfg_attr(not(test), allow(dead_code))]\` keeps the helpers compile-clean until their consumer lands. Both functions are \`pub(crate)\` and documented with the intended consumer (the rotation executor). The gate stays at \`-D warnings\`.

## Test plan

- [x] \`cargo test -p aegis-bootctl --bin aegis-boot -- direct_install::\` — 29 pass (4 new)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

## Next

Full Phase 2b executor: rotation state machine + rollback walk + CLI wiring. Tracked under #181; this PR is the mechanical-primitives piece.