### PR TITLE
fix(#428): direct-install writes host-side attestation so update works

### DIFF
--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -762,7 +762,51 @@ fn write_manifest_stage(
     if let Some(sig_path) = sign_manifest_if_configured(&body, work_dir, stage_err)? {
         mcopy_to_esp(part1_dev, &sig_path, MANIFEST_SIG_ESP_PATH)?;
     }
+
+    // Also mirror the manifest to the host-side attestations store so
+    // `aegis-boot update` can find it via disk_guid lookup (#428). The
+    // ESP-side write above is the canonical record; the host-side copy
+    // is a convenience index. A failure here is logged but must NOT
+    // abort the flash — the ESP copy is the source of truth.
+    if let Err(e) = write_host_side_attestation(&body, &manifest.device.disk_guid) {
+        eprintln!("warning: host-side attestation mirror failed: {e}");
+        eprintln!("(the ESP manifest is still in place; `aegis-boot update` may not find this stick until the mirror succeeds on a re-flash)");
+    }
+
     Ok(())
+}
+
+/// Write a copy of the direct-install manifest to the host-side
+/// attestations store so `aegis-boot update`'s disk-GUID lookup in
+/// `~/.local/share/aegis-boot/attestations/` finds this stick. Filename
+/// mirrors the legacy `attest::record_flash` pattern:
+/// `<disk-guid>-<ts>.json`.
+///
+/// Failure here is surfaced to the caller as a warning — the ESP
+/// manifest is authoritative; this is a convenience index for update.
+/// See issue #428 for the gap this closes.
+#[cfg(target_os = "linux")]
+fn write_host_side_attestation(body: &[u8], disk_guid: &str) -> Result<PathBuf, String> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let dest_dir = crate::paths::aegis_state_root().join("attestations");
+    std::fs::create_dir_all(&dest_dir)
+        .map_err(|e| format!("create {}: {e}", dest_dir.display()))?;
+
+    // Sortable epoch-second timestamp; bakes uniqueness across rapid
+    // re-flashes without needing a UUID generator.
+    let ts_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(1);
+    let id = if disk_guid.is_empty() {
+        "unknown".to_string()
+    } else {
+        disk_guid.to_lowercase()
+    };
+    let dest = dest_dir.join(format!("{id}-{ts_secs}.json"));
+    std::fs::write(&dest, body).map_err(|e| format!("write {}: {e}", dest.display()))?;
+    Ok(dest)
 }
 
 /// Load the signing key from `AEGIS_BOOT_SIGNING_KEY` (if set), sign

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -770,7 +770,9 @@ fn write_manifest_stage(
     // abort the flash — the ESP copy is the source of truth.
     if let Err(e) = write_host_side_attestation(&body, &manifest.device.disk_guid) {
         eprintln!("warning: host-side attestation mirror failed: {e}");
-        eprintln!("(the ESP manifest is still in place; `aegis-boot update` may not find this stick until the mirror succeeds on a re-flash)");
+        eprintln!(
+            "(the ESP manifest is still in place; `aegis-boot update` may not find this stick until the mirror succeeds on a re-flash)"
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Closes #428. \`aegis-boot flash --direct-install\` now mirrors its ESP-side attestation manifest to the host-side store at \`~/.local/share/aegis-boot/attestations/\`, so \`aegis-boot update\` correctly resolves direct-install-flashed sticks as ELIGIBLE.

## Before / after

Before:

\`\`\`
\$ sudo aegis-boot flash --direct-install --yes --out-dir ./out /dev/sda
  ... flash completes ...
\$ sudo aegis-boot update /dev/sda
error[UPDATE_INELIGIBLE]: stick not eligible for in-place update
  what happened: no attestation manifest found for disk GUID <new-guid>
\`\`\`

After (verified on real hardware this session):

\`\`\`
\$ sudo aegis-boot flash --direct-install --yes --out-dir ./out /dev/sda
  ... flash completes; new <guid>-<ts>.json written to host store ...
\$ sudo aegis-boot update /dev/sda
Status: ELIGIBLE for in-place update.
  disk GUID:   b17af29d-d10e-4a86-9aa6-0210a90e682e
  attestation: ~/.local/share/aegis-boot/attestations/b17af29d-...-1776912848.json
  ...
\`\`\`

## Why a mirror, not a relocation

The ESP-side write remains canonical — the stick carries its own provenance and can be inspected without any host-side state. The host-side copy is a convenience index for the \`update\` path's disk-GUID → attestation lookup. A failure writing the mirror warns but doesn't abort the flash; the operator just can't run \`update\` from this host until the mirror succeeds on a re-flash.

## Unblocks

\`#181\` Phase 2b CLI wiring — the OVMF-E2E test for the rotation executor couldn't run against a freshly-flashed stick because update rejected it as ineligible. Now it can.

## Test plan

- [x] \`cargo test -p aegis-bootctl --bin aegis-boot -- flash::\` — 40 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] Real hardware: flash → ls attestations/ shows new entry → update reports ELIGIBLE ✓