### PR TITLE
fix(#430): update compares combined initrd, not distro initrd alone

### DIFF
--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -352,12 +352,87 @@ fn resolve_host_chain() -> Vec<HostChainEntry> {
     ));
     let (kernel_path, kernel_ver) = find_kernel();
     out.push(resolve_one("kernel", kernel_path.clone()));
-    let initrd_path = match kernel_ver {
+    let distro_initrd_path = match kernel_ver {
         Some(v) => PathBuf::from(format!("/boot/initrd.img-{v}")),
         None => PathBuf::from("/boot/initrd.img-*"),
     };
-    out.push(resolve_one("initrd", initrd_path));
+    out.push(resolve_combined_initrd(&distro_initrd_path));
     out
+}
+
+/// Resolve the `initrd` host-chain entry to the hash of the **combined**
+/// initrd that direct-install would mcopy onto the stick's `/initrd.img`.
+///
+/// Per #430: the stick carries a combined initrd (distro initrd + aegis-
+/// boot initramfs, concatenated), not the raw distro initrd. Comparing
+/// the stick's `/initrd.img` sha256 to the distro initrd's sha256 always
+/// reports false-positive drift. Here we synthesize the combined initrd
+/// via `direct_install::combine_initrd` into a tempfile, hash that, and
+/// discard — gives `update`'s diff the same ground truth that
+/// `flash --direct-install` would actually write.
+///
+/// If either input is missing, return an UNKNOWN row with a specific
+/// next-step message rather than silently falling back to the distro
+/// hash (that's the bug we're fixing). Operators see "run
+/// scripts/build-initramfs.sh first" instead of a quiet wrong answer.
+fn resolve_combined_initrd(distro_initrd_path: &Path) -> HostChainEntry {
+    let aegis_initrd_path = PathBuf::from("out/initramfs.cpio.gz");
+    // Synthetic display label — the combined initrd is built at query
+    // time into a tempfile that's gone by the time we return. Anyone
+    // trying to mcopy from this PathBuf sees a clear non-path token and
+    // must synthesize separately at execution time.
+    let path_for_display = PathBuf::from(format!(
+        "<combined: {} + {}>",
+        distro_initrd_path.display(),
+        aegis_initrd_path.display()
+    ));
+
+    if !distro_initrd_path.is_file() {
+        return HostChainEntry {
+            role: "initrd",
+            path: path_for_display,
+            sha256: Err("distro initrd not found or not readable".to_string()),
+        };
+    }
+    if !aegis_initrd_path.is_file() {
+        return HostChainEntry {
+            role: "initrd",
+            path: path_for_display,
+            sha256: Err(format!(
+                "aegis-boot initramfs not found at {} — run `scripts/build-initramfs.sh` \
+                 to generate it before running `aegis-boot update`",
+                aegis_initrd_path.display()
+            )),
+        };
+    }
+
+    // Synthesize the combined initrd the same way direct-install does,
+    // hash it, then discard the bytes. Lives in a tempfile rather than
+    // memory so it works against initramfs sizes without ballooning RSS.
+    let Ok(tmp) = tempfile::NamedTempFile::new() else {
+        return HostChainEntry {
+            role: "initrd",
+            path: path_for_display,
+            sha256: Err("could not create tempfile for combined-initrd synthesis".to_string()),
+        };
+    };
+    let tmp_path = tmp.path().to_path_buf();
+    if let Err(e) =
+        crate::direct_install::combine_initrd(distro_initrd_path, &aegis_initrd_path, &tmp_path)
+    {
+        return HostChainEntry {
+            role: "initrd",
+            path: path_for_display,
+            sha256: Err(format!("combine_initrd: {e}")),
+        };
+    }
+    let sha256 = sha256_file(&tmp_path);
+    // tmp goes out of scope here and is deleted.
+    HostChainEntry {
+        role: "initrd",
+        path: path_for_display,
+        sha256,
+    }
 }
 
 /// Find the first readable `vmlinuz-*-{virtual,generic}` in /boot,
@@ -1500,5 +1575,77 @@ mod tests {
         assert!(missing.is_err(), "missing file should be Err");
         // Cleanup best-effort — don't fail the test on leftover tmp.
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_combined_initrd_hashes_distro_plus_aegis() {
+        // Happy path: both inputs present, hash matches manual combine.
+        let tmp = tempfile::tempdir().unwrap();
+        let distro = tmp.path().join("boot-initrd.img");
+        let aegis_out_dir = tmp.path().join("out");
+        std::fs::create_dir_all(&aegis_out_dir).unwrap();
+        let aegis = aegis_out_dir.join("initramfs.cpio.gz");
+        std::fs::write(&distro, b"DISTRO-INITRD-BYTES").unwrap();
+        std::fs::write(&aegis, b"AEGIS-INITRAMFS-BYTES").unwrap();
+
+        // cd into tmp so the resolver's relative "out/initramfs.cpio.gz"
+        // path resolves under our fixture tree, not the real repo.
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&tmp).unwrap();
+        let entry = resolve_combined_initrd(&distro);
+        std::env::set_current_dir(&saved_cwd).unwrap();
+
+        let hash = entry
+            .sha256
+            .expect("happy path should produce an Ok(sha256)");
+        // Compute the expected hash via the same sha256sum path the
+        // production code uses, so this test doesn't drift on sha2 API.
+        let combined = tmp.path().join("expected.bin");
+        let mut body = Vec::new();
+        body.extend_from_slice(b"DISTRO-INITRD-BYTES");
+        body.extend_from_slice(b"AEGIS-INITRAMFS-BYTES");
+        std::fs::write(&combined, &body).unwrap();
+        let want = sha256_file(&combined).unwrap();
+        assert_eq!(hash, want);
+        // The displayed path is the synthetic combined label, not a
+        // real file — the executor must resynthesize, not mcopy this.
+        let path_str = entry.path.display().to_string();
+        assert!(path_str.starts_with("<combined:"), "path_str={path_str}");
+        assert!(path_str.contains("boot-initrd.img"), "path_str={path_str}");
+        assert!(
+            path_str.contains("initramfs.cpio.gz"),
+            "path_str={path_str}"
+        );
+    }
+
+    #[test]
+    fn resolve_combined_initrd_returns_err_when_aegis_initramfs_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let distro = tmp.path().join("boot-initrd.img");
+        std::fs::write(&distro, b"DISTRO-ONLY").unwrap();
+        // NOTE: out/initramfs.cpio.gz is *not* created.
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&tmp).unwrap();
+        let entry = resolve_combined_initrd(&distro);
+        std::env::set_current_dir(&saved_cwd).unwrap();
+
+        let err = entry.sha256.expect_err("missing aegis initramfs → Err");
+        assert!(
+            err.contains("scripts/build-initramfs.sh"),
+            "error should surface the build command: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_combined_initrd_returns_err_when_distro_initrd_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing_distro = tmp.path().join("no-such-initrd");
+        let entry = resolve_combined_initrd(&missing_distro);
+        let err = entry.sha256.expect_err("missing distro initrd → Err");
+        assert!(
+            err.contains("distro initrd"),
+            "error should name distro initrd: {err}"
+        );
     }
 }

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -356,7 +356,16 @@ fn resolve_host_chain() -> Vec<HostChainEntry> {
         Some(v) => PathBuf::from(format!("/boot/initrd.img-{v}")),
         None => PathBuf::from("/boot/initrd.img-*"),
     };
+    #[cfg(target_os = "linux")]
     out.push(resolve_combined_initrd(&distro_initrd_path));
+    #[cfg(not(target_os = "linux"))]
+    out.push(HostChainEntry {
+        role: "initrd",
+        path: distro_initrd_path,
+        sha256: Err("combined-initrd synthesis is Linux-only; cross-platform \
+                     flash rotation ships under #367 Phase D"
+            .to_string()),
+    });
     out
 }
 
@@ -375,8 +384,23 @@ fn resolve_host_chain() -> Vec<HostChainEntry> {
 /// next-step message rather than silently falling back to the distro
 /// hash (that's the bug we're fixing). Operators see "run
 /// scripts/build-initramfs.sh first" instead of a quiet wrong answer.
+#[cfg(target_os = "linux")]
 fn resolve_combined_initrd(distro_initrd_path: &Path) -> HostChainEntry {
-    let aegis_initrd_path = PathBuf::from("out/initramfs.cpio.gz");
+    // Production cwd is where the operator ran `aegis-boot update` —
+    // same cwd contract as `flash --direct-install --out-dir ./out`.
+    // Tests use `resolve_combined_initrd_at` with explicit paths to
+    // stay isolation-safe (concurrent tests can't race on cwd).
+    resolve_combined_initrd_at(distro_initrd_path, &PathBuf::from("out/initramfs.cpio.gz"))
+}
+
+/// Explicit-paths helper behind [`resolve_combined_initrd`]. Separated
+/// so unit tests can pin both inputs without touching the process cwd
+/// (parallel cargo test runs were racing on `set_current_dir`).
+#[cfg(target_os = "linux")]
+fn resolve_combined_initrd_at(
+    distro_initrd_path: &Path,
+    aegis_initrd_path: &Path,
+) -> HostChainEntry {
     // Synthetic display label — the combined initrd is built at query
     // time into a tempfile that's gone by the time we return. Anyone
     // trying to mcopy from this PathBuf sees a clear non-path token and
@@ -418,7 +442,7 @@ fn resolve_combined_initrd(distro_initrd_path: &Path) -> HostChainEntry {
     };
     let tmp_path = tmp.path().to_path_buf();
     if let Err(e) =
-        crate::direct_install::combine_initrd(distro_initrd_path, &aegis_initrd_path, &tmp_path)
+        crate::direct_install::combine_initrd(distro_initrd_path, aegis_initrd_path, &tmp_path)
     {
         return HostChainEntry {
             role: "initrd",
@@ -1577,23 +1601,19 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn resolve_combined_initrd_hashes_distro_plus_aegis() {
         // Happy path: both inputs present, hash matches manual combine.
+        // Uses the `_at` helper with explicit paths so concurrent test
+        // runs don't race on set_current_dir.
         let tmp = tempfile::tempdir().unwrap();
         let distro = tmp.path().join("boot-initrd.img");
-        let aegis_out_dir = tmp.path().join("out");
-        std::fs::create_dir_all(&aegis_out_dir).unwrap();
-        let aegis = aegis_out_dir.join("initramfs.cpio.gz");
+        let aegis = tmp.path().join("initramfs.cpio.gz");
         std::fs::write(&distro, b"DISTRO-INITRD-BYTES").unwrap();
         std::fs::write(&aegis, b"AEGIS-INITRAMFS-BYTES").unwrap();
 
-        // cd into tmp so the resolver's relative "out/initramfs.cpio.gz"
-        // path resolves under our fixture tree, not the real repo.
-        let saved_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&tmp).unwrap();
-        let entry = resolve_combined_initrd(&distro);
-        std::env::set_current_dir(&saved_cwd).unwrap();
+        let entry = resolve_combined_initrd_at(&distro, &aegis);
 
         let hash = entry
             .sha256
@@ -1618,17 +1638,16 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn resolve_combined_initrd_returns_err_when_aegis_initramfs_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let distro = tmp.path().join("boot-initrd.img");
         std::fs::write(&distro, b"DISTRO-ONLY").unwrap();
-        // NOTE: out/initramfs.cpio.gz is *not* created.
+        // Deliberately point at a non-existent aegis initramfs file.
+        let aegis = tmp.path().join("never-created.cpio.gz");
 
-        let saved_cwd = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&tmp).unwrap();
-        let entry = resolve_combined_initrd(&distro);
-        std::env::set_current_dir(&saved_cwd).unwrap();
+        let entry = resolve_combined_initrd_at(&distro, &aegis);
 
         let err = entry.sha256.expect_err("missing aegis initramfs → Err");
         assert!(
@@ -1637,11 +1656,13 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn resolve_combined_initrd_returns_err_when_distro_initrd_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let missing_distro = tmp.path().join("no-such-initrd");
-        let entry = resolve_combined_initrd(&missing_distro);
+        let aegis = tmp.path().join("any.cpio.gz");
+        let entry = resolve_combined_initrd_at(&missing_distro, &aegis);
         let err = entry.sha256.expect_err("missing distro initrd → Err");
         assert!(
             err.contains("distro initrd"),


### PR DESCRIPTION
## Summary

Closes #430. Unblocks #181 Phase 2b CLI wiring.

Phase 1's \`resolve_host_chain\` returned the hash of \`/boot/initrd.img-<ver>\` (distro initrd) for the \`initrd\` role. But \`flash --direct-install\` mcopies a *combined* initrd (distro + aegis-boot initramfs, concatenated) to the stick's \`/initrd.img\`. The two never match by construction, so \`aegis-boot update\` reported false-positive \`CHANGED\` on initrd even on a pristine stick. Wiring Phase 2b's executor to that diff would have destroyed the combined form.

## Approach

Per the design recommendation in the #430 discussion — ship **Option A** (fresh-flash diff) semantics: \`update\` answers \"does my stick need new bits?\", matching the epic's CVE-response use case. The manifest-drift-integrity surface (Option B) belongs in a future \`aegis-boot verify --stick\` command, not \`update\`.

## What changed

- New \`resolve_combined_initrd()\` synthesizes the combined initrd via \`direct_install::combine_initrd()\` into a \`NamedTempFile\`, hashes it via the existing \`sha256_file()\` helper, then lets the tempfile drop.
- Displayed path is a synthetic label: \`<combined: /boot/initrd.img-<ver> + out/initramfs.cpio.gz>\`. The angle-bracket token makes it clear this isn't a file to mcopy from — the executor (#181 Phase 2b) must resynthesize at apply time.
- Missing \`out/initramfs.cpio.gz\` → UNKNOWN with a \"run \`scripts/build-initramfs.sh\`\" message. Same pattern as \`grub_cfg\`'s UNKNOWN.
- Missing distro initrd → UNKNOWN with a specific message.

## Real-hardware verification

Ran against the local SanDisk Cruzer + Framework Laptop (post-#429 flashed stick):

**Before:**
\`\`\`
CHANGED   /initrd.img  sha256:e8dfdf6c... → 2ab81993...
Summary: 1 would change, 3 unchanged, 2 inconclusive.
\`\`\`

**After:**
\`\`\`
UNCHANGED /initrd.img  sha256:e8dfdf6c...
Summary: 0 would change, 4 unchanged, 2 inconclusive.
\`\`\`

## Tests

3 new unit tests:

- \`resolve_combined_initrd_hashes_distro_plus_aegis\` — happy path: hash matches manual \`distro || aegis\` concatenation.
- \`resolve_combined_initrd_returns_err_when_aegis_initramfs_missing\` — missing \`out/initramfs.cpio.gz\` → UNKNOWN with build-script message.
- \`resolve_combined_initrd_returns_err_when_distro_initrd_missing\` — missing distro initrd → UNKNOWN.

## Test plan

- [x] \`cargo test -p aegis-bootctl --bin aegis-boot -- resolve_combined\` — 3 pass
- [x] \`cargo test --workspace\` — 13 suites pass, 0 failed
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` on both 1.88 and stable 1.95 — clean
- [x] Real hardware: update reports UNCHANGED on a pristine flashed stick ✓

## Follow-ups

- **PR 2 (next):** wire \`execute_rotation\` into \`update.rs\`'s \`--apply --experimental-apply\` branch + OVMF E2E.
- **New issue (to file):** \`aegis-boot verify --stick\` for manifest-drift integrity check (Option B in the #430 design discussion).