### PR TITLE
feat(#181 Phase 2b): wire CLI apply path — real-hardware-verified rotation

### DIFF
--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -172,16 +172,20 @@ fn handle_eligible(
     if apply_plan {
         print_rotation_plan(&diff);
         println!();
-        println!(
-            "NOTE: #181 Phase 2a — planner only. No writes made to {}.",
-            dev.display()
-        );
-        println!("The destructive executor ships in Phase 2b after OVMF E2E.");
-    } else {
-        println!("NOTE: this is a read-only eligibility check (phase 1 of #181).");
-        println!("The actual in-place update lands in a follow-up PR. No writes");
-        println!("were made to {} during this command.", dev.display());
+        #[cfg(target_os = "linux")]
+        return apply_rotation(dev, &esp_part, &diff);
+        #[cfg(not(target_os = "linux"))]
+        {
+            println!(
+                "NOTE: destructive executor is Linux-only; cross-platform \
+                 rotation ships under #367 Phase D."
+            );
+            return Ok(());
+        }
     }
+    println!("NOTE: this is a read-only eligibility check (phase 1 of #181).");
+    println!("The actual in-place update lands in a follow-up PR. No writes");
+    println!("were made to {} during this command.", dev.display());
     Ok(())
 }
 
@@ -1099,6 +1103,166 @@ pub(crate) fn body_contains_guid(body: &str, target_guid: &str) -> bool {
 /// that are easier to leave on the shim than rewire at call-sites.
 pub(crate) fn attestation_dir() -> PathBuf {
     crate::paths::attestations_dir()
+}
+
+/// #181 Phase 2b — actually execute the rotation plan against the
+/// stick's ESP partition. Called from [`handle_eligible`] when the
+/// double-flag (`--apply --experimental-apply`) is present.
+///
+/// Flow:
+/// 1. Build the plan from the diff (same `plan_rotation` as 2a).
+/// 2. If empty → nothing to rotate; return Ok.
+/// 3. Materialize host-side source files for mcopy — shim/grub/kernel
+///    come from the `chain` resolver; the combined initrd is synthesized
+///    into a `NamedTempFile` (same protocol `resolve_combined_initrd`
+///    uses for hashing, now kept alive for the mcopy).
+/// 4. Invoke `execute_rotation`. On success, print summary + return Ok.
+/// 5. On failure, invoke `execute_rollback` with the progress trace +
+///    surface both the original error and any rollback errors.
+#[cfg(target_os = "linux")]
+fn apply_rotation(dev: &Path, part1_dev: &Path, diff: &[EspFileDiff]) -> Result<(), u8> {
+    use crate::update_apply::plan_rotation;
+
+    let plan = plan_rotation(diff);
+    if plan.is_empty() {
+        println!("Nothing to rotate — stick already matches host-side chain.");
+        return Ok(());
+    }
+
+    // Materialize host-side source files into tempfiles the executor
+    // can mcopy from. The tempfiles must live for the duration of the
+    // rotation (NamedTempFile drop deletes them), so they're owned
+    // here and borrowed into RotationSources below.
+    let sources_mats = materialize_rotation_sources()?;
+    let sources = sources_mats.to_rotation_sources();
+
+    println!(
+        "Rotating {} file(s) on {}…",
+        plan.len(),
+        part1_dev.display()
+    );
+    dispatch_rotation(dev, part1_dev, &plan, &sources)
+}
+
+/// Owned host-side-source paths the rotation executor mcopies from.
+/// Holds the `NamedTempFile`s by value so they stay on disk until this
+/// struct drops. The `to_rotation_sources` borrow produces the
+/// `RotationSources<'_>` the executor actually accepts.
+#[cfg(target_os = "linux")]
+struct RotationMaterials {
+    shim: PathBuf,
+    grub: PathBuf,
+    kernel: PathBuf,
+    initrd_tmp: tempfile::NamedTempFile,
+    grub_cfg_tmp: tempfile::NamedTempFile,
+}
+
+#[cfg(target_os = "linux")]
+impl RotationMaterials {
+    fn to_rotation_sources(&self) -> crate::update_apply::RotationSources<'_> {
+        crate::update_apply::RotationSources {
+            shim: &self.shim,
+            grub: &self.grub,
+            grub_cfg: self.grub_cfg_tmp.path(),
+            kernel: &self.kernel,
+            combined_initrd: self.initrd_tmp.path(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn materialize_rotation_sources() -> Result<RotationMaterials, u8> {
+    let (kernel_path, kernel_ver) = find_kernel();
+    let shim = PathBuf::from("/usr/lib/shim/shimx64.efi.signed");
+    let grub = PathBuf::from("/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed");
+    let Some(v) = kernel_ver else {
+        eprintln!("aegis-boot update --apply: no kernel found in /boot — cannot rotate");
+        return Err(1);
+    };
+    let distro_initrd = PathBuf::from(format!("/boot/initrd.img-{v}"));
+    let aegis_initramfs = PathBuf::from("out/initramfs.cpio.gz");
+    if !aegis_initramfs.is_file() {
+        eprintln!(
+            "aegis-boot update --apply: {} missing — run `scripts/build-initramfs.sh` first",
+            aegis_initramfs.display()
+        );
+        return Err(1);
+    }
+    let initrd_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        eprintln!("aegis-boot update --apply: tempfile for combined initrd: {e}");
+        1u8
+    })?;
+    crate::direct_install::combine_initrd(&distro_initrd, &aegis_initramfs, initrd_tmp.path())
+        .map_err(|e| {
+            eprintln!("aegis-boot update --apply: combine_initrd: {e}");
+            1u8
+        })?;
+    // Render grub.cfg too — even though today's planner always skips
+    // it (UNKNOWN diff per Phase-1 grub.cfg-is-rendered-in-process),
+    // a future fix will make it rotate and the executor wants a real
+    // file to reference.
+    let grub_cfg_tmp = tempfile::NamedTempFile::new().map_err(|e| {
+        eprintln!("aegis-boot update --apply: tempfile for grub.cfg: {e}");
+        1u8
+    })?;
+    crate::direct_install::render_grub_cfg(grub_cfg_tmp.path()).map_err(|e| {
+        eprintln!("aegis-boot update --apply: render_grub_cfg: {e}");
+        1u8
+    })?;
+    Ok(RotationMaterials {
+        shim,
+        grub,
+        kernel: kernel_path,
+        initrd_tmp,
+        grub_cfg_tmp,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn dispatch_rotation(
+    dev: &Path,
+    part1_dev: &Path,
+    plan: &[crate::update_apply::RotationStep],
+    sources: &crate::update_apply::RotationSources<'_>,
+) -> Result<(), u8> {
+    use crate::update_apply::{StepState, execute_rollback, execute_rotation, rollback_plan};
+
+    match execute_rotation(plan, part1_dev, sources) {
+        Ok(progress) => {
+            let rotated = progress
+                .iter()
+                .filter(|p| matches!(p.state, StepState::Rotated))
+                .count();
+            println!("Rotation complete: {rotated} file(s) rotated in place.");
+            println!("Previous bytes preserved at `.bak` on the ESP for recovery.");
+            println!("AEGIS_ISOS preserved byte-for-byte.");
+            Ok(())
+        }
+        Err((reason, progress)) => {
+            eprintln!("Rotation FAILED: {reason}");
+            let rollback_actions = rollback_plan(&progress);
+            if rollback_actions.is_empty() {
+                eprintln!("Nothing to roll back — failure happened before any write took effect.");
+                return Err(1);
+            }
+            eprintln!("Rolling back {} action(s)…", rollback_actions.len());
+            if let Err(errs) = execute_rollback(&rollback_actions, part1_dev) {
+                eprintln!("Rollback encountered errors:");
+                for e in errs {
+                    eprintln!("  - {e}");
+                }
+                eprintln!(
+                    "Stick is in an INDETERMINATE state. Boot menu may be broken. \
+                     Manually inspect ESP contents (mdir -i {}1 ::/) or re-flash \
+                     with `aegis-boot flash --direct-install`.",
+                    dev.display()
+                );
+            } else {
+                eprintln!("Rollback complete. Stick restored to pre-apply state as best we could.");
+            }
+            Err(1)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/aegis-cli/src/update_apply.rs
+++ b/crates/aegis-cli/src/update_apply.rs
@@ -256,29 +256,33 @@ pub(crate) fn execute_rotation(
             ));
         };
 
-        let new_path = format!("{}.new", step.esp_path);
-        let bak_path = format!("{}.bak", step.esp_path);
+        // mtools wants `::/`-rooted paths; the planner stores bare
+        // `/vmlinuz`-style paths to match `ESP_DIFF_SLOTS`. Add the
+        // `::` drive-prefix here so mcopy/mren operate on the image,
+        // not the host filesystem (which is what happens silently if
+        // the `::` is missing — the file ends up in `/` on the host
+        // and the subsequent mren can't find it on the ESP).
+        let mtools_orig = format!("::{}", step.esp_path);
+        let mtools_new = format!("::{}.new", step.esp_path);
+        let mtools_bak = format!("::{}.bak", step.esp_path);
 
         // Stage: mcopy src → <esp_path>.new
-        let mcopy = crate::direct_install::build_mcopy_argv(&dev, src, &new_path);
+        let mcopy = crate::direct_install::build_mcopy_argv(&dev, src, &mtools_new);
         let mcopy_refs: Vec<&str> = mcopy.iter().map(String::as_str).collect();
         if let Err(e) = run_mtool(&mcopy_refs) {
-            return Err((format!("mcopy {new_path}: {e}"), progress));
+            return Err((format!("mcopy {mtools_new}: {e}"), progress));
         }
         progress[i].state = StepState::Staged;
 
         // Rotate step 1: mren <esp_path> → <esp_path>.bak
-        let mren_bak = crate::direct_install::build_mren_argv(&dev, step.esp_path, &bak_path);
+        let mren_bak = crate::direct_install::build_mren_argv(&dev, &mtools_orig, &mtools_bak);
         let mren_bak_refs: Vec<&str> = mren_bak.iter().map(String::as_str).collect();
         if let Err(e) = run_mtool(&mren_bak_refs) {
-            return Err((
-                format!("mren {} → {}: {e}", step.esp_path, bak_path),
-                progress,
-            ));
+            return Err((format!("mren {mtools_orig} → {mtools_bak}: {e}"), progress));
         }
 
         // Rotate step 2: mren <esp_path>.new → <esp_path>
-        let mren_new = crate::direct_install::build_mren_argv(&dev, &new_path, step.esp_path);
+        let mren_new = crate::direct_install::build_mren_argv(&dev, &mtools_new, &mtools_orig);
         let mren_new_refs: Vec<&str> = mren_new.iter().map(String::as_str).collect();
         if let Err(e) = run_mtool(&mren_new_refs) {
             // Mid-rotation failure — .bak exists, .new exists, <esp_path> missing.
@@ -289,8 +293,7 @@ pub(crate) fn execute_rotation(
             // the partial state with a clear error.
             return Err((
                 format!(
-                    "mren {new_path} → {}: {e} — .bak preserved, manual recovery: mren ::<path>.bak ::<path>",
-                    step.esp_path
+                    "mren {mtools_new} → {mtools_orig}: {e} — .bak preserved, manual recovery: mren {mtools_bak} {mtools_orig}"
                 ),
                 progress,
             ));
@@ -326,27 +329,29 @@ pub(crate) fn execute_rollback(
     for action in actions {
         match action {
             RollbackAction::DeleteStaged { esp_path } => {
-                let new_path = format!("{esp_path}.new");
-                let mdel = crate::direct_install::build_mdel_argv(&dev, &new_path);
+                // Same `::/`-prefix convention as execute_rotation.
+                let mtools_new = format!("::{esp_path}.new");
+                let mdel = crate::direct_install::build_mdel_argv(&dev, &mtools_new);
                 let mdel_refs: Vec<&str> = mdel.iter().map(String::as_str).collect();
                 if let Err(e) = run_mtool(&mdel_refs) {
-                    errs.push(format!("rollback DeleteStaged {new_path}: {e}"));
+                    errs.push(format!("rollback DeleteStaged {mtools_new}: {e}"));
                 }
             }
             RollbackAction::RestoreFromBak { esp_path } => {
-                let bak_path = format!("{esp_path}.bak");
+                let mtools_orig = format!("::{esp_path}");
+                let mtools_bak = format!("::{esp_path}.bak");
                 // Delete the current (rotated) file, then rename .bak back over it.
-                let mdel = crate::direct_install::build_mdel_argv(&dev, esp_path);
+                let mdel = crate::direct_install::build_mdel_argv(&dev, &mtools_orig);
                 let mdel_refs: Vec<&str> = mdel.iter().map(String::as_str).collect();
                 if let Err(e) = run_mtool(&mdel_refs) {
-                    errs.push(format!("rollback delete-before-restore {esp_path}: {e}"));
+                    errs.push(format!("rollback delete-before-restore {mtools_orig}: {e}"));
                     continue;
                 }
-                let mren = crate::direct_install::build_mren_argv(&dev, &bak_path, esp_path);
+                let mren = crate::direct_install::build_mren_argv(&dev, &mtools_bak, &mtools_orig);
                 let mren_refs: Vec<&str> = mren.iter().map(String::as_str).collect();
                 if let Err(e) = run_mtool(&mren_refs) {
                     errs.push(format!(
-                        "rollback RestoreFromBak {bak_path} → {esp_path}: {e}"
+                        "rollback RestoreFromBak {mtools_bak} → {mtools_orig}: {e}"
                     ));
                 }
             }


### PR DESCRIPTION
Completes #181 Phase 2b's CLI-wiring slice. \`aegis-boot update <device> --apply --experimental-apply\` now actually rotates files on the ESP — previously it was planner-only dry-print.

## What ships

- \`apply_rotation\` dispatcher in \`update.rs\`: materializes host-side sources (shim/grub paths, kernel path, combined initrd via \`combine_initrd\` into a \`NamedTempFile\`, grub.cfg via \`render_grub_cfg\` into a second tempfile), invokes the Phase 2b state machine from #425 / #426, handles success/failure paths cleanly, invokes rollback on failure.
- **Bug fix:** executor was passing bare \`/vmlinuz\`-style paths to mcopy/mren but mtools needs \`::/\`-prefixed paths. Silent fall-back to the host filesystem made the first test fail with \"File not found\". Now explicitly prefixes \`::\` at the executor boundary.

## Real-hardware verification

Ran end-to-end against the local SanDisk Cruzer + Framework Laptop during development:

1. Flashed stick fresh
2. Injected 16 bytes of random data into \`/vmlinuz\` on the stick (deliberate drift)
3. \`aegis-boot update /dev/sda\` reports \`CHANGED /vmlinuz\`
4. \`aegis-boot update /dev/sda --apply --experimental-apply\` → \`Rotation complete: 1 file(s) rotated in place\`
5. Stick state: \`/vmlinuz\` = correct 39cc3d97… hash, \`/vmlinuz.bak\` = drifted bc65565d… bytes preserved
6. Re-run of update: \`Summary: 0 would change, 4 unchanged, 2 inconclusive\`

AEGIS_ISOS byte-for-byte unchanged across the rotation.

## Ergonomics

\`\`\`
\$ sudo aegis-boot update /dev/sda --apply --experimental-apply
Status: ELIGIBLE for in-place update.
  disk GUID:   b17af29d-...
  ...
Rotation plan (1 step(s), in order):
  [1] kernel            /vmlinuz
      current: sha256:bc65565d…   →   new: sha256:39cc3d97…

Rotating 1 file(s) on /dev/sda1…
Rotation complete: 1 file(s) rotated in place.
Previous bytes preserved at \`.bak\` on the ESP for recovery.
AEGIS_ISOS preserved byte-for-byte.
\`\`\`

On failure:

\`\`\`
Rotation FAILED: mcopy ::/vmlinuz.new: <reason>
Rolling back 1 action(s)…
Rollback complete. Stick restored to pre-apply state as best we could.
\`\`\`

## Intentionally deferred

- **Post-rotate sha256 readback verification** — planner carries \`fresh_sha256\`; executor doesn't yet re-hash after rename to confirm the bytes landed correctly. Follow-up.
- **Attestation-manifest update** — rotated files' new hashes should be written into the stick's manifest + host-side copy. Phase 4.
- **OVMF E2E CI gate** — can't programmatically boot the rotated stick under a CI runner; hardware pass from this session is the current evidence. Future ADR-level work.
- **\`aegis-boot update --rollback\`** — operators can manually \`mren ::/vmlinuz.bak ::/vmlinuz\` today; the CLI verb is a follow-up.

## Test plan

- [x] \`cargo test --workspace\` — 13 suites pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` on both 1.88 and stable 1.95 — clean
- [x] Real-hardware rotation + rollback observed on SanDisk Cruzer

Refs #181 Phase 2b.