### PR TITLE
feat(#181 Phase 4): refresh attestation manifest on successful rotation

### DIFF
--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -192,7 +192,7 @@ fn handle_eligible(
         print_rotation_plan(&diff);
         println!();
         #[cfg(target_os = "linux")]
-        return apply_rotation(dev, &esp_part, &diff);
+        return apply_rotation(dev, &esp_part, &diff, attestation_path);
         #[cfg(not(target_os = "linux"))]
         {
             println!(
@@ -1186,7 +1186,12 @@ pub(crate) fn attestation_dir() -> PathBuf {
 /// 5. On failure, invoke `execute_rollback` with the progress trace +
 ///    surface both the original error and any rollback errors.
 #[cfg(target_os = "linux")]
-fn apply_rotation(dev: &Path, part1_dev: &Path, diff: &[EspFileDiff]) -> Result<(), u8> {
+fn apply_rotation(
+    dev: &Path,
+    part1_dev: &Path,
+    diff: &[EspFileDiff],
+    attestation_path: &Path,
+) -> Result<(), u8> {
     use crate::update_apply::plan_rotation;
 
     let plan = plan_rotation(diff);
@@ -1207,7 +1212,105 @@ fn apply_rotation(dev: &Path, part1_dev: &Path, diff: &[EspFileDiff]) -> Result<
         plan.len(),
         part1_dev.display()
     );
-    dispatch_rotation(dev, part1_dev, &plan, &sources)
+    let rotation_result = dispatch_rotation(dev, part1_dev, &plan, &sources);
+
+    // On successful rotation: refresh the attestation manifest (both
+    // host-side + ESP-side copies). Failure warns but doesn't fail —
+    // the rotation already landed; a stale manifest causes
+    // `verify --stick` drift on rotated slots, which is recoverable.
+    if rotation_result.is_ok()
+        && let Err(e) = refresh_manifest_after_rotate(attestation_path, part1_dev, &plan, &sources)
+    {
+        eprintln!("warning: manifest refresh after rotation failed: {e}");
+        eprintln!(
+            "(rotation landed successfully; `verify --stick` will show drift on rotated files until the manifest is refreshed)"
+        );
+    }
+
+    rotation_result
+}
+
+/// Read the current attestation manifest, update `esp_files[]` entries
+/// for rotated slots with their new sha256 + size, bump `sequence`,
+/// update `tool_version`, and write the manifest back to both the
+/// host-side attestations dir AND the ESP's canonical
+/// `::/aegis-boot-manifest.json`. Linux-only.
+#[cfg(target_os = "linux")]
+fn refresh_manifest_after_rotate(
+    attestation_path: &Path,
+    part1_dev: &Path,
+    plan: &[crate::update_apply::RotationStep],
+    sources: &crate::update_apply::RotationSources<'_>,
+) -> Result<(), String> {
+    // 1. Read + parse existing manifest.
+    let body = std::fs::read_to_string(attestation_path)
+        .map_err(|e| format!("read {}: {e}", attestation_path.display()))?;
+    let mut manifest: aegis_wire_formats::Manifest =
+        serde_json::from_str(&body).map_err(|e| format!("parse manifest: {e}"))?;
+
+    // 2. For each rotated step, find the matching EspFileEntry and
+    //    update sha256 + size. Manifest paths are `::/`-prefixed;
+    //    planner's `esp_path` is bare. Match by prepending `::`.
+    for step in plan {
+        let mtools_path = format!("::{}", step.esp_path);
+        let Some(entry) = manifest
+            .esp_files
+            .iter_mut()
+            .find(|e| e.path == mtools_path)
+        else {
+            eprintln!(
+                "warning: rotated slot {mtools_path} not in manifest.esp_files[] — skipping entry update"
+            );
+            continue;
+        };
+        let Some(src) = sources.source_for(step.role) else {
+            continue;
+        };
+        let size = std::fs::metadata(src)
+            .map(|m| m.len())
+            .map_err(|e| format!("stat {}: {e}", src.display()))?;
+        entry.sha256.clone_from(&step.fresh_sha256);
+        entry.size_bytes = size;
+    }
+
+    // 3. Bump sequence + tool_version so verifiers know this is newer
+    //    than what was flashed.
+    manifest.sequence = manifest.sequence.saturating_add(1);
+    manifest.tool_version = format!("aegis-boot {}", env!("CARGO_PKG_VERSION"));
+
+    // 4. Serialize + write both copies.
+    let new_body =
+        serde_json::to_string_pretty(&manifest).map_err(|e| format!("serialize manifest: {e}"))?;
+    std::fs::write(attestation_path, &new_body)
+        .map_err(|e| format!("write host-side {}: {e}", attestation_path.display()))?;
+
+    let tmp =
+        tempfile::NamedTempFile::new().map_err(|e| format!("tempfile for ESP manifest: {e}"))?;
+    std::fs::write(tmp.path(), &new_body).map_err(|e| format!("stage ESP manifest body: {e}"))?;
+    let dev_str = part1_dev.display().to_string();
+    let argv = crate::direct_install::build_mcopy_argv(
+        &dev_str,
+        tmp.path(),
+        crate::direct_install_manifest::MANIFEST_ESP_PATH,
+    );
+    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = std::process::Command::new("sudo")
+        .args(&argv_refs)
+        .output()
+        .map_err(|e| format!("mcopy exec: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "mcopy ESP manifest: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    println!(
+        "Manifest refreshed: sequence bumped to {}, {} slot(s) updated.",
+        manifest.sequence,
+        plan.len()
+    );
+    Ok(())
 }
 
 /// Owned host-side-source paths the rotation executor mcopies from.


### PR DESCRIPTION
The last significant Phase 4 operator-UX piece. After \`aegis-boot update --apply\` rotates files, update the attestation manifest (host-side + ESP-side) in place so \`verify --stick\` keeps returning OK.

## Flow

1. Read existing manifest from the \`attestation_path\` that eligibility check already resolved.
2. For each rotated slot: find matching \`EspFileEntry\` by path, update \`sha256\` + \`size_bytes\`.
3. Bump \`manifest.sequence\` by 1 (monotonic anti-rollback invariant).
4. Normalize \`tool_version\` to \`\"aegis-boot <ver>\"\`.
5. Write back to **both** the host-side attestations dir AND \`mcopy\` to \`::/aegis-boot-manifest.json\` on the ESP.

## Why it matters

Before this PR, \`verify --stick\` would report DRIFT on every rotated slot — manifest-recorded hash vs stick bytes diverged on every \`--apply\`. Rotation itself was correct; the integrity surface was broken. Now the two commands stay mutually consistent.

## Failure handling

If manifest refresh fails, the overall rotation still reports success (the ESP bytes are correct). A warning prints to stderr. Rationale: rotation is the load-bearing operation; refresh is the bookkeeping follow-up. Forcing rotation to \"fail\" when only the manifest refresh had a hiccup would confuse operators.

## Real-hardware verification

\`\`\`
\$ # Pre-rotation manifest
\$ jq '.manifest_sequence, .tool_version, (.esp_files[] | select(.path == "::/vmlinuz") | .sha256)' <manifest>
1776922331
"0.16.0"
"39cc3d97d415d99523754af0203f3951fa3bfdace5f3387926ccf2a7fd4fc8f0"

\$ # inject drift, rotate
\$ dd if=/dev/urandom of=/mnt/aegis-esp/vmlinuz bs=1 count=16 conv=notrunc
\$ aegis-boot update /dev/sda --apply --experimental-apply
Rotation complete: 1 file(s) rotated in place.
Manifest refreshed: sequence bumped to 1776922332, 1 slot(s) updated.

\$ # Post-rotation manifest
\$ jq '.manifest_sequence, .tool_version, (.esp_files[] | select(.path == "::/vmlinuz") | .sha256)'
1776922332
"aegis-boot 0.16.0"
"39cc3d97d415d99523754af0203f3951fa3bfdace5f3387926ccf2a7fd4fc8f0"

\$ aegis-boot verify --stick /dev/sda
Summary: 6 OK, 0 drift, 0 unreadable (of 6 total).
\`\`\`

## Test plan

- [x] \`cargo test --workspace\` — 13 suites pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` on 1.88 and stable 1.95 — clean
- [x] Real-hardware: rotate → manifest refresh → \`verify --stick\` still OK

## Related / remaining

Phase 4 still has some smaller UX items (\`--yes\`, progress output polish, \`doctor --stick\` last-updated row). Not blocking operator use today.

Refs #181 Phase 4.