### PR TITLE
feat(rescue-tui): keybinding registry drives footer (Phase 5 of #455)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "textwrap",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -1233,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1300,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
 ]
 
 [[package]]

--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -146,7 +146,7 @@ pub enum ProbeError {
 /// image, unfamiliar layout, truncated file). rescue-tui renders
 /// these as tier-4 rows with a descriptive reason instead of hiding
 /// them. (#456)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveryReport {
     /// ISOs that mounted + parsed successfully.
     pub isos: Vec<DiscoveredIso>,
@@ -157,7 +157,7 @@ pub struct DiscoveryReport {
 /// A `.iso` file found on disk that failed to parse. Paired with a
 /// human-readable reason and a structured [`FailureKind`] for
 /// downstream tier mapping.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FailedIso {
     /// Absolute path to the broken `.iso` file.
     pub iso_path: PathBuf,

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -24,6 +24,11 @@ crossterm = "0.29"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
 sha2 = "0.11"
 hex = "0.4"
+# Pre-wrap info-pane reason strings before handing to ratatui
+# Paragraph. `Paragraph::wrap` + `.scroll` has a known issue with
+# wrapped-line accounting (ratatui/ratatui#2342); using textwrap
+# gives us a stable `Vec<Line>` that scroll math handles correctly.
+textwrap = { version = "0.16", default-features = false, features = ["smawk"] }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/rescue-tui/src/keybindings.rs
+++ b/crates/rescue-tui/src/keybindings.rs
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Canonical keybinding registry — the single source of truth for
+//! the rescue-tui footer legend, the help overlay, and (via #462
+//! `tiers-docgen`) the published keybinding reference.
+//!
+//! Adding a new keybinding:
+//! 1. Add a row to [`KEYBINDINGS`].
+//! 2. Implement the dispatch in `main.rs` (event handling is
+//!    match-based; unifying match + registry is tracked separately).
+//! 3. `tiers-docgen` picks up the new row automatically.
+//!
+//! The registry is read by [`draw_footer`](crate::render) which
+//! filters by `(screen_kind, pane, filter_editing)` so the footer
+//! legend always matches what's actually available in the current
+//! context.
+//!
+//! ## Doc-friendly shape
+//!
+//! Every entry pairs a short `label` (footer-fit) with a long-form
+//! `description` (help overlay + docs). Both fields are `'static`
+//! string slices so the whole registry compiles down to
+//! `.rodata` — no allocation at render time.
+
+use crate::state::{Pane, Screen};
+
+/// Simplified screen tag used for keybinding filtering. Mirrors
+/// [`Screen`]'s variants but drops the data payloads since bindings
+/// depend only on *which* screen, not its current contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ScreenKind {
+    /// List of ISOs (dual-pane).
+    List,
+    /// Confirm-and-boot screen.
+    Confirm,
+    /// Edit kernel cmdline overlay.
+    EditCmdline,
+    /// Error screen after a kexec or verify failure.
+    Error,
+    /// Verify-now progress screen.
+    Verifying,
+    /// Typed-confirmation trust challenge for tier 2/3 ISOs.
+    TrustChallenge,
+    /// Help overlay.
+    Help,
+    /// Quit-confirmation overlay.
+    ConfirmQuit,
+    /// Quitting (terminal state; no bindings).
+    Quitting,
+}
+
+impl ScreenKind {
+    /// Derive the kind from the full [`Screen`] variant (ignoring the
+    /// underlying payload).
+    pub(crate) fn from_screen(s: &Screen) -> Self {
+        match s {
+            Screen::List { .. } => Self::List,
+            Screen::Confirm { .. } => Self::Confirm,
+            Screen::EditCmdline { .. } => Self::EditCmdline,
+            Screen::Error { .. } => Self::Error,
+            Screen::Verifying { .. } => Self::Verifying,
+            Screen::TrustChallenge { .. } => Self::TrustChallenge,
+            Screen::Help { .. } => Self::Help,
+            Screen::ConfirmQuit { .. } => Self::ConfirmQuit,
+            Screen::Quitting => Self::Quitting,
+        }
+    }
+}
+
+/// A single keybinding entry. Lives in the static [`KEYBINDINGS`]
+/// slice — all fields are `'static`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Keybinding {
+    /// Human-readable key glyph — what the user sees in the footer.
+    /// Examples: `"↑↓"`, `"Tab"`, `"Enter"`, `"/"`, `"q"`.
+    pub(crate) key: &'static str,
+    /// Short label (one or two words). Rendered in the footer legend.
+    pub(crate) label: &'static str,
+    /// Long-form description. Rendered in the help overlay + docs.
+    pub(crate) description: &'static str,
+    /// Screens this binding applies to. Empty slice = all screens.
+    pub(crate) screens: &'static [ScreenKind],
+    /// If `Some`, binding only matters when focus is on this pane.
+    /// `None` = pane-agnostic (works regardless of focus).
+    pub(crate) pane: Option<Pane>,
+    /// If `true`, binding only applies while the filter input is open.
+    /// Default `false` (applies when filter is not being edited).
+    pub(crate) while_filter_editing: bool,
+}
+
+/// Canonical keybinding table. `tiers-docgen` (#462) renders this as
+/// the published reference; [`filter_for`] is what the footer reads
+/// at render time.
+pub(crate) const KEYBINDINGS: &[Keybinding] = &[
+    // ---- Universal bindings (all screens) --------------------------
+    Keybinding {
+        key: "?",
+        label: "Help",
+        description: "Show the help overlay with all keybindings",
+        screens: &[],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "q",
+        label: "Quit",
+        description: "Quit rescue-tui (returns control to the boot menu)",
+        screens: &[],
+        pane: None,
+        while_filter_editing: false,
+    },
+    // ---- List screen -----------------------------------------------
+    Keybinding {
+        key: "↑↓/jk",
+        label: "Move",
+        description: "Move the list cursor (pane=List) or scroll info pane (pane=Info)",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "Tab",
+        label: "Focus",
+        description: "Toggle focus between the ISO list and the info pane",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "Enter",
+        label: "Boot",
+        description: "Confirm the selected ISO (only valid in the list pane)",
+        screens: &[ScreenKind::List],
+        pane: Some(Pane::List),
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "/",
+        label: "Filter",
+        description: "Open the substring filter — typed chars match label + path",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "s",
+        label: "Sort",
+        description: "Cycle sort order: name → size → distro → name",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "v",
+        label: "Verify",
+        description: "Re-compute sha256 of the selected ISO in a background thread",
+        screens: &[ScreenKind::List, ScreenKind::Confirm],
+        pane: None,
+        while_filter_editing: false,
+    },
+    // ---- Filter-editing overlay ------------------------------------
+    Keybinding {
+        key: "Enter",
+        label: "Commit",
+        description: "Commit the current filter and close the input",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: true,
+    },
+    Keybinding {
+        key: "Esc",
+        label: "Clear",
+        description: "Close the filter input and clear the current filter",
+        screens: &[ScreenKind::List],
+        pane: None,
+        while_filter_editing: true,
+    },
+    // ---- Confirm screen --------------------------------------------
+    Keybinding {
+        key: "Enter",
+        label: "kexec",
+        description: "Kexec into the selected ISO (may trigger a trust challenge)",
+        screens: &[ScreenKind::Confirm],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "e",
+        label: "cmdline",
+        description: "Edit the kernel command line before boot",
+        screens: &[ScreenKind::Confirm],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "Esc/h",
+        label: "Back",
+        description: "Return to the list without booting",
+        screens: &[ScreenKind::Confirm, ScreenKind::Error],
+        pane: None,
+        while_filter_editing: false,
+    },
+    // ---- EditCmdline overlay ---------------------------------------
+    Keybinding {
+        key: "Enter",
+        label: "Save",
+        description: "Save the edited kernel command line and return to Confirm",
+        screens: &[ScreenKind::EditCmdline],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "Esc",
+        label: "Cancel",
+        description: "Discard edits and return to Confirm",
+        screens: &[
+            ScreenKind::EditCmdline,
+            ScreenKind::Verifying,
+            ScreenKind::TrustChallenge,
+        ],
+        pane: None,
+        while_filter_editing: false,
+    },
+    // ---- Error screen ----------------------------------------------
+    Keybinding {
+        key: "F10",
+        label: "Save evidence",
+        description: "Write a failure-log bundle to AEGIS_ISOS for post-mortem analysis",
+        screens: &[ScreenKind::Error],
+        pane: None,
+        while_filter_editing: false,
+    },
+    // ---- TrustChallenge --------------------------------------------
+    Keybinding {
+        key: "boot+Enter",
+        label: "Proceed",
+        description: "Type the word 'boot' and press Enter to proceed past the trust challenge",
+        screens: &[ScreenKind::TrustChallenge],
+        pane: None,
+        while_filter_editing: false,
+    },
+];
+
+/// Return all bindings that apply in the given context, preserving
+/// the registry's declared order (which is also the order rendered
+/// in the footer and docs).
+pub(crate) fn filter_for(
+    screen: ScreenKind,
+    pane: Pane,
+    filter_editing: bool,
+) -> impl Iterator<Item = &'static Keybinding> {
+    KEYBINDINGS.iter().filter(move |k| {
+        if k.while_filter_editing != filter_editing {
+            return false;
+        }
+        if !k.screens.is_empty() && !k.screens.contains(&screen) {
+            return false;
+        }
+        if let Some(required) = k.pane {
+            if required != pane {
+                return false;
+            }
+        }
+        true
+    })
+}
+
+/// Render the filtered bindings as a single-line footer legend —
+/// `[key] label · [key] label · …`. Used by
+/// [`crate::render::draw_footer`].
+///
+/// Terminal states ([`ScreenKind::Quitting`], [`ScreenKind::Help`],
+/// [`ScreenKind::ConfirmQuit`]) produce an empty footer — the prior
+/// screen's bindings are surfaced by the overlay routing in
+/// `draw_footer` (it reads `prior`, not the overlay screen itself).
+pub(crate) fn footer_line(screen: ScreenKind, pane: Pane, filter_editing: bool) -> String {
+    if matches!(
+        screen,
+        ScreenKind::Quitting | ScreenKind::Help | ScreenKind::ConfirmQuit
+    ) {
+        return String::new();
+    }
+    let mut parts: Vec<String> = filter_for(screen, pane, filter_editing)
+        .map(|k| format!("[{}] {}", k.key, k.label))
+        .collect();
+    if parts.is_empty() {
+        return String::new();
+    }
+    parts.insert(0, String::new()); // leading space for breathing room
+    parts.join("  ")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_keybinding_has_non_empty_fields() {
+        for k in KEYBINDINGS {
+            assert!(!k.key.is_empty(), "empty key: {k:?}");
+            assert!(!k.label.is_empty(), "empty label: {k:?}");
+            assert!(!k.description.is_empty(), "empty description: {k:?}");
+        }
+    }
+
+    #[test]
+    fn filter_for_list_pane_shows_boot() {
+        let bindings: Vec<&Keybinding> = filter_for(ScreenKind::List, Pane::List, false).collect();
+        assert!(
+            bindings.iter().any(|k| k.label == "Boot"),
+            "Boot binding missing when list pane focused"
+        );
+        // Tab/Move are pane-agnostic so they show regardless.
+        assert!(bindings.iter().any(|k| k.label == "Focus"));
+        assert!(bindings.iter().any(|k| k.label == "Move"));
+    }
+
+    #[test]
+    fn filter_for_info_pane_hides_boot() {
+        // Enter = Boot only applies when list pane holds focus.
+        let bindings: Vec<&Keybinding> = filter_for(ScreenKind::List, Pane::Info, false).collect();
+        assert!(
+            !bindings.iter().any(|k| k.label == "Boot"),
+            "Boot binding must be hidden when info pane holds focus"
+        );
+        // But Move + Focus are still available.
+        assert!(bindings.iter().any(|k| k.label == "Move"));
+        assert!(bindings.iter().any(|k| k.label == "Focus"));
+    }
+
+    #[test]
+    fn filter_for_filter_editing_shows_commit_clear() {
+        let bindings: Vec<&Keybinding> = filter_for(ScreenKind::List, Pane::List, true).collect();
+        assert!(bindings.iter().any(|k| k.label == "Commit"));
+        assert!(bindings.iter().any(|k| k.label == "Clear"));
+        // Normal navigation bindings hidden — they don't apply here.
+        assert!(!bindings.iter().any(|k| k.label == "Move"));
+    }
+
+    #[test]
+    fn filter_for_confirm_screen_shows_kexec() {
+        let bindings: Vec<&Keybinding> =
+            filter_for(ScreenKind::Confirm, Pane::List, false).collect();
+        assert!(bindings.iter().any(|k| k.label == "kexec"));
+        assert!(bindings.iter().any(|k| k.label == "cmdline"));
+        assert!(bindings.iter().any(|k| k.label == "Back"));
+        // List-only bindings hidden.
+        assert!(!bindings.iter().any(|k| k.label == "Filter"));
+    }
+
+    #[test]
+    fn footer_line_not_empty_for_list_screen() {
+        let line = footer_line(ScreenKind::List, Pane::List, false);
+        assert!(line.contains("[Tab]"));
+        assert!(line.contains("[?]"));
+        assert!(line.contains("[q]"));
+    }
+
+    #[test]
+    fn footer_line_empty_on_quitting() {
+        assert_eq!(
+            footer_line(ScreenKind::Quitting, Pane::List, false),
+            "",
+            "Quitting state has no applicable bindings"
+        );
+    }
+
+    #[test]
+    fn screen_kind_maps_every_screen_variant() {
+        // Exhaustiveness: every Screen variant must produce a
+        // distinct ScreenKind so the filter is well-defined.
+        let kinds = [
+            ScreenKind::from_screen(&Screen::List { selected: 0 }),
+            ScreenKind::from_screen(&Screen::Confirm { selected: 0 }),
+            ScreenKind::from_screen(&Screen::EditCmdline {
+                selected: 0,
+                buffer: String::new(),
+                cursor: 0,
+            }),
+            ScreenKind::from_screen(&Screen::Error {
+                message: String::new(),
+                remedy: None,
+                return_to: 0,
+            }),
+            ScreenKind::from_screen(&Screen::Verifying {
+                selected: 0,
+                bytes: 0,
+                total: 0,
+                result: None,
+            }),
+            ScreenKind::from_screen(&Screen::TrustChallenge {
+                selected: 0,
+                buffer: String::new(),
+            }),
+            ScreenKind::from_screen(&Screen::Quitting),
+        ];
+        // Sanity: 7 inputs → 7 distinct kinds (Help / ConfirmQuit also
+        // exist but require a `prior` Screen we'd need to construct).
+        let distinct: std::collections::HashSet<ScreenKind> = kinds.iter().copied().collect();
+        assert_eq!(distinct.len(), 7);
+    }
+}

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -15,6 +15,7 @@ mod render;
 mod state;
 mod theme;
 mod tpm;
+mod verdict;
 
 use std::env;
 use std::io;
@@ -147,21 +148,16 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
             return Err(e.into());
         }
     };
-    // The structured `failed` list is discarded at this layer for now —
-    // #457 adds AppState::failed_isos and the dual-pane rendering that
-    // surfaces these as tier-4 rows. Until then, a count preserves the
-    // existing SKIPPED banner UX.
-    //
-    // The skipped count now sources from failed.len() (iso-parser's
-    // actual parse-failure list) plus any ISOs the count_iso_files walk
-    // saw that iso-parser never even attempted (should be zero under
-    // normal operation but stays defensive).
+    // Log structured failures at DEBUG. The inline SKIPPED banner is
+    // kept for now (sourced from failed.len() plus any on-disk files
+    // iso-parser never even attempted to mount); #458 replaces it with
+    // per-ISO tier-4 rows rendered from AppState::failed_isos.
     for failure in &failed {
         tracing::debug!(
             iso = %failure.iso_path.display(),
             reason = %failure.reason,
             kind = ?failure.kind,
-            "iso-probe: failed ISO (will surface in rescue-tui after #457)"
+            "iso-probe: failed ISO (surfaces as tier-4 row once #458 lands)"
         );
     }
     let counted_but_not_attempted = on_disk_iso_count.saturating_sub(isos.len() + failed.len());
@@ -194,6 +190,7 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
         );
     }
     let mut state = AppState::new(isos)
+        .with_failed_isos(failed)
         .with_scanned_roots(roots.to_vec())
         .with_skipped_iso_count(skipped);
     if let Ok(name) = env::var("AEGIS_THEME") {

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -583,6 +583,22 @@ fn run_text_mode(state: &mut AppState) -> Result<u8, Box<dyn std::error::Error>>
                         iso.iso_path.display()
                     )?;
                 }
+                crate::state::ViewEntry::FailedIso(idx) => {
+                    // Tier 4 — iso-parser couldn't extract boot entries.
+                    // Surfaced in the text-mode menu so the operator
+                    // sees the file exists and why it's not bootable.
+                    // Not selectable (index yields a RefusedBoot branch
+                    // in the dispatch match below). (#459)
+                    if let Some(f) = state.failed_isos.get(*idx) {
+                        writeln!(
+                            out,
+                            "  {:>2}. [!] {} — PARSE FAILED: {}",
+                            i + 1,
+                            f.iso_path.display(),
+                            f.reason
+                        )?;
+                    }
+                }
                 crate::state::ViewEntry::RescueShell => {
                     writeln!(out, "  {:>2}. [#] rescue shell (busybox)", i + 1)?;
                 }
@@ -637,6 +653,18 @@ fn run_text_mode(state: &mut AppState) -> Result<u8, Box<dyn std::error::Error>>
                 run_text_confirm(state, &mut out, idx)?;
                 // After confirm/verdict/shell return, loop repaints.
                 // If kexec succeeded it replaced the process.
+            }
+            crate::state::ViewEntry::FailedIso(idx) => {
+                // Tier-4 rows aren't bootable by design. Text mode
+                // surfaces the reason and loops so the operator can
+                // pick a different entry. (#459)
+                if let Some(f) = state.failed_isos.get(idx) {
+                    writeln!(
+                        out,
+                        "error: entry {n} is a parse-failed ISO and cannot boot: {}",
+                        f.reason
+                    )?;
+                }
             }
         }
     }

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -10,6 +10,7 @@
 #![forbid(unsafe_code)]
 
 mod failure_log;
+mod keybindings;
 mod persistence;
 mod render;
 mod state;

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -396,9 +396,27 @@ where
         }
 
         match (&state.screen, key.code) {
-            // Vim navigation aliases for arrow keys (#85).
-            (Screen::List { .. }, KeyCode::Up | KeyCode::Char('k')) => state.move_selection(-1),
-            (Screen::List { .. }, KeyCode::Down | KeyCode::Char('j')) => state.move_selection(1),
+            // Tab toggles focus between the list pane and the info pane
+            // on the List screen only. Shift+Tab is treated the same
+            // way — we only have two panes so there's no forward/back
+            // distinction to preserve. (#458)
+            (Screen::List { .. }, KeyCode::Tab | KeyCode::BackTab) => state.toggle_pane(),
+            // Vim navigation aliases for arrow keys (#85). Routed to
+            // whichever pane currently holds focus (#458).
+            (Screen::List { .. }, KeyCode::Up | KeyCode::Char('k')) => {
+                if state.pane == state::Pane::Info {
+                    state.move_info_scroll(-1);
+                } else {
+                    state.move_selection(-1);
+                }
+            }
+            (Screen::List { .. }, KeyCode::Down | KeyCode::Char('j')) => {
+                if state.pane == state::Pane::Info {
+                    state.move_info_scroll(1);
+                } else {
+                    state.move_selection(1);
+                }
+            }
             // `g`/`G` are the vim aliases; `Home`/`End` are the layout-
             // agnostic equivalents — crossterm maps them identically
             // under AZERTY, Dvorak, and any other layout, whereas the

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -713,6 +713,7 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
             ViewEntry::Iso(i) => {
                 render_iso_list_item(&state.isos[*i], &state.scanned_roots, state.secure_boot)
             }
+            ViewEntry::FailedIso(i) => render_failed_iso_list_item(&state.failed_isos[*i]),
             ViewEntry::RescueShell => {
                 ListItem::new("[#] rescue shell (busybox)  — dropped from rescue-tui")
             }
@@ -772,6 +773,33 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
 /// input target. Unfocused panes use `Color::DarkGray` so they
 /// recede — but stay visible enough that the layout is still
 /// readable. (#458)
+/// Render a list row for a [`iso_probe::FailedIso`] — tier-4 entry
+/// in the rescue-tui list. Shown with a red glyph and a truncated
+/// reason. The info pane reveals the full reason when the row is
+/// selected. (#459)
+fn render_failed_iso_list_item<'a>(failed: &iso_probe::FailedIso) -> ListItem<'a> {
+    let glyph = "[!]"; // tier-4 marker
+    let name = failed
+        .iso_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| failed.iso_path.display().to_string());
+    // Short reason for the list row — full reason lives in the info pane.
+    let short = {
+        let r = &failed.reason;
+        if r.len() > 40 {
+            let mut end = 40;
+            while !r.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{}…", &r[..end])
+        } else {
+            r.clone()
+        }
+    };
+    ListItem::new(format!("{glyph} {name}  — PARSE FAILED: {short}"))
+}
+
 fn pane_border_style(focused: bool, theme: &Theme) -> Style {
     if focused {
         Style::default().fg(theme.success)
@@ -780,9 +808,17 @@ fn pane_border_style(focused: bool, theme: &Theme) -> Style {
     }
 }
 
-/// Render the info pane. #458 ships the scaffold — verdict, filename,
-/// one-line reason. #459 replaces this with the full per-tier content
-/// specified in the design doc.
+/// Render the info pane — full per-tier content for the currently
+/// selected row. (#459)
+///
+/// Tier 1/2/3 (bootable): metadata rows (verdict, file, size, sha256,
+/// signer, kernel, initrd, cmdline, distro, quirks) plus any
+/// tier-specific notes.
+///
+/// Tier 4/5/6 (blocked): verdict + filename/size + a `Reason:` block
+/// with the full wrapped error. Long reasons are pre-wrapped via the
+/// `textwrap` crate (ratatui's `Paragraph::wrap` + `.scroll` has a
+/// known issue with wrapped-line accounting, ratatui/ratatui#2342).
 fn draw_info_pane(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -800,41 +836,19 @@ fn draw_info_pane(
     };
     let border = pane_border_style(focused, &state.theme);
 
+    // Usable content width = pane width - 2 border cols - 2 padding.
+    // Clamped to a small minimum so extreme-narrow terminals still
+    // produce at least some wrapping rather than 0-width panics.
+    let content_width = usize::from(area.width).saturating_sub(4).max(10);
+
     let lines: Vec<Line> = match entries.get(cursor) {
         Some(ViewEntry::Iso(idx)) => match state.isos.get(*idx) {
-            Some(iso) => {
-                let verdict = TrustVerdict::from_discovered(iso, state.secure_boot);
-                vec![
-                    Line::from(vec![
-                        Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
-                        Span::styled(
-                            verdict.label(),
-                            Style::default()
-                                .fg(verdict.color(&state.theme))
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    ]),
-                    Line::from(vec![
-                        Span::styled("File:     ", Style::default().add_modifier(Modifier::BOLD)),
-                        Span::raw(
-                            iso.iso_path
-                                .file_name()
-                                .map(|n| n.to_string_lossy().into_owned())
-                                .unwrap_or_default(),
-                        ),
-                    ]),
-                    Line::from(vec![
-                        Span::styled("Reason:   ", Style::default().add_modifier(Modifier::BOLD)),
-                        Span::raw(verdict.reason()),
-                    ]),
-                    Line::from(""),
-                    Line::from(Span::styled(
-                        "(full per-tier content lands in #459)",
-                        Style::default().add_modifier(Modifier::DIM),
-                    )),
-                ]
-            }
+            Some(iso) => info_pane_iso_lines(iso, state, content_width),
             None => vec![Line::from("(no ISO at selected index)")],
+        },
+        Some(ViewEntry::FailedIso(idx)) => match state.failed_isos.get(*idx) {
+            Some(failed) => info_pane_failed_lines(failed, &state.theme, content_width),
+            None => vec![Line::from("(no failed ISO at selected index)")],
         },
         Some(ViewEntry::RescueShell) => vec![
             Line::from(vec![
@@ -845,6 +859,9 @@ fn draw_info_pane(
                 Span::styled("Action:   ", Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw("exits rescue-tui to a busybox shell"),
             ]),
+            Line::from(""),
+            Line::from("Useful when no ISO will boot or you need to"),
+            Line::from("inspect the stick from a signed environment."),
         ],
         None => vec![Line::from("(empty)")],
     };
@@ -856,9 +873,211 @@ fn draw_info_pane(
                 .title(title)
                 .border_style(border),
         )
-        .wrap(Wrap { trim: false })
         .scroll((state.info_scroll, 0));
     frame.render_widget(paragraph, area);
+}
+
+/// Helper: render the info-pane line set for a successfully-parsed
+/// ISO. Covers tiers 1/2/3/5/6. (#459)
+fn info_pane_iso_lines<'a>(
+    iso: &iso_probe::DiscoveredIso,
+    state: &AppState,
+    content_width: usize,
+) -> Vec<Line<'a>> {
+    let verdict = TrustVerdict::from_discovered(iso, state.secure_boot);
+    let mut lines = Vec::with_capacity(14);
+
+    lines.push(Line::from(vec![
+        Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            verdict.label(),
+            Style::default()
+                .fg(verdict.color(&state.theme))
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(labeled("File:     ", filename_str(&iso.iso_path)));
+    lines.push(labeled("Size:     ", humanize_size(iso.size_bytes)));
+    lines.push(labeled("sha256:   ", hash_summary(iso)));
+    lines.push(labeled("Signer:   ", signer_summary(iso)));
+    lines.push(labeled("Kernel:   ", iso.kernel.display().to_string()));
+    lines.push(labeled(
+        "Initrd:   ",
+        iso.initrd
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "(none)".to_string()),
+    ));
+    lines.push(labeled(
+        "Cmdline:  ",
+        iso.cmdline.clone().unwrap_or_else(|| "(none)".to_string()),
+    ));
+    lines.push(labeled("Distro:   ", format!("{:?}", iso.distribution)));
+    let qs = quirks_summary(iso);
+    lines.push(labeled(
+        "Quirks:   ",
+        if qs.is_empty() {
+            "none".to_string()
+        } else {
+            qs
+        },
+    ));
+
+    // Tier-specific note. For tier-4/5/6 (which can be reached here if
+    // a tier-6 hash mismatch is detected on an otherwise-parseable
+    // ISO), render a wrapped reason block.
+    if !verdict.is_bootable() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Reason:",
+            Style::default()
+                .fg(state.theme.error)
+                .add_modifier(Modifier::BOLD),
+        )));
+        extend_wrapped(&mut lines, &verdict.reason(), content_width);
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Boot is disabled for this ISO.",
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    } else if matches!(
+        verdict,
+        TrustVerdict::BareUnverified | TrustVerdict::KeyNotTrusted
+    ) {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Note:",
+            Style::default()
+                .fg(state.theme.warning)
+                .add_modifier(Modifier::BOLD),
+        )));
+        let note = match verdict {
+            TrustVerdict::BareUnverified => {
+                "This ISO is bootable but has no operator attestation. \
+                 A typed confirmation is required before boot."
+            }
+            TrustVerdict::KeyNotTrusted => {
+                "Signature is structurally valid but the signer is not in \
+                 AEGIS_TRUSTED_KEYS. Typed confirmation is required before boot."
+            }
+            _ => "",
+        };
+        extend_wrapped(&mut lines, note, content_width);
+    }
+
+    lines
+}
+
+/// Helper: render the info-pane line set for a tier-4 (ParseFailed)
+/// row. Routes through [`TrustVerdict::from_failed`] so the tier
+/// label, color, and reason come from the same canonical source the
+/// rest of the UI uses. (#459)
+fn info_pane_failed_lines<'a>(
+    failed: &iso_probe::FailedIso,
+    theme: &Theme,
+    content_width: usize,
+) -> Vec<Line<'a>> {
+    let verdict = TrustVerdict::from_failed(failed);
+    let mut lines = Vec::with_capacity(10);
+    lines.push(Line::from(vec![
+        Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            verdict.label(),
+            Style::default()
+                .fg(verdict.color(theme))
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(labeled("File:     ", filename_str(&failed.iso_path)));
+    lines.push(labeled("Path:     ", failed.iso_path.display().to_string()));
+    lines.push(labeled("Kind:     ", format!("{:?}", failed.kind)));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Reason:",
+        Style::default()
+            .fg(verdict.color(theme))
+            .add_modifier(Modifier::BOLD),
+    )));
+    extend_wrapped(&mut lines, &verdict.reason(), content_width);
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "This ISO could not be mounted or did not contain a recognized",
+        Style::default().add_modifier(Modifier::DIM),
+    )));
+    lines.push(Line::from(Span::styled(
+        "boot layout. Boot is disabled.",
+        Style::default().add_modifier(Modifier::DIM),
+    )));
+    lines
+}
+
+/// Build a `"Label: value"` info-pane line with the label in bold.
+fn labeled<'a>(label: &'a str, value: String) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(value),
+    ])
+}
+
+fn filename_str(p: &std::path::Path) -> String {
+    p.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| p.display().to_string())
+}
+
+/// Short verification summary for the info pane's sha256 row. Avoids
+/// dumping a 64-char hex blob while still saying whether verification
+/// happened and which side-car source was used.
+fn hash_summary(iso: &iso_probe::DiscoveredIso) -> String {
+    use iso_probe::HashVerification as H;
+    match &iso.hash_verification {
+        H::Verified { digest, source } => {
+            format!("verified ({}) from {}", short_hex(digest), source)
+        }
+        H::Mismatch {
+            expected, actual, ..
+        } => format!(
+            "MISMATCH expected {} got {}",
+            short_hex(expected),
+            short_hex(actual)
+        ),
+        H::NotPresent => "—  (no sibling .sha256)".to_string(),
+        H::Unreadable { reason, .. } => format!("unreadable: {reason}"),
+    }
+}
+
+/// Short signer summary paired with trust decision.
+fn signer_summary(iso: &iso_probe::DiscoveredIso) -> String {
+    use iso_probe::SignatureVerification as S;
+    match &iso.signature_verification {
+        S::Verified { key_id, .. } => format!("{key_id} (✓ trusted)"),
+        S::KeyNotTrusted { key_id } => format!("{key_id} (✗ not in AEGIS_TRUSTED_KEYS)"),
+        S::Forged { .. } => "FORGED signature".to_string(),
+        S::Error { reason } => format!("verification error: {reason}"),
+        S::NotPresent => "—  (no sibling .minisig)".to_string(),
+    }
+}
+
+fn short_hex(hex: &str) -> String {
+    if hex.len() <= 14 {
+        return hex.to_string();
+    }
+    let mut end = 12;
+    while !hex.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &hex[..end])
+}
+
+/// Pre-wrap a string to `content_width` and append one `Line` per
+/// wrapped row to `out`. Uses `textwrap::wrap` because ratatui's own
+/// `Paragraph::wrap` + `.scroll` mis-counts wrapped lines
+/// (ratatui/ratatui#2342) and breaks info-pane scroll math.
+fn extend_wrapped(out: &mut Vec<Line<'_>>, text: &str, content_width: usize) {
+    let wrapped = textwrap::wrap(text, content_width);
+    for piece in wrapped {
+        out.push(Line::from(piece.to_string()));
+    }
 }
 
 // Intentionally over the 100-line threshold: the Confirm screen is the
@@ -1619,6 +1838,104 @@ mod tests {
         assert!(
             !s.contains("Verdict:"),
             "empty state should not show info pane verdict: {s}"
+        );
+    }
+
+    // ---- #459 — info pane full content + tier-4 rows ----------------
+
+    fn fake_failed_iso(name: &str, reason: &str) -> iso_probe::FailedIso {
+        iso_probe::FailedIso {
+            iso_path: std::path::PathBuf::from(format!("/isos/{name}")),
+            reason: reason.to_string(),
+            kind: iso_probe::FailureKind::MountFailed,
+        }
+    }
+
+    #[test]
+    fn info_pane_tier1_shows_full_metadata_rows() {
+        // Fake an ISO with a verified hash so it renders as tier 1
+        // (OperatorAttested) and the info pane's full metadata
+        // rows (Kernel, Initrd, Cmdline, Distro, Quirks) should appear.
+        let mut iso = fake_iso("ubuntu");
+        iso.hash_verification = iso_probe::HashVerification::Verified {
+            digest: "abcdef1234567890".to_string(),
+            source: "/isos/ubuntu.iso.sha256".to_string(),
+        };
+        let state = AppState::new(vec![iso]);
+        let s = render_to_string(&state);
+        assert!(s.contains("VERIFIED"), "tier 1 label missing: {s}");
+        // Each metadata row's label must appear somewhere in the pane.
+        for label in &["File:", "Size:", "sha256:", "Kernel:", "Distro:"] {
+            assert!(s.contains(label), "info pane missing {label}: {s}");
+        }
+    }
+
+    #[test]
+    fn info_pane_tier4_failed_iso_shows_reason_block() {
+        let state = AppState::new(Vec::new()).with_failed_isos(vec![fake_failed_iso(
+            "broken.iso",
+            "mount: wrong fs type, bad option, bad superblock",
+        )]);
+        let s = render_to_string(&state);
+        assert!(s.contains("PARSE FAILED"), "tier-4 label missing: {s}");
+        assert!(s.contains("broken.iso"), "filename missing: {s}");
+        assert!(s.contains("wrong fs type"), "reason string missing: {s}");
+        assert!(s.contains("Boot is disabled"), "disabled hint missing: {s}");
+    }
+
+    #[test]
+    fn info_pane_wraps_long_reason_strings() {
+        // 400-char reason — wider than the info pane at 120x30 → must
+        // wrap. textwrap renders multiple lines; no line may exceed
+        // the pane's content width.
+        let long_reason = "x".repeat(400);
+        let state = AppState::new(Vec::new())
+            .with_failed_isos(vec![fake_failed_iso("x.iso", &long_reason)]);
+        let s = render_to_string(&state);
+        // Rendered output should contain many 'x' chars across the
+        // wrapped region. The raw long string isn't present
+        // contiguously — textwrap inserts breaks.
+        let x_runs: Vec<&str> = s
+            .split_whitespace()
+            .filter(|t| t.starts_with('x'))
+            .collect();
+        assert!(
+            x_runs.len() > 1,
+            "long reason should wrap into multiple line fragments: {s}"
+        );
+    }
+
+    #[test]
+    fn list_includes_failed_iso_as_parse_failed_row() {
+        // All ISOs on disk must be visible — tier-4 rows too.
+        let state = AppState::new(Vec::new())
+            .with_failed_isos(vec![fake_failed_iso("fail.iso", "mount error")]);
+        let s = render_to_string(&state);
+        assert!(
+            s.contains("fail.iso"),
+            "failed ISO filename missing from list: {s}"
+        );
+        assert!(s.contains("PARSE FAILED"), "tier-4 list label missing: {s}");
+    }
+
+    #[test]
+    fn info_pane_bare_unverified_shows_typed_confirmation_note() {
+        // Tier 2 shows a warning-colored Note block pointing at the
+        // typed-confirmation challenge the operator will hit on boot.
+        let iso = fake_iso("bare");
+        let state = AppState::new(vec![iso]);
+        let s = render_to_string(&state);
+        assert!(s.contains("UNVERIFIED"), "tier-2 label missing: {s}");
+        assert!(s.contains("Note:"), "tier-2 note block missing: {s}");
+        // "typed confirmation" can wrap into separate lines in the
+        // render buffer, so the two words aren't guaranteed
+        // contiguous. Check for presence of each word plus the
+        // uniquely-phrased signal "no operator attestation" so the
+        // assertion doesn't false-pass on an unrelated screen.
+        assert!(s.contains("typed"), "tier-2 note missing 'typed': {s}");
+        assert!(
+            s.contains("operator attestation"),
+            "tier-2 note missing 'operator attestation': {s}"
         );
     }
 

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -13,6 +13,7 @@ use ratatui::{
 
 use crate::state::{AppState, Screen, SecureBootStatus, quirks_summary};
 use crate::theme::Theme;
+use crate::verdict::TrustVerdict;
 
 /// Render the current frame for the given state.
 ///
@@ -97,7 +98,7 @@ fn draw_trust_challenge(
     let Some(iso) = state.isos.get(selected) else {
         return;
     };
-    let verdict = trust_verdict(iso);
+    let verdict = trust_verdict(iso, state);
     let lines = vec![
         Line::from(Span::styled(
             "Degraded trust — typed confirmation required",
@@ -339,67 +340,11 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     frame.render_widget(Paragraph::new(hint), area);
 }
 
-/// Android Verified Boot-style coarse verdict for a single ISO. One of
-/// four states drives a colored banner on the Confirm screen. (#93)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TrustVerdict {
-    /// Hash OR signature verified (strongest signal that sig exists).
-    Green,
-    /// Signature parsed but signer not in trust store (YELLOW on Android VB).
-    Yellow,
-    /// Bytes tampered / forged signature / not kexec-bootable.
-    Red,
-    /// No verification material at all.
-    Gray,
-}
-
-impl TrustVerdict {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Green => "GREEN  VERIFIED",
-            Self::Yellow => "YELLOW UNTRUSTED SIGNER",
-            Self::Red => "RED    DO NOT BOOT",
-            Self::Gray => "GRAY   NO VERIFICATION",
-        }
-    }
-
-    fn reason(self) -> &'static str {
-        match self {
-            Self::Green => "hash + signature checked against trusted key",
-            Self::Yellow => "signature parsed but key is not in AEGIS_TRUSTED_KEYS",
-            Self::Red => "integrity failure — kexec will be refused",
-            Self::Gray => "no sibling .sha256 or .minisig found",
-        }
-    }
-
-    fn color(self, theme: &Theme) -> ratatui::style::Color {
-        use ratatui::style::Color;
-        match self {
-            Self::Green => theme.success,
-            Self::Yellow => theme.warning,
-            Self::Red => theme.error,
-            Self::Gray => Color::Gray,
-        }
-    }
-}
-
-fn trust_verdict(iso: &iso_probe::DiscoveredIso) -> TrustVerdict {
-    use iso_probe::{HashVerification as H, Quirk, SignatureVerification as S};
-    if iso.quirks.contains(&Quirk::NotKexecBootable)
-        || matches!(iso.hash_verification, H::Mismatch { .. })
-        || matches!(iso.signature_verification, S::Forged { .. })
-    {
-        return TrustVerdict::Red;
-    }
-    if matches!(iso.signature_verification, S::Verified { .. })
-        || matches!(iso.hash_verification, H::Verified { .. })
-    {
-        return TrustVerdict::Green;
-    }
-    if matches!(iso.signature_verification, S::KeyNotTrusted { .. }) {
-        return TrustVerdict::Yellow;
-    }
-    TrustVerdict::Gray
+/// Derive the trust verdict for an ISO. Delegates to the canonical
+/// [`TrustVerdict::from_discovered`] in [`crate::verdict`] so there's
+/// a single source of truth for the tier model (#457).
+fn trust_verdict(iso: &iso_probe::DiscoveredIso, state: &AppState) -> TrustVerdict {
+    TrustVerdict::from_discovered(iso, state.secure_boot)
 }
 
 /// Single-character status glyph for a list row, encoding the worst
@@ -413,8 +358,9 @@ fn trust_verdict(iso: &iso_probe::DiscoveredIso) -> TrustVerdict {
 fn render_iso_list_item<'a>(
     iso: &iso_probe::DiscoveredIso,
     scanned_roots: &[std::path::PathBuf],
+    secure_boot: SecureBootStatus,
 ) -> ListItem<'a> {
-    let glyph = status_glyph(iso);
+    let glyph = TrustVerdict::from_discovered(iso, secure_boot).glyph();
     let qs = quirks_summary(iso);
     // Prefer pretty_name over label when present so operators see the
     // version (e.g. "Ubuntu 24.04.2 LTS" vs just "Ubuntu"). (#119)
@@ -472,26 +418,6 @@ fn iso_folder_prefix(iso_path: &std::path::Path, roots: &[std::path::PathBuf]) -
     } else {
         Some(parts.join("/"))
     }
-}
-
-fn status_glyph(iso: &iso_probe::DiscoveredIso) -> &'static str {
-    use iso_probe::{HashVerification as H, Quirk, SignatureVerification as S};
-    if iso.quirks.contains(&Quirk::NotKexecBootable) {
-        return "[X]"; // can't kexec at all
-    }
-    if matches!(iso.hash_verification, H::Mismatch { .. }) {
-        return "[!]"; // tampered
-    }
-    if matches!(iso.signature_verification, S::Forged { .. }) {
-        return "[!]"; // crypto fail
-    }
-    if matches!(iso.signature_verification, S::Verified { .. }) {
-        return "[+]"; // signed + trusted
-    }
-    if matches!(iso.hash_verification, H::Verified { .. }) {
-        return "[~]"; // hash ok, sig absent
-    }
-    "[ ]"
 }
 
 fn draw_help_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -776,7 +702,9 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
     let items: Vec<ListItem> = entries
         .iter()
         .map(|e| match e {
-            ViewEntry::Iso(i) => render_iso_list_item(&state.isos[*i], &state.scanned_roots),
+            ViewEntry::Iso(i) => {
+                render_iso_list_item(&state.isos[*i], &state.scanned_roots, state.secure_boot)
+            }
             ViewEntry::RescueShell => {
                 ListItem::new("[#] rescue shell (busybox)  — dropped from rescue-tui")
             }
@@ -826,9 +754,10 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
         "Cmdline:  "
     };
 
-    // Android VB-style verdict line (#93). One coarse GREEN / YELLOW /
-    // RED / GRAY state derived from hash + signature + quirk results.
-    let verdict = trust_verdict(iso);
+    // Trust-tier verdict line. One of the 6 TrustVerdict variants
+    // (#457 extends the original GREEN/YELLOW/RED/GRAY model to also
+    // surface ParseFailed / SecureBootBlocked / HashMismatch).
+    let verdict = trust_verdict(iso, state);
     let verdict_line = Line::from(vec![
         Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
         Span::styled(
@@ -1165,7 +1094,7 @@ fn draw_error(
                 "Verdict:    ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw(trust_verdict(iso).label().to_string()),
+            Span::raw(trust_verdict(iso, state).label().to_string()),
         ]));
         lines.push(Line::from(vec![
             Span::styled(

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -11,7 +11,7 @@ use ratatui::{
     widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use crate::state::{AppState, Screen, SecureBootStatus, quirks_summary};
+use crate::state::{AppState, Pane, Screen, SecureBootStatus, quirks_summary};
 use crate::theme::Theme;
 use crate::verdict::TrustVerdict;
 
@@ -638,12 +638,20 @@ fn split_list_chrome(frame: &mut Frame<'_>, area: Rect, state: &AppState) -> (Re
 
 fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
     use crate::state::ViewEntry;
-    if state.isos.is_empty() {
+    if state.isos.is_empty() && state.failed_isos.is_empty() {
         draw_empty_list(frame, area, state);
         return;
     }
 
-    let (info_area, list_area) = split_list_chrome(frame, area, state);
+    // Chrome: (filter/sort hint line) on top, (main body) below. The
+    // main body is now a 40/60 horizontal split between the ISO list
+    // (left) and the info pane (right). (#458)
+    let (info_line_area, body_area) = split_list_chrome(frame, area, state);
+    let panes = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(body_area);
+    let (list_area, info_pane_area) = (panes[0], panes[1]);
 
     // Design-review #102: filter-mode visual was too subtle (trailing
     // `_` the only indicator). Now: when editing, render a reversed-
@@ -668,21 +676,21 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
                 state.sort_order.summary()
             )),
         ]);
-        frame.render_widget(Paragraph::new(styled), info_area);
+        frame.render_widget(Paragraph::new(styled), info_line_area);
     } else {
         let info_line = if state.filter.is_empty() {
             format!(
-                " sort: {}   (/ filter, s cycle sort)",
+                " sort: {}   (/ filter, s cycle sort, Tab focus)",
                 state.sort_order.summary()
             )
         } else {
             format!(
-                " filter: \"{}\"   sort: {}   (/ edit, s cycle sort)",
+                " filter: \"{}\"   sort: {}   (/ edit, Tab focus)",
                 state.filter,
                 state.sort_order.summary()
             )
         };
-        frame.render_widget(Paragraph::new(info_line), info_area);
+        frame.render_widget(Paragraph::new(info_line), info_line_area);
     }
 
     // Full entries view includes the rescue-shell synthetic row at
@@ -722,15 +730,135 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
             state.isos.len()
         )
     };
+    // Focus styling — the active pane's border brightens; the inactive
+    // pane dims. List-pane highlight is only visible when the list
+    // itself holds focus (otherwise the reverse-video row looks like
+    // a bug from the operator's POV). (#458, gitui pattern.)
+    let list_focused = state.pane == Pane::List;
+    let list_block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(pane_border_style(list_focused, &state.theme));
+    let list_highlight = if list_focused {
+        Style::default().add_modifier(Modifier::REVERSED)
+    } else {
+        Style::default().add_modifier(Modifier::DIM)
+    };
     let list = List::new(items)
-        .block(Block::default().borders(Borders::ALL).title(title))
-        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .block(list_block)
+        .highlight_style(list_highlight)
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();
     let cursor = selected.min(entries.len().saturating_sub(1));
     list_state.select(Some(cursor));
     frame.render_stateful_widget(list, list_area, &mut list_state);
+
+    // Info pane — tier-aware summary of the currently-selected row.
+    // This is the #458 scaffold: verdict + filename + one-line reason.
+    // #459 extends with the full per-tier metadata (sha256, signer,
+    // kernel/initrd, cmdline, quirks, …).
+    draw_info_pane(
+        frame,
+        info_pane_area,
+        state,
+        selected,
+        state.pane == Pane::Info,
+    );
+}
+
+/// Border style for a pane based on focus state. Focused panes use
+/// theme.success (bright) so the eye immediately lands on the active
+/// input target. Unfocused panes use `Color::DarkGray` so they
+/// recede — but stay visible enough that the layout is still
+/// readable. (#458)
+fn pane_border_style(focused: bool, theme: &Theme) -> Style {
+    if focused {
+        Style::default().fg(theme.success)
+    } else {
+        Style::default().fg(ratatui::style::Color::DarkGray)
+    }
+}
+
+/// Render the info pane. #458 ships the scaffold — verdict, filename,
+/// one-line reason. #459 replaces this with the full per-tier content
+/// specified in the design doc.
+fn draw_info_pane(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    selected: usize,
+    focused: bool,
+) {
+    use crate::state::ViewEntry;
+    let entries = state.visible_entries();
+    let cursor = selected.min(entries.len().saturating_sub(1));
+    let title = if focused {
+        " info (focused) "
+    } else {
+        " info "
+    };
+    let border = pane_border_style(focused, &state.theme);
+
+    let lines: Vec<Line> = match entries.get(cursor) {
+        Some(ViewEntry::Iso(idx)) => match state.isos.get(*idx) {
+            Some(iso) => {
+                let verdict = TrustVerdict::from_discovered(iso, state.secure_boot);
+                vec![
+                    Line::from(vec![
+                        Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::styled(
+                            verdict.label(),
+                            Style::default()
+                                .fg(verdict.color(&state.theme))
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("File:     ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(
+                            iso.iso_path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().into_owned())
+                                .unwrap_or_default(),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Reason:   ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(verdict.reason()),
+                    ]),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        "(full per-tier content lands in #459)",
+                        Style::default().add_modifier(Modifier::DIM),
+                    )),
+                ]
+            }
+            None => vec![Line::from("(no ISO at selected index)")],
+        },
+        Some(ViewEntry::RescueShell) => vec![
+            Line::from(vec![
+                Span::styled("Verdict:  ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("SHELL (busybox)"),
+            ]),
+            Line::from(vec![
+                Span::styled("Action:   ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("exits rescue-tui to a busybox shell"),
+            ]),
+        ],
+        None => vec![Line::from("(empty)")],
+    };
+
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(border),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((state.info_scroll, 0));
+    frame.render_widget(paragraph, area);
 }
 
 // Intentionally over the 100-line threshold: the Confirm screen is the
@@ -1242,7 +1370,21 @@ mod tests {
     }
 
     fn render_to_string(state: &AppState) -> String {
-        let backend = TestBackend::new(80, 20);
+        // Bumped from 80x20 → 120x30 with the dual-pane layout (#458) —
+        // the 40/60 split leaves ~48 cols for the list pane including
+        // borders, which is still tight for long labels + distro +
+        // quirks. 120 cols is a typical modern terminal and matches
+        // what real operators see in rescue-tui.
+        render_to_string_sized(state, 120, 30)
+    }
+
+    /// Render variant that lets individual tests exercise smaller or
+    /// larger terminal geometries. Default is [`render_to_string`]'s
+    /// 120x30. The minimum reasonable rescue-tui width is 80 cols
+    /// (pre-#458 default); tests that assert on the truncated /
+    /// minimum layout should use this helper explicitly.
+    fn render_to_string_sized(state: &AppState, cols: u16, rows: u16) -> String {
+        let backend = TestBackend::new(cols, rows);
         let mut terminal = Terminal::new(backend).unwrap_or_else(|e| panic!("terminal: {e}"));
         terminal
             .draw(|f| draw(f, state))
@@ -1421,6 +1563,63 @@ mod tests {
         let state = AppState::new(vec![iso]);
         let s = render_to_string(&state);
         assert!(s.contains("unsigned-kernel"));
+    }
+
+    // ---- #458 — dual-pane layout --------------------------------------
+
+    #[test]
+    fn list_screen_renders_info_pane_with_verdict() {
+        // The info pane (right side of the 40/60 split) must surface
+        // the currently-selected row's verdict label so the operator
+        // sees what tier they're about to act on.
+        let iso = fake_iso("ubuntu-live");
+        let state = AppState::new(vec![iso]);
+        let s = render_to_string(&state);
+        assert!(s.contains("Verdict:"));
+        // fake_iso has no sidecar/sig → tier 2 (BareUnverified).
+        assert!(s.contains("UNVERIFIED"), "expected Tier 2 label in: {s}");
+    }
+
+    #[test]
+    fn list_screen_renders_info_pane_with_filename() {
+        let iso = fake_iso("ubuntu-live");
+        let state = AppState::new(vec![iso]);
+        let s = render_to_string(&state);
+        assert!(s.contains("File:"), "info pane must label File: ");
+        // fake_iso's iso_path ends in the label — it's constructed
+        // that way in the test harness (ubuntu-live.iso).
+        assert!(s.contains("ubuntu-live"));
+    }
+
+    #[test]
+    fn info_pane_label_reflects_focus_state() {
+        let iso = fake_iso("a");
+        let mut state = AppState::new(vec![iso]);
+        // Default: List focused, info pane title is " info ".
+        let unfocused = render_to_string(&state);
+        assert!(
+            unfocused.contains(" info "),
+            "unfocused title missing: {unfocused}"
+        );
+        // Tab moves focus → info pane title becomes " info (focused) ".
+        state.toggle_pane();
+        let focused = render_to_string(&state);
+        assert!(
+            focused.contains("info (focused)"),
+            "focused title missing: {focused}"
+        );
+    }
+
+    #[test]
+    fn empty_list_bypasses_dual_pane_and_shows_empty_screen() {
+        // No ISOs and no failures → empty screen path, not dual pane.
+        let state = AppState::new(Vec::new());
+        let s = render_to_string(&state);
+        // draw_empty_list renders a single-pane message.
+        assert!(
+            !s.contains("Verdict:"),
+            "empty state should not show info pane verdict: {s}"
+        );
     }
 
     #[test]

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -11,6 +11,7 @@ use ratatui::{
     widgets::{Block, Borders, Gauge, List, ListItem, ListState, Paragraph, Wrap},
 };
 
+use crate::keybindings::{self, ScreenKind};
 use crate::state::{AppState, Pane, Screen, SecureBootStatus, quirks_summary};
 use crate::theme::Theme;
 use crate::verdict::TrustVerdict;
@@ -312,31 +313,14 @@ fn draw_header(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
 
 fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     // Footer hints depend on the underlying screen, not the overlay.
+    // Registry-driven since #460 — the KEYBINDINGS table is the single
+    // source of truth for footer, help overlay, and docgen.
     let effective = match &state.screen {
         Screen::Help { prior } | Screen::ConfirmQuit { prior } => prior.as_ref(),
         other => other,
     };
-    let hint = if state.filter_editing {
-        " Filter: type to match  ·  [Enter] commit  ·  [Esc] clear"
-    } else {
-        match effective {
-            Screen::List { .. } => {
-                " [↑↓/jk] Move  [Enter] Boot  [/] Filter  [s] Sort  [v] Verify  [?] Help  [q] Quit"
-            }
-            Screen::Confirm { .. } => {
-                " [Enter] kexec  [e] cmdline  [v] Verify  [Esc/h] Back  [?] Help  [q] Quit"
-            }
-            Screen::EditCmdline { .. } => {
-                " [Enter] Save  [Esc] Cancel  [←/→] Move  [Backspace] Delete"
-            }
-            Screen::Error { .. } => {
-                " [F10] Save evidence to AEGIS_ISOS  ·  any key = back  ·  [q] Quit"
-            }
-            Screen::Verifying { .. } => " Verifying in background  ·  [Esc] Cancel",
-            Screen::TrustChallenge { .. } => " Type `boot` + Enter to proceed  ·  [Esc] Cancel",
-            Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => "",
-        }
-    };
+    let kind = ScreenKind::from_screen(effective);
+    let hint = keybindings::footer_line(kind, state.pane, state.filter_editing);
     frame.render_widget(Paragraph::new(hint), area);
 }
 

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -91,6 +91,13 @@ pub enum Screen {
 pub struct AppState {
     /// All discovered ISOs.
     pub isos: Vec<DiscoveredIso>,
+    /// `.iso` files on disk that iso-parser couldn't extract boot
+    /// entries from (mount failure, unfamiliar layout, truncated
+    /// file). Carried alongside [`Self::isos`] so the TUI can render
+    /// tier-4 rows with the per-file reason — the list stays
+    /// exhaustive even when parse fails. Populated from
+    /// [`iso_probe::DiscoveryReport::failed`] in `main.rs`. (#457)
+    pub failed_isos: Vec<iso_probe::FailedIso>,
     /// Current screen.
     pub screen: Screen,
     /// Per-ISO cmdline overrides keyed by index. When absent the
@@ -308,6 +315,7 @@ impl AppState {
     pub fn new(isos: Vec<DiscoveredIso>) -> Self {
         Self {
             isos,
+            failed_isos: Vec::new(),
             screen: Screen::List { selected: 0 },
             cmdline_overrides: std::collections::HashMap::new(),
             theme: Theme::default_theme(),
@@ -320,6 +328,18 @@ impl AppState {
             scanned_roots: Vec::new(),
             skipped_iso_count: 0,
         }
+    }
+
+    /// Attach the list of ISOs that iso-parser couldn't extract boot
+    /// entries from — carried alongside the successful ISOs so the
+    /// TUI can render tier-4 rows in the list instead of hiding them
+    /// behind a count. Populated from
+    /// [`iso_probe::DiscoveryReport::failed`] in `main.rs`. Tests
+    /// default to an empty vec via [`Self::new`]. (#457)
+    #[must_use]
+    pub fn with_failed_isos(mut self, failed: Vec<iso_probe::FailedIso>) -> Self {
+        self.failed_isos = failed;
+        self
     }
 
     /// Attach the paths `discover()` was asked to scan. Called from

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -140,6 +140,14 @@ pub struct AppState {
     /// (#85 Tier 2 last child.) #457 will replace this banner with
     /// per-ISO tier-4 rows sourced from `DiscoveryReport::failed`.
     pub skipped_iso_count: usize,
+    /// Which pane holds keyboard focus on the List screen. Defaults to
+    /// [`Pane::List`]; toggled with `Tab`. (#458)
+    pub pane: Pane,
+    /// Vertical scroll offset for the info pane (tier-specific detail
+    /// view). Increments when `↑`/`↓` are pressed while `pane` is
+    /// [`Pane::Info`]. Resets to 0 when the list selection changes —
+    /// per-ISO scrollback would be confusing. (#458 / #459)
+    pub info_scroll: u16,
 }
 
 /// Sort order applied to the List view. Cycled with the `s` key.
@@ -192,6 +200,29 @@ impl SortOrder {
             Self::Name => "name",
             Self::SizeDesc => "size↓",
             Self::Distro => "distro",
+        }
+    }
+}
+
+/// Which pane holds keyboard focus on the List screen. List selection
+/// moves with ↑↓ when focus is `List`; the info-pane scroll offset
+/// moves with ↑↓ when focus is `Info`. `Tab` toggles. (#458)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Pane {
+    /// Left pane — ISO list. Default focus at startup.
+    #[default]
+    List,
+    /// Right pane — info/detail view for the selected ISO.
+    Info,
+}
+
+impl Pane {
+    /// Swap between `List` and `Info`. Used by the `Tab` key handler.
+    #[must_use]
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::List => Self::Info,
+            Self::Info => Self::List,
         }
     }
 }
@@ -327,6 +358,8 @@ impl AppState {
             sort_order: SortOrder::Name,
             scanned_roots: Vec::new(),
             skipped_iso_count: 0,
+            pane: Pane::default(),
+            info_scroll: 0,
         }
     }
 
@@ -637,6 +670,10 @@ impl AppState {
     /// Advance the visible cursor up (negative) or down (positive),
     /// saturating at the visible-list bounds. Cursor indexes the full
     /// entries list (ISOs + rescue shell), not just ISOs (#85, #90).
+    ///
+    /// Also resets `info_scroll` to 0 whenever the cursor actually
+    /// moves — per-ISO scrollback in the info pane would be
+    /// confusing (#458).
     pub fn move_selection(&mut self, delta: i32) {
         let view_len = self.visible_entries().len();
         let Screen::List { selected } = &mut self.screen else {
@@ -646,12 +683,37 @@ impl AppState {
             return;
         }
         let max = view_len - 1;
+        let before = *selected;
         if delta < 0 {
             let step = delta.unsigned_abs() as usize;
             *selected = selected.saturating_sub(step);
         } else {
             let step = usize::try_from(delta).unwrap_or(0);
             *selected = selected.saturating_add(step).min(max);
+        }
+        if *selected != before {
+            self.info_scroll = 0;
+        }
+    }
+
+    /// Swap the keyboard-focus pane (List ↔ Info). No-op outside the
+    /// List screen. (#458)
+    pub fn toggle_pane(&mut self) {
+        if matches!(self.screen, Screen::List { .. }) {
+            self.pane = self.pane.toggle();
+        }
+    }
+
+    /// Scroll the info pane up (negative) or down (positive),
+    /// saturating at zero. Upper bound is enforced at render time
+    /// (the pane knows its own height + content length). (#458)
+    pub fn move_info_scroll(&mut self, delta: i32) {
+        if delta < 0 {
+            let step = u16::try_from(delta.unsigned_abs()).unwrap_or(u16::MAX);
+            self.info_scroll = self.info_scroll.saturating_sub(step);
+        } else {
+            let step = u16::try_from(delta).unwrap_or(u16::MAX);
+            self.info_scroll = self.info_scroll.saturating_add(step);
         }
     }
 
@@ -1775,5 +1837,71 @@ mod tests {
         let s = quirks_summary(&iso);
         assert!(s.contains("unsigned-kernel"));
         assert!(s.contains("bios-only"));
+    }
+
+    // ---- #458 — dual-pane focus + info-scroll -----------------------
+
+    #[test]
+    fn default_pane_is_list() {
+        let s = AppState::new(vec![fake_iso("a")]);
+        assert_eq!(s.pane, Pane::List);
+    }
+
+    #[test]
+    fn toggle_pane_swaps_focus_on_list_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        assert_eq!(s.pane, Pane::List);
+        s.toggle_pane();
+        assert_eq!(s.pane, Pane::Info);
+        s.toggle_pane();
+        assert_eq!(s.pane, Pane::List);
+    }
+
+    #[test]
+    fn toggle_pane_noop_outside_list_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.screen = Screen::Confirm { selected: 0 };
+        s.toggle_pane();
+        assert_eq!(
+            s.pane,
+            Pane::List,
+            "pane must not change when not on List screen"
+        );
+    }
+
+    #[test]
+    fn move_info_scroll_increments_and_saturates_at_zero() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        assert_eq!(s.info_scroll, 0);
+        s.move_info_scroll(3);
+        assert_eq!(s.info_scroll, 3);
+        s.move_info_scroll(-5);
+        assert_eq!(s.info_scroll, 0, "saturates at zero");
+    }
+
+    #[test]
+    fn move_selection_resets_info_scroll() {
+        // Per-ISO scroll state would confuse operators; resetting on
+        // selection change matches gitui's pattern.
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        s.info_scroll = 7;
+        s.move_selection(1);
+        assert_eq!(s.info_scroll, 0);
+    }
+
+    #[test]
+    fn move_selection_noop_does_not_reset_info_scroll() {
+        // When the cursor hits a saturation boundary, info_scroll
+        // should not be reset — it wasn't a real navigation.
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.info_scroll = 5;
+        s.move_selection(-1); // already at 0, can't go further up
+        assert_eq!(s.info_scroll, 5);
+    }
+
+    #[test]
+    fn pane_toggle_method_returns_opposite() {
+        assert_eq!(Pane::List.toggle(), Pane::Info);
+        assert_eq!(Pane::Info.toggle(), Pane::List);
     }
 }

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -164,12 +164,16 @@ pub enum SortOrder {
 }
 
 /// An entry displayed on the List screen. Includes discovered ISOs
-/// (by real index) and synthetic entries like the always-present
-/// rescue shell (#90).
+/// (by real index), parse-failed ISOs (tier-4), and synthetic entries
+/// like the always-present rescue shell (#90, #459).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViewEntry {
     /// Real ISO at this index into [`AppState::isos`].
     Iso(usize),
+    /// Parse-failed `.iso` at this index into [`AppState::failed_isos`].
+    /// Rendered as a tier-4 row with a descriptive reason in the info
+    /// pane; boot disabled.
+    FailedIso(usize),
     /// Synthetic "drop to rescue shell" entry (#90). Selecting it
     /// exits rescue-tui with [`RESCUE_SHELL_EXIT_CODE`] so the
     /// initramfs `/init` can recognize the operator request and
@@ -396,12 +400,16 @@ impl AppState {
         self
     }
 
-    /// Ordered list of entries displayed on the List screen (#90).
-    /// Mix of [`ViewEntry::Iso`] (one per filter-matching ISO in sort
-    /// order) followed by the synthetic [`ViewEntry::RescueShell`] at
-    /// the end. The rescue-shell entry is always present — even when
-    /// no ISOs are discovered — so operators always have an escape
-    /// hatch to a signed busybox shell.
+    /// Ordered list of entries displayed on the List screen.
+    ///
+    /// Layout (#459):
+    /// 1. Successful ISOs (tier 1/2/3/5/6) in the active sort order,
+    ///    filtered by the active substring filter.
+    /// 2. Parse-failed ISOs (tier 4) in alphabetical order — always
+    ///    surfaced so the operator sees every file on the stick. Also
+    ///    subject to the substring filter (matches against iso_path).
+    /// 3. The synthetic [`ViewEntry::RescueShell`] — always present so
+    ///    operators have an escape hatch to a signed busybox shell.
     #[must_use]
     pub fn visible_entries(&self) -> Vec<ViewEntry> {
         let mut entries: Vec<ViewEntry> = self
@@ -409,6 +417,32 @@ impl AppState {
             .into_iter()
             .map(ViewEntry::Iso)
             .collect();
+        let needle = self.filter.to_ascii_lowercase();
+        let mut failed: Vec<(usize, String)> = self
+            .failed_isos
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| {
+                if needle.is_empty() {
+                    return true;
+                }
+                f.iso_path
+                    .to_string_lossy()
+                    .to_ascii_lowercase()
+                    .contains(&needle)
+            })
+            .map(|(i, f)| {
+                (
+                    i,
+                    f.iso_path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        failed.sort_by(|a, b| a.1.cmp(&b.1));
+        entries.extend(failed.into_iter().map(|(i, _)| ViewEntry::FailedIso(i)));
         entries.push(ViewEntry::RescueShell);
         entries
     }

--- a/crates/rescue-tui/src/verdict.rs
+++ b/crates/rescue-tui/src/verdict.rs
@@ -37,18 +37,6 @@
 //! [`HashMismatch`]: TrustVerdict::HashMismatch
 //! [`docs/design/rescue-tui-ux-overhaul.md`]: ../../../../docs/design/rescue-tui-ux-overhaul.md
 //!
-//! # Dead-code allow
-//!
-//! `TrustVerdict::ParseFailed`, [`TrustVerdict::is_bootable`], and
-//! [`TrustVerdict::from_failed`] are canonical surface for tier-4
-//! rendering that lands in #458 (dual-pane layout) and #459 (info-
-//! pane content). Tested here, wired later. Module-scoped
-//! `allow(dead_code)` keeps CI green through the phased migration;
-//! remove once #459 merges and the full surface is exercised from
-//! non-test code.
-
-#![allow(dead_code)]
-
 use iso_probe::{DiscoveredIso, FailedIso, HashVerification, Quirk, SignatureVerification};
 use ratatui::style::Color;
 

--- a/crates/rescue-tui/src/verdict.rs
+++ b/crates/rescue-tui/src/verdict.rs
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Trust-tier verdict for a single row in the rescue-tui ISO list.
+//!
+//! Six tiers, each with a color, glyph, and descriptive message. Drive
+//! both display (list-pane badge, info-pane header) and boot gating
+//! (`is_bootable` — tier 4/5/6 refuse Enter). Canonical source for the
+//! tier table surfaced to operator docs via #462 (`tiers-docgen`).
+//!
+//! ## Trust-tier contract
+//!
+//! See [`docs/design/rescue-tui-ux-overhaul.md`] for the full model.
+//! Summary:
+//!
+//! | Tier | Variant                 | Bootable | Boot-time friction            |
+//! | ---- | ----------------------- | -------- | ------------------------------ |
+//! | 1    | [`OperatorAttested`]    | yes      | Enter alone                   |
+//! | 2    | [`BareUnverified`]      | yes      | typed-confirmation challenge  |
+//! | 3    | [`KeyNotTrusted`]       | yes      | typed-confirmation challenge  |
+//! | 4    | [`ParseFailed`]         | **no**   | Enter refused; reason shown   |
+//! | 5    | [`SecureBootBlocked`]   | **no**   | Enter refused; reason shown   |
+//! | 6    | [`HashMismatch`]        | **no**   | Enter refused; reason shown   |
+//!
+//! ## Source-of-truth pairing
+//!
+//! Tier 4 is built from [`iso_probe::FailedIso`] (the `DiscoveryReport::failed`
+//! list). Tiers 1/2/3/5/6 are built from [`iso_probe::DiscoveredIso`] +
+//! ambient [`SecureBootStatus`]. Tier 5 keys off the `NotKexecBootable`
+//! quirk and off `UnsignedKernel` + Secure Boot Enforcing (since the
+//! kernel would be rejected by `kexec_file_load` at boot time).
+//!
+//! [`OperatorAttested`]: TrustVerdict::OperatorAttested
+//! [`BareUnverified`]: TrustVerdict::BareUnverified
+//! [`KeyNotTrusted`]: TrustVerdict::KeyNotTrusted
+//! [`ParseFailed`]: TrustVerdict::ParseFailed
+//! [`SecureBootBlocked`]: TrustVerdict::SecureBootBlocked
+//! [`HashMismatch`]: TrustVerdict::HashMismatch
+//! [`docs/design/rescue-tui-ux-overhaul.md`]: ../../../../docs/design/rescue-tui-ux-overhaul.md
+//!
+//! # Dead-code allow
+//!
+//! `TrustVerdict::ParseFailed`, [`TrustVerdict::is_bootable`], and
+//! [`TrustVerdict::from_failed`] are canonical surface for tier-4
+//! rendering that lands in #458 (dual-pane layout) and #459 (info-
+//! pane content). Tested here, wired later. Module-scoped
+//! `allow(dead_code)` keeps CI green through the phased migration;
+//! remove once #459 merges and the full surface is exercised from
+//! non-test code.
+
+#![allow(dead_code)]
+
+use iso_probe::{DiscoveredIso, FailedIso, HashVerification, Quirk, SignatureVerification};
+use ratatui::style::Color;
+
+use crate::state::SecureBootStatus;
+use crate::theme::Theme;
+
+/// Trust-tier verdict for a single list row.
+///
+/// Six tiers spanning three bootable (1/2/3) and three blocked (4/5/6).
+/// See the module docs for the full contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TrustVerdict {
+    /// Tier 1 — hash OR signature verified against a trusted source.
+    /// Green, boots on Enter with no friction.
+    OperatorAttested,
+    /// Tier 2 — no sibling `.sha256` / `.minisig`. Parseable + bootable
+    /// but the operator hasn't attested the bytes. Gray, typed-
+    /// confirmation required before boot.
+    BareUnverified,
+    /// Tier 3 — signature parsed but the signer isn't in
+    /// `AEGIS_TRUSTED_KEYS`. Yellow, typed-confirmation required.
+    KeyNotTrusted,
+    /// Tier 4 — iso-parser couldn't extract kernel/initrd from this
+    /// `.iso`. Reason carries the sanitized iso-parser error. Red,
+    /// boot refused.
+    ParseFailed {
+        /// TUI-safe, pre-sanitized explanation from iso-parser.
+        reason: String,
+    },
+    /// Tier 5 — the kernel would be rejected by the platform keyring.
+    /// Either a Windows/non-Linux boot protocol (`NotKexecBootable`
+    /// quirk) or an `UnsignedKernel` distro running under Secure Boot
+    /// enforcement. Red, boot refused.
+    SecureBootBlocked {
+        /// TUI-safe explanation naming the specific block reason.
+        reason: String,
+    },
+    /// Tier 6 — the ISO bytes don't match either the declared sidecar
+    /// hash or the minisign signature. Strong tamper signal. Red,
+    /// boot refused.
+    HashMismatch {
+        /// Hex digest the sidecar declared.
+        expected: String,
+        /// Hex digest the actual ISO bytes produced.
+        actual: String,
+        /// Source of the expected hash (sidecar path or "minisign").
+        source: String,
+    },
+}
+
+impl TrustVerdict {
+    /// One-line, single-word label suitable for a list-row badge or
+    /// monochrome render. ASCII-only so it survives serial/braille
+    /// output paths.
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            Self::OperatorAttested => "VERIFIED",
+            Self::BareUnverified => "UNVERIFIED",
+            Self::KeyNotTrusted => "UNTRUSTED KEY",
+            Self::ParseFailed { .. } => "PARSE FAILED",
+            Self::SecureBootBlocked { .. } => "BOOT BLOCKED",
+            Self::HashMismatch { .. } => "HASH MISMATCH",
+        }
+    }
+
+    /// Long-form reason suitable for an info-pane body. For variants
+    /// carrying data, this includes the payload string so operators
+    /// see *why* the verdict is what it is.
+    pub(crate) fn reason(&self) -> String {
+        match self {
+            Self::OperatorAttested => {
+                "hash or signature verified against a trusted source".to_string()
+            }
+            Self::BareUnverified => "no sibling .sha256 or .minisig found".to_string(),
+            Self::KeyNotTrusted => {
+                "signature parses but key is not in AEGIS_TRUSTED_KEYS".to_string()
+            }
+            Self::ParseFailed { reason } => reason.clone(),
+            Self::SecureBootBlocked { reason } => reason.clone(),
+            Self::HashMismatch {
+                expected,
+                actual,
+                source,
+            } => {
+                format!(
+                    "sidecar declares {expected}, ISO bytes hash to {actual} (source: {source})"
+                )
+            }
+        }
+    }
+
+    /// Color from the active theme. 16-color-safe; never depends on
+    /// truecolor being available.
+    pub(crate) fn color(&self, theme: &Theme) -> Color {
+        match self {
+            Self::OperatorAttested => theme.success,
+            Self::BareUnverified => Color::Gray,
+            Self::KeyNotTrusted => theme.warning,
+            Self::ParseFailed { .. }
+            | Self::SecureBootBlocked { .. }
+            | Self::HashMismatch { .. } => theme.error,
+        }
+    }
+
+    /// Single-character status glyph for a list row. Visible in
+    /// monochrome themes (no color reliance) — matches the glyph
+    /// convention used before #457.
+    pub(crate) fn glyph(&self) -> &'static str {
+        match self {
+            Self::OperatorAttested => "[+]",
+            Self::KeyNotTrusted => "[~]",
+            Self::BareUnverified => "[ ]",
+            Self::ParseFailed { .. } => "[!]",
+            Self::SecureBootBlocked { .. } => "[X]",
+            Self::HashMismatch { .. } => "[!]",
+        }
+    }
+
+    /// Whether a row with this verdict should be bootable. Tiers 1/2/3
+    /// are bootable (with the existing typed-confirmation gate
+    /// handling 2/3); tiers 4/5/6 are not bootable because the
+    /// failure mode precludes a successful kexec.
+    pub(crate) fn is_bootable(&self) -> bool {
+        matches!(
+            self,
+            Self::OperatorAttested | Self::BareUnverified | Self::KeyNotTrusted
+        )
+    }
+
+    /// Derive a verdict for a successfully-parsed [`DiscoveredIso`].
+    /// The `secure_boot` argument is consulted for the tier-5
+    /// `UnsignedKernel` case — on `Disabled` or `Unknown` systems the
+    /// quirk surfaces only as a warning rather than a hard block.
+    pub(crate) fn from_discovered(iso: &DiscoveredIso, secure_boot: SecureBootStatus) -> Self {
+        // Tier 6 first — tamper signals trump everything else.
+        if let HashVerification::Mismatch {
+            expected,
+            actual,
+            source,
+        } = &iso.hash_verification
+        {
+            return Self::HashMismatch {
+                expected: short_hex(expected),
+                actual: short_hex(actual),
+                source: source.clone(),
+            };
+        }
+        if let SignatureVerification::Forged { sig_path } = &iso.signature_verification {
+            return Self::HashMismatch {
+                expected: "(minisign signer's recorded digest)".to_string(),
+                actual: "(mismatched digest of ISO bytes)".to_string(),
+                source: sig_path.display().to_string(),
+            };
+        }
+
+        // Tier 5 — Secure Boot gates. Windows/non-Linux boot protocol
+        // is always tier 5 (kexec can't load it regardless of SB).
+        // UnsignedKernel is tier 5 only under SB enforcement; otherwise
+        // the ISO may still kexec successfully.
+        if iso.quirks.contains(&Quirk::NotKexecBootable) {
+            return Self::SecureBootBlocked {
+                reason: format!(
+                    "{} uses a boot protocol incompatible with kexec_file_load \
+                     (Windows NT loader or equivalent); kexec would refuse",
+                    iso.distribution.label()
+                ),
+            };
+        }
+        if iso.quirks.contains(&Quirk::UnsignedKernel)
+            && matches!(secure_boot, SecureBootStatus::Enforcing)
+        {
+            return Self::SecureBootBlocked {
+                reason: format!(
+                    "{} ships an unsigned kernel; platform keyring under Secure Boot \
+                     enforcement will reject kexec_file_load",
+                    iso.distribution.label()
+                ),
+            };
+        }
+
+        // Tier 1 — hash or signature verified.
+        if matches!(
+            iso.signature_verification,
+            SignatureVerification::Verified { .. }
+        ) || matches!(iso.hash_verification, HashVerification::Verified { .. })
+        {
+            return Self::OperatorAttested;
+        }
+
+        // Tier 3 — signature parses but key untrusted.
+        if matches!(
+            iso.signature_verification,
+            SignatureVerification::KeyNotTrusted { .. }
+        ) {
+            return Self::KeyNotTrusted;
+        }
+
+        // Tier 2 — no verification material.
+        Self::BareUnverified
+    }
+
+    /// Derive a verdict for an ISO that failed to parse. Always
+    /// produces [`TrustVerdict::ParseFailed`] with the failure reason.
+    pub(crate) fn from_failed(failed: &FailedIso) -> Self {
+        Self::ParseFailed {
+            reason: failed.reason.clone(),
+        }
+    }
+}
+
+/// Truncate a long hex digest to the first 12 chars with an ellipsis —
+/// keeps the HashMismatch reason line readable in narrow terminals.
+fn short_hex(hex: &str) -> String {
+    if hex.len() <= 14 {
+        return hex.to_string();
+    }
+    format!("{}…", &hex[..12])
+}
+
+/// Extension trait on [`iso_parser::Distribution`] giving a short,
+/// capitalized display label for reason strings.
+trait DistroLabel {
+    fn label(&self) -> &'static str;
+}
+
+impl DistroLabel for iso_probe::Distribution {
+    fn label(&self) -> &'static str {
+        use iso_probe::Distribution as D;
+        match self {
+            D::Arch => "Arch Linux",
+            D::Debian => "Debian-family",
+            D::Fedora => "Fedora",
+            D::RedHat => "RHEL-family",
+            D::Alpine => "Alpine Linux",
+            D::NixOS => "NixOS",
+            D::Windows => "Windows",
+            D::Unknown => "This ISO",
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use iso_probe::{Distribution, HashVerification, Quirk, SignatureVerification};
+    use std::path::PathBuf;
+
+    fn iso_with(
+        hash: HashVerification,
+        sig: SignatureVerification,
+        quirks: Vec<Quirk>,
+        distro: Distribution,
+    ) -> DiscoveredIso {
+        DiscoveredIso {
+            iso_path: PathBuf::from("/isos/test.iso"),
+            label: "test".to_string(),
+            pretty_name: None,
+            distribution: distro,
+            kernel: PathBuf::from("boot/vmlinuz"),
+            initrd: None,
+            cmdline: None,
+            quirks,
+            hash_verification: hash,
+            signature_verification: sig,
+            size_bytes: Some(100),
+            contains_installer: false,
+            sidecar: None,
+        }
+    }
+
+    #[test]
+    fn every_variant_has_non_empty_label_reason_glyph() {
+        let variants = [
+            TrustVerdict::OperatorAttested,
+            TrustVerdict::BareUnverified,
+            TrustVerdict::KeyNotTrusted,
+            TrustVerdict::ParseFailed {
+                reason: "x".to_string(),
+            },
+            TrustVerdict::SecureBootBlocked {
+                reason: "x".to_string(),
+            },
+            TrustVerdict::HashMismatch {
+                expected: "a".to_string(),
+                actual: "b".to_string(),
+                source: "c".to_string(),
+            },
+        ];
+        for v in variants {
+            assert!(!v.label().is_empty(), "empty label for {v:?}");
+            assert!(!v.reason().is_empty(), "empty reason for {v:?}");
+            assert!(!v.glyph().is_empty(), "empty glyph for {v:?}");
+        }
+    }
+
+    #[test]
+    fn is_bootable_true_for_tier_1_2_3() {
+        assert!(TrustVerdict::OperatorAttested.is_bootable());
+        assert!(TrustVerdict::BareUnverified.is_bootable());
+        assert!(TrustVerdict::KeyNotTrusted.is_bootable());
+    }
+
+    #[test]
+    fn is_bootable_false_for_tier_4_5_6() {
+        assert!(!TrustVerdict::ParseFailed { reason: "x".into() }.is_bootable());
+        assert!(!TrustVerdict::SecureBootBlocked { reason: "x".into() }.is_bootable());
+        assert!(
+            !TrustVerdict::HashMismatch {
+                expected: "a".into(),
+                actual: "b".into(),
+                source: "c".into()
+            }
+            .is_bootable()
+        );
+    }
+
+    #[test]
+    fn from_discovered_green_when_signature_verified() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Verified {
+                key_id: "abc".to_string(),
+                sig_path: PathBuf::from("/isos/test.iso.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(v, TrustVerdict::OperatorAttested));
+    }
+
+    #[test]
+    fn from_discovered_green_when_hash_verified() {
+        let iso = iso_with(
+            HashVerification::Verified {
+                digest: "hashhash".to_string(),
+                source: "/isos/test.iso.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Arch,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Disabled);
+        assert!(matches!(v, TrustVerdict::OperatorAttested));
+    }
+
+    #[test]
+    fn from_discovered_yellow_when_key_not_trusted() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::KeyNotTrusted {
+                key_id: "untrusted".to_string(),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(v, TrustVerdict::KeyNotTrusted));
+    }
+
+    #[test]
+    fn from_discovered_gray_when_no_material() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(v, TrustVerdict::BareUnverified));
+    }
+
+    #[test]
+    fn from_discovered_tier6_on_hash_mismatch() {
+        let iso = iso_with(
+            HashVerification::Mismatch {
+                expected: "a".repeat(64),
+                actual: "b".repeat(64),
+                source: "/isos/test.iso.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        match v {
+            TrustVerdict::HashMismatch {
+                expected,
+                actual,
+                source,
+            } => {
+                // Long hashes get truncated with an ellipsis for display.
+                assert!(expected.ends_with('…'));
+                assert!(actual.ends_with('…'));
+                assert!(source.contains("test.iso.sha256"));
+            }
+            other => panic!("expected HashMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_discovered_tier6_on_forged_signature() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Forged {
+                sig_path: PathBuf::from("/isos/test.iso.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(v, TrustVerdict::HashMismatch { .. }));
+    }
+
+    #[test]
+    fn from_discovered_tier5_windows_always_blocked() {
+        // Windows is NotKexecBootable regardless of Secure Boot state —
+        // it's a different boot protocol entirely.
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![Quirk::NotKexecBootable],
+            Distribution::Windows,
+        );
+        for sb in [
+            SecureBootStatus::Enforcing,
+            SecureBootStatus::Disabled,
+            SecureBootStatus::Unknown,
+        ] {
+            let v = TrustVerdict::from_discovered(&iso, sb);
+            assert!(
+                matches!(v, TrustVerdict::SecureBootBlocked { .. }),
+                "Windows must be blocked under {sb:?}, got {v:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn from_discovered_tier5_unsigned_kernel_only_under_sb_enforcing() {
+        // Unsigned kernel on an Arch ISO: Secure Boot Enforcing blocks
+        // (keyring rejects kexec_file_load); Disabled / Unknown still
+        // allow boot at lower tier (BareUnverified or KeyNotTrusted
+        // based on sig state).
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![Quirk::UnsignedKernel],
+            Distribution::Arch,
+        );
+        let v_enforcing = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(
+            v_enforcing,
+            TrustVerdict::SecureBootBlocked { .. }
+        ));
+        let v_disabled = TrustVerdict::from_discovered(&iso, SecureBootStatus::Disabled);
+        assert!(matches!(v_disabled, TrustVerdict::BareUnverified));
+        let v_unknown = TrustVerdict::from_discovered(&iso, SecureBootStatus::Unknown);
+        assert!(matches!(v_unknown, TrustVerdict::BareUnverified));
+    }
+
+    #[test]
+    fn from_discovered_tier6_takes_precedence_over_tier5() {
+        // Hash mismatch must win over NotKexecBootable — the tamper
+        // signal is stronger information than the kexec protocol gap.
+        let iso = iso_with(
+            HashVerification::Mismatch {
+                expected: "a".repeat(64),
+                actual: "b".repeat(64),
+                source: "/isos/sha256sums".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![Quirk::NotKexecBootable],
+            Distribution::Windows,
+        );
+        let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
+        assert!(matches!(v, TrustVerdict::HashMismatch { .. }));
+    }
+
+    #[test]
+    fn from_failed_always_produces_parse_failed_with_reason() {
+        let failed = FailedIso {
+            iso_path: PathBuf::from("/isos/broken.iso"),
+            reason: "mount: wrong fs type".to_string(),
+            kind: iso_probe::FailureKind::MountFailed,
+        };
+        let v = TrustVerdict::from_failed(&failed);
+        match v {
+            TrustVerdict::ParseFailed { reason } => {
+                assert_eq!(reason, "mount: wrong fs type");
+            }
+            other => panic!("expected ParseFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn short_hex_truncates_long_digests_with_ellipsis() {
+        let full = "a".repeat(64);
+        let out = short_hex(&full);
+        assert!(out.ends_with('…'));
+        assert_eq!(out.chars().filter(|c| *c == 'a').count(), 12);
+    }
+
+    #[test]
+    fn short_hex_passes_short_digests_verbatim() {
+        assert_eq!(short_hex("deadbeef"), "deadbeef");
+        // Boundary: exactly 14 chars stays as-is.
+        assert_eq!(short_hex("0123456789abcd"), "0123456789abcd");
+    }
+
+    #[test]
+    fn distribution_label_populated_for_every_variant() {
+        use iso_probe::Distribution as D;
+        for d in [
+            D::Arch,
+            D::Debian,
+            D::Fedora,
+            D::RedHat,
+            D::Alpine,
+            D::NixOS,
+            D::Windows,
+            D::Unknown,
+        ] {
+            assert!(!d.label().is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 of epic #455 — canonical \`KeybindingRegistry\` (static
KEYBINDINGS table) as the single source of truth for the footer
legend. #462 will add \`tiers-docgen\` that reads from this registry
to emit the published keybinding reference.

- Closes #460.
- Depends on #467 (#459 info-pane).
- Blocks #462.

## What changes

- New \`src/keybindings.rs\` with \`Keybinding\` struct + static KEYBINDINGS table
- \`footer_line(screen, pane, filter_editing)\` filters + renders
- \`draw_footer\` now reads from the registry (hardcoded strings removed)
- Registry captures contextual nuance the old hardcoded strings couldn't: Boot shows only when list pane focused; Tab shows explicitly; filter-editing bindings are first-class entries

## Not in this PR

Event dispatch stays match-based. Unifying dispatch+registry is a
separate refactor; #460 delivers the visible operator benefit
(context-aware footer) + the docgen source for #462.

## Test plan

- [x] 7 new registry tests (filter behavior, footer composition, screen mapping exhaustiveness)
- [x] 651 workspace tests total, all green
- [x] \`cargo fmt --check\` clean