### PR TITLE
feat(docs): tiers-docgen — programmatic trust-tier + keybinding docs (Phase 7 of #455)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,3 +229,20 @@ jobs:
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p aegis-wire-formats --features schema --bin aegis-wire-formats-schema-docgen --locked -- --check
+
+  # rescue-tui trust-tier + keybinding drift-check (Phase 7 of #455 / #462).
+  # Regenerates the trust-tier table and keybinding reference in
+  # docs/HOW_IT_WORKS.md, docs/TOUR.md, and crates/rescue-tui/README.md
+  # from the canonical in-code sources (TrustVerdict enum +
+  # KEYBINDINGS registry). Fails if any table has drifted — the fix
+  # is to run `cargo run -p rescue-tui --bin tiers-docgen` locally
+  # and commit the result.
+  tiers-drift:
+    name: Doc trust-tier + keybinding drift-check
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -p rescue-tui --bin tiers-docgen --locked -- --check

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -11,6 +11,13 @@ description = "ratatui application for the aegis-boot signed Linux rescue enviro
 name = "rescue-tui"
 path = "src/main.rs"
 
+# Docgen devtool — regenerates the trust-tier + keybinding tables in
+# user-facing docs from the in-code sources. `--check` runs in CI to
+# enforce drift-freedom. Phase 7 of #455 / closes #462.
+[[bin]]
+name = "tiers-docgen"
+path = "src/bin/tiers_docgen.rs"
+
 [dependencies]
 aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
 iso-probe = { path = "../iso-probe" }

--- a/crates/rescue-tui/README.md
+++ b/crates/rescue-tui/README.md
@@ -1,0 +1,81 @@
+# rescue-tui
+
+The [ratatui](https://ratatui.rs)-based interactive picker that runs inside the
+aegis-boot signed Linux rescue environment. Discovers ISOs on the
+`AEGIS_ISOS` partition, lets the operator pick one, and hands off to
+`kexec-loader` for signed kexec.
+
+## Trust-tier model
+
+Every ISO on the stick is classified into one of 6 tiers that drive the
+list-pane badge, info-pane header, and boot gating. Tiers 4/5/6 refuse
+boot; tiers 1/2/3 are bootable (tiers 2/3 with a typed-confirmation
+challenge).
+
+<!-- tiers:BEGIN:TRUST_TIER_TABLE -->
+| Tier | Verdict             | Glyph | Bootable | Meaning                                    |
+| ---- | ------------------- | ----- | -------- | ------------------------------------------ |
+| 1    | VERIFIED            | `[+]` | yes      | Hash or sig verified vs trusted source     |
+| 2    | UNVERIFIED          | `[ ]` | yes      | No sidecar — bootable with typed confirm   |
+| 3    | UNTRUSTED KEY       | `[~]` | yes      | Sig parses, signer untrusted               |
+| 4    | PARSE FAILED        | `[!]` | **no**   | iso-parser couldn't extract kernel         |
+| 5    | BOOT BLOCKED        | `[X]` | **no**   | Kernel rejected by platform keyring        |
+| 6    | HASH MISMATCH       | `[!]` | **no**   | ISO bytes don't match declared hash        |
+<!-- tiers:END:TRUST_TIER_TABLE -->
+
+This table is generated from the `TrustVerdict` enum in
+[`src/verdict.rs`](src/verdict.rs) by the `tiers-docgen` devtool. To
+regenerate after an enum change:
+
+```bash
+cargo run -p rescue-tui --bin tiers-docgen
+```
+
+CI runs `tiers-docgen --check` to enforce drift-freedom (see
+[#462](https://github.com/aegis-boot/aegis-boot/issues/462)).
+
+## Keybindings
+
+Context-sensitive — the footer legend filters by the current screen
+and focused pane. Press `?` inside the TUI for the full help overlay.
+
+<!-- tiers:BEGIN:KEYBINDINGS -->
+| Key | Screens | Pane | Filter-editing | Description |
+| --- | ------- | ---- | -------------- | ----------- |
+| `?` | any | any | no | Show the help overlay with all keybindings |
+| `q` | any | any | no | Quit rescue-tui (returns control to the boot menu) |
+| `↑↓/jk` | List | any | no | Move the list cursor (pane=List) or scroll info pane (pane=Info) |
+| `Tab` | List | any | no | Toggle focus between the ISO list and the info pane |
+| `Enter` | List | List | no | Confirm the selected ISO (only valid in the list pane) |
+| `/` | List | any | no | Open the substring filter — typed chars match label + path |
+| `s` | List | any | no | Cycle sort order: name → size → distro → name |
+| `v` | List, Confirm | any | no | Re-compute sha256 of the selected ISO in a background thread |
+| `Enter` | List | any | yes | Commit the current filter and close the input |
+| `Esc` | List | any | yes | Close the filter input and clear the current filter |
+| `Enter` | Confirm | any | no | Kexec into the selected ISO (may trigger a trust challenge) |
+| `e` | Confirm | any | no | Edit the kernel command line before boot |
+| `Esc/h` | Confirm, Error | any | no | Return to the list without booting |
+| `Enter` | EditCmdline | any | no | Save the edited kernel command line and return to Confirm |
+| `Esc` | EditCmdline, Verifying, TrustChallenge | any | no | Discard edits and return to Confirm |
+| `F10` | Error | any | no | Write a failure-log bundle to AEGIS_ISOS for post-mortem analysis |
+| `boot+Enter` | TrustChallenge | any | no | Type the word 'boot' and press Enter to proceed past the trust challenge |
+<!-- tiers:END:KEYBINDINGS -->
+
+Derived from the `KEYBINDINGS` registry in
+[`src/keybindings.rs`](src/keybindings.rs).
+
+## Architecture
+
+- **state.rs** — pure state machine (no I/O). Screen enum, AppState
+  builder, transitions.
+- **render.rs** — ratatui rendering. Tested with `TestBackend`.
+- **verdict.rs** — the 6-tier `TrustVerdict` enum + mappers.
+- **keybindings.rs** — `KEYBINDINGS` registry driving the footer.
+- **theme.rs** — color palettes (default / high-contrast / monochrome /
+  okabe-ito / aegis).
+- **persistence.rs** — last-choice state saved across reboots.
+- **tpm.rs** — pre-kexec PCR 12 measurement.
+- **failure_log.rs** — F10 bundle writer for post-mortem analysis.
+
+See [`docs/design/rescue-tui-ux-overhaul.md`](../../docs/design/rescue-tui-ux-overhaul.md)
+for the dual-pane UX design (epic [#455](https://github.com/aegis-boot/aegis-boot/issues/455)).

--- a/crates/rescue-tui/src/bin/tiers_docgen.rs
+++ b/crates/rescue-tui/src/bin/tiers_docgen.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `tiers-docgen` — regenerate the trust-tier table and keybinding
+//! reference in user-facing docs from the canonical in-code sources
+//! (`rescue_tui::verdict::TrustVerdict` and
+//! `rescue_tui::keybindings::KEYBINDINGS`).
+//!
+//! Phase 7 of [#455] / closes #462. Mirrors the `constants-docgen`
+//! pattern (Phase 2 of #286): marker-pair rewriting in a fixed list
+//! of target docs.
+//!
+//! ## Modes
+//!
+//! - `--write` (default): rewrite each target file in place.
+//! - `--check`: compute what `--write` would produce, diff against
+//!   the committed file, exit non-zero if any file would change.
+//!   Used by CI to enforce drift-freedom.
+//!
+//! [#455]: https://github.com/aegis-boot/aegis-boot/issues/455
+
+#![forbid(unsafe_code)]
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use rescue_tui::docgen;
+
+/// Fixed list of doc files this tool may rewrite. Hard-coded (rather
+/// than a `walkdir` scan) so scope is explicit and a stray marker in
+/// an unrelated file can't accidentally trigger a rewrite.
+fn target_files(repo_root: &Path) -> Vec<PathBuf> {
+    [
+        "docs/HOW_IT_WORKS.md",
+        "docs/TOUR.md",
+        "crates/rescue-tui/README.md",
+    ]
+    .iter()
+    .map(|p| repo_root.join(p))
+    .collect()
+}
+
+enum Mode {
+    Write,
+    Check,
+}
+
+fn parse_mode(args: &[String]) -> Result<Mode, String> {
+    match args
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] | ["--write"] => Ok(Mode::Write),
+        ["--check"] => Ok(Mode::Check),
+        _ => Err(format!(
+            "usage: tiers-docgen [--write|--check]  (got: {args:?})"
+        )),
+    }
+}
+
+/// Walk up from `start` looking for the workspace root (top-level
+/// `Cargo.toml` containing `[workspace]`). Mirrors
+/// `constants-docgen::find_repo_root`.
+fn find_repo_root(start: &Path) -> Result<PathBuf, String> {
+    let mut cur = start;
+    loop {
+        let candidate = cur.join("Cargo.toml");
+        if candidate.is_file()
+            && let Ok(body) = fs::read_to_string(&candidate)
+            && body.contains("[workspace]")
+        {
+            return Ok(cur.to_path_buf());
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => {
+                return Err(format!(
+                    "tiers-docgen: could not find workspace root Cargo.toml walking up from {}",
+                    start.display()
+                ));
+            }
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    // Devtool — args are flag names only, not security keys.
+    // nosemgrep: rust.lang.security.args.args
+    let args: Vec<String> = env::args().skip(1).collect();
+    let mode = match parse_mode(&args) {
+        Ok(m) => m,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let cwd = match env::current_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("tiers-docgen: cannot read CWD: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let repo_root = match find_repo_root(&cwd) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let mut drift_files: Vec<PathBuf> = Vec::new();
+    let mut total_replacements = 0usize;
+
+    for path in target_files(&repo_root) {
+        let body = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("tiers-docgen: cannot read {}: {e}", path.display());
+                return ExitCode::from(2);
+            }
+        };
+        let (rendered, n) = docgen::apply_markers(&body);
+        total_replacements += n;
+
+        match mode {
+            Mode::Write => {
+                if rendered == body {
+                    println!("unchanged {} ({n} markers)", path.display());
+                } else {
+                    if let Err(e) = fs::write(&path, &rendered) {
+                        eprintln!("tiers-docgen: cannot write {}: {e}", path.display());
+                        return ExitCode::from(2);
+                    }
+                    println!("updated {} ({n} markers)", path.display());
+                }
+            }
+            Mode::Check => {
+                if rendered != body {
+                    drift_files.push(path.clone());
+                    eprintln!(
+                        "drift: {} would change ({n} markers render differently than committed)",
+                        path.display()
+                    );
+                }
+            }
+        }
+    }
+
+    match mode {
+        Mode::Write => {
+            println!(
+                "tiers-docgen: wrote {} target files, {total_replacements} total markers rendered",
+                target_files(&repo_root).len()
+            );
+            ExitCode::SUCCESS
+        }
+        Mode::Check => {
+            if drift_files.is_empty() {
+                println!(
+                    "tiers-docgen: OK — {total_replacements} markers across {} files all match source",
+                    target_files(&repo_root).len()
+                );
+                ExitCode::SUCCESS
+            } else {
+                eprintln!();
+                eprintln!(
+                    "tiers-docgen: FAIL — {} file(s) diverge from the canonical source.",
+                    drift_files.len()
+                );
+                eprintln!(
+                    "Fix: run `cargo run -p rescue-tui --bin tiers-docgen` locally and commit the result."
+                );
+                ExitCode::from(1)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mode_defaults_to_write() {
+        assert!(matches!(parse_mode(&[]), Ok(Mode::Write)));
+        assert!(matches!(
+            parse_mode(&["--write".to_string()]),
+            Ok(Mode::Write)
+        ));
+    }
+
+    #[test]
+    fn parse_mode_accepts_check() {
+        assert!(matches!(
+            parse_mode(&["--check".to_string()]),
+            Ok(Mode::Check)
+        ));
+    }
+
+    #[test]
+    fn parse_mode_rejects_unknown() {
+        assert!(parse_mode(&["--bogus".to_string()]).is_err());
+        assert!(parse_mode(&["--write".to_string(), "extra".to_string()]).is_err());
+    }
+
+    #[test]
+    fn target_files_lists_three_known_docs() {
+        let repo = PathBuf::from("/tmp/fake-repo");
+        let files = target_files(&repo);
+        assert_eq!(files.len(), 3);
+        assert!(files.iter().any(|p| p.ends_with("docs/HOW_IT_WORKS.md")));
+        assert!(files.iter().any(|p| p.ends_with("docs/TOUR.md")));
+        assert!(
+            files
+                .iter()
+                .any(|p| p.ends_with("crates/rescue-tui/README.md"))
+        );
+    }
+}

--- a/crates/rescue-tui/src/docgen.rs
+++ b/crates/rescue-tui/src/docgen.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Programmatic Markdown generation for the trust-tier table and
+//! keybinding reference — derived from the same [`TrustVerdict`]
+//! enum and [`KEYBINDINGS`] registry the rescue-tui itself uses, so
+//! published docs never drift from the code.
+//!
+//! Consumed by the `tiers-docgen` binary (#462), which writes marker
+//! regions in `docs/HOW_IT_WORKS.md`, `docs/TOUR.md`, and
+//! `crates/rescue-tui/README.md`.
+//!
+//! ## Marker format
+//!
+//! Target docs contain marker pairs identical to the
+//! [`constants-docgen`](../../../aegis-cli/src/bin/constants_docgen.rs)
+//! pattern (Phase 2 of #286):
+//!
+//! ```text
+//! <!-- tiers:BEGIN:TRUST_TIER_TABLE -->
+//! | Tier | Verdict | ... |
+//! <!-- tiers:END:TRUST_TIER_TABLE -->
+//! ```
+//!
+//! The marker tags themselves are preserved verbatim — only the body
+//! between them is rewritten.
+//!
+//! [`TrustVerdict`]: crate::verdict::TrustVerdict
+//! [`KEYBINDINGS`]: crate::keybindings::KEYBINDINGS
+
+use crate::keybindings::{KEYBINDINGS, ScreenKind};
+use crate::verdict::TrustVerdict;
+
+/// Render the 6-tier trust-tier table as a Markdown table.
+/// Covers every [`TrustVerdict`] variant, including the ones carrying
+/// payload data (fixtures use placeholder payloads for docs).
+#[must_use]
+pub fn render_tier_table() -> String {
+    let mut out = String::new();
+    out.push_str("| Tier | Verdict             | Glyph | Bootable | Meaning                                    |\n");
+    out.push_str("| ---- | ------------------- | ----- | -------- | ------------------------------------------ |\n");
+    for (i, v) in tier_variants().into_iter().enumerate() {
+        let bootable = if v.is_bootable() { "yes" } else { "**no**" };
+        out.push_str(&format!(
+            "| {tier:<4} | {label:<19} | `{glyph}` | {bootable:<8} | {reason:<42} |\n",
+            tier = i + 1,
+            label = v.label(),
+            glyph = v.glyph(),
+            bootable = bootable,
+            reason = tier_short_meaning(&v)
+        ));
+    }
+    out
+}
+
+/// Canonical ordering of the 6 TrustVerdict variants (tier 1 → 6).
+/// Constructed with placeholder payloads for variants that carry
+/// data — the docgen surface only looks at label/color/glyph/
+/// bootable so payload content doesn't affect the rendered table.
+fn tier_variants() -> Vec<TrustVerdict> {
+    vec![
+        TrustVerdict::OperatorAttested,
+        TrustVerdict::BareUnverified,
+        TrustVerdict::KeyNotTrusted,
+        TrustVerdict::ParseFailed {
+            reason: String::new(),
+        },
+        TrustVerdict::SecureBootBlocked {
+            reason: String::new(),
+        },
+        TrustVerdict::HashMismatch {
+            expected: String::new(),
+            actual: String::new(),
+            source: String::new(),
+        },
+    ]
+}
+
+/// Short (≤42 char) English blurb describing each tier. Kept
+/// separate from `TrustVerdict::reason` (which renders the specific
+/// runtime reason) because the doc table wants a stable static
+/// description, not the runtime payload.
+fn tier_short_meaning(v: &TrustVerdict) -> &'static str {
+    match v {
+        TrustVerdict::OperatorAttested => "Hash or sig verified vs trusted source",
+        TrustVerdict::BareUnverified => "No sidecar — bootable with typed confirm",
+        TrustVerdict::KeyNotTrusted => "Sig parses, signer untrusted",
+        TrustVerdict::ParseFailed { .. } => "iso-parser couldn't extract kernel",
+        TrustVerdict::SecureBootBlocked { .. } => "Kernel rejected by platform keyring",
+        TrustVerdict::HashMismatch { .. } => "ISO bytes don't match declared hash",
+    }
+}
+
+/// Render the keybinding reference as a Markdown table.
+/// Reads from [`KEYBINDINGS`]; one row per registered binding.
+#[must_use]
+pub fn render_keybinding_table() -> String {
+    let mut out = String::new();
+    out.push_str("| Key | Screens | Pane | Filter-editing | Description |\n");
+    out.push_str("| --- | ------- | ---- | -------------- | ----------- |\n");
+    for k in KEYBINDINGS {
+        let screens = if k.screens.is_empty() {
+            "any".to_string()
+        } else {
+            k.screens
+                .iter()
+                .map(screen_short_name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let pane = match k.pane {
+            Some(crate::state::Pane::List) => "List",
+            Some(crate::state::Pane::Info) => "Info",
+            None => "any",
+        };
+        let filter = if k.while_filter_editing { "yes" } else { "no" };
+        out.push_str(&format!(
+            "| `{key}` | {screens} | {pane} | {filter} | {desc} |\n",
+            key = k.key,
+            screens = screens,
+            pane = pane,
+            filter = filter,
+            desc = k.description
+        ));
+    }
+    out
+}
+
+fn screen_short_name(s: &ScreenKind) -> String {
+    match s {
+        ScreenKind::List => "List",
+        ScreenKind::Confirm => "Confirm",
+        ScreenKind::EditCmdline => "EditCmdline",
+        ScreenKind::Error => "Error",
+        ScreenKind::Verifying => "Verifying",
+        ScreenKind::TrustChallenge => "TrustChallenge",
+        ScreenKind::Help => "Help",
+        ScreenKind::ConfirmQuit => "ConfirmQuit",
+        ScreenKind::Quitting => "Quitting",
+    }
+    .to_string()
+}
+
+/// Marker pair used to delimit regenerable regions in doc files.
+/// Mirrors the constants-docgen pattern — add a new marker by
+/// wrapping the target region with BEGIN/END tags carrying the same
+/// name, then register the name in [`REGISTRY`].
+pub struct DocMarker {
+    /// Identifier appearing inside `<!-- tiers:BEGIN:NAME -->`.
+    pub name: &'static str,
+    /// Generator — produces the rendered body between BEGIN and END.
+    pub render: fn() -> String,
+}
+
+/// Registered doc markers. `tiers-docgen` iterates this list for both
+/// `--write` (rewrite target files) and `--check` (fail on drift).
+pub const REGISTRY: &[DocMarker] = &[
+    DocMarker {
+        name: "TRUST_TIER_TABLE",
+        render: render_tier_table,
+    },
+    DocMarker {
+        name: "KEYBINDINGS",
+        render: render_keybinding_table,
+    },
+];
+
+/// Rewrite the body of every registered marker pair in `input`.
+/// Unknown marker names are preserved verbatim. Returns the rewritten
+/// string plus a count of replacements performed.
+#[must_use]
+pub fn apply_markers(input: &str) -> (String, usize) {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    let mut replacements = 0usize;
+    let bytes = input.as_bytes();
+
+    while let Some(begin_abs) = find_from(bytes, cursor, b"<!-- tiers:BEGIN:") {
+        let Some(close_idx) = find_from(bytes, begin_abs, b"-->") else {
+            break;
+        };
+        let after_begin_tag = close_idx + 3;
+        let Some(name) = marker_name(&input[begin_abs..after_begin_tag]) else {
+            out.push_str(&input[cursor..after_begin_tag]);
+            cursor = after_begin_tag;
+            continue;
+        };
+        let end_tag = format!("<!-- tiers:END:{name} -->");
+        let Some(end_abs) = find_from(bytes, after_begin_tag, end_tag.as_bytes()) else {
+            break;
+        };
+
+        out.push_str(&input[cursor..after_begin_tag]);
+        // A rendered table ends with a trailing \n; we want the body
+        // between markers to start on a fresh line and end cleanly
+        // before the END tag — so wrap with newlines.
+        if let Some(m) = REGISTRY.iter().find(|m| m.name == name) {
+            out.push('\n');
+            out.push_str(&(m.render)());
+            replacements += 1;
+        } else {
+            out.push_str(&input[after_begin_tag..end_abs]);
+        }
+        out.push_str(&end_tag);
+        cursor = end_abs + end_tag.len();
+    }
+
+    out.push_str(&input[cursor..]);
+    (out, replacements)
+}
+
+fn marker_name(begin_tag: &str) -> Option<&str> {
+    let prefix = "<!-- tiers:BEGIN:";
+    let suffix = " -->";
+    let inner = begin_tag.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    if inner.is_empty() || !inner.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    Some(inner)
+}
+
+fn find_from(haystack: &[u8], start: usize, needle: &[u8]) -> Option<usize> {
+    if start > haystack.len() {
+        return None;
+    }
+    haystack[start..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|p| start + p)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_table_has_row_for_every_variant() {
+        let t = render_tier_table();
+        // One data row per variant — 6 total.
+        let data_rows = t
+            .lines()
+            .filter(|l| l.starts_with("| ") && !l.starts_with("| ----"))
+            .count();
+        assert_eq!(data_rows, 7, "header + 6 data rows expected, got:\n{t}");
+    }
+
+    #[test]
+    fn tier_table_labels_match_enum() {
+        let t = render_tier_table();
+        for label in &[
+            "VERIFIED",
+            "UNVERIFIED",
+            "UNTRUSTED KEY",
+            "PARSE FAILED",
+            "BOOT BLOCKED",
+            "HASH MISMATCH",
+        ] {
+            assert!(t.contains(label), "tier table missing {label}");
+        }
+    }
+
+    #[test]
+    fn keybinding_table_contains_every_registered_binding() {
+        let t = render_keybinding_table();
+        for k in KEYBINDINGS {
+            assert!(
+                t.contains(k.description),
+                "keybinding description missing: {}",
+                k.description
+            );
+        }
+    }
+
+    #[test]
+    fn apply_markers_rewrites_tier_region() {
+        let input = "before\n<!-- tiers:BEGIN:TRUST_TIER_TABLE -->\nSTALE\n<!-- tiers:END:TRUST_TIER_TABLE -->\nafter";
+        let (out, n) = apply_markers(input);
+        assert_eq!(n, 1);
+        assert!(out.contains("VERIFIED"));
+        assert!(!out.contains("STALE"));
+    }
+
+    #[test]
+    fn apply_markers_idempotent() {
+        let input = "<!-- tiers:BEGIN:TRUST_TIER_TABLE -->\n\n<!-- tiers:END:TRUST_TIER_TABLE -->";
+        let (first, _) = apply_markers(input);
+        let (second, _) = apply_markers(&first);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn apply_markers_preserves_unknown_names() {
+        let input = "<!-- tiers:BEGIN:UNKNOWN -->dont-touch<!-- tiers:END:UNKNOWN -->";
+        let (out, n) = apply_markers(input);
+        assert_eq!(n, 0);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn registry_contains_both_markers() {
+        let names: Vec<&str> = REGISTRY.iter().map(|m| m.name).collect();
+        assert!(names.contains(&"TRUST_TIER_TABLE"));
+        assert!(names.contains(&"KEYBINDINGS"));
+    }
+}

--- a/crates/rescue-tui/src/lib.rs
+++ b/crates/rescue-tui/src/lib.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Library facade for the rescue-tui crate.
+//!
+//! Most of rescue-tui's logic lives in the `rescue-tui` binary
+//! (`src/main.rs`); this lib.rs exists to expose a small set of
+//! modules to sibling binaries (notably `tiers-docgen` — #462) so
+//! generated docs can derive from the same `TrustVerdict` enum and
+//! `KEYBINDINGS` registry the TUI itself uses. Having a lib also lets
+//! integration tests exercise render paths from outside `main.rs`.
+//!
+//! ## What's public here
+//!
+//! - [`verdict`] — the 6-tier [`TrustVerdict`](verdict::TrustVerdict).
+//! - [`keybindings`] — the canonical [`KEYBINDINGS`](keybindings::KEYBINDINGS) registry.
+//! - [`state`] — [`AppState`](state::AppState) and supporting types.
+//! - [`theme`] — color palettes.
+//! - [`docgen`] — render the tier + keybinding tables as Markdown
+//!   (used by the `tiers-docgen` binary).
+//!
+//! The event-loop / IO-heavy modules (`failure_log`, `persistence`,
+//! `render`, `tpm`) are `pub` here so the `rescue-tui` binary in
+//! `main.rs` can reach them, but they're not meant as external API —
+//! they assume a running rescue-tui context.
+
+#![forbid(unsafe_code)]
+
+pub mod docgen;
+pub mod failure_log;
+pub mod keybindings;
+pub mod persistence;
+pub mod render;
+pub mod state;
+pub mod theme;
+pub mod tpm;
+pub mod verdict;

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -9,14 +9,9 @@
 
 #![forbid(unsafe_code)]
 
-mod failure_log;
-mod keybindings;
-mod persistence;
-mod render;
-mod state;
-mod theme;
-mod tpm;
-mod verdict;
+// All modules now live in lib.rs so sibling binaries like
+// tiers-docgen (#462) can share them. main.rs is a thin driver.
+use rescue_tui::{failure_log, persistence, render, state, theme, tpm};
 
 use std::env;
 use std::io;

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -61,6 +61,33 @@ See [docs/USB_LAYOUT.md](USB_LAYOUT.md) for the full partition + filesystem cont
 
 When the rescue-tui menu lists your ISOs, it computes their sha256 on the spot and compares against optional `<iso>.sha256` sidecars you write yourself. The verdict (verified ✓ / mismatch ✗ / no sidecar) is shown before you boot — but the **boot decision** itself stays with you. There is no auto-update, no phone-home, no auto-trust.
 
+## Trust tiers in rescue-tui
+
+When you boot the stick and rescue-tui scans `AEGIS_ISOS`, every
+`.iso` file gets classified into one of 6 trust tiers. The tier drives
+the color, glyph, and whether Enter actually boots — the design
+principle is "Secure Boot stays strict; operator attestation relaxes
+gracefully" (see [epic #455](https://github.com/aegis-boot/aegis-boot/issues/455)).
+
+<!-- tiers:BEGIN:TRUST_TIER_TABLE -->
+| Tier | Verdict             | Glyph | Bootable | Meaning                                    |
+| ---- | ------------------- | ----- | -------- | ------------------------------------------ |
+| 1    | VERIFIED            | `[+]` | yes      | Hash or sig verified vs trusted source     |
+| 2    | UNVERIFIED          | `[ ]` | yes      | No sidecar — bootable with typed confirm   |
+| 3    | UNTRUSTED KEY       | `[~]` | yes      | Sig parses, signer untrusted               |
+| 4    | PARSE FAILED        | `[!]` | **no**   | iso-parser couldn't extract kernel         |
+| 5    | BOOT BLOCKED        | `[X]` | **no**   | Kernel rejected by platform keyring        |
+| 6    | HASH MISMATCH       | `[!]` | **no**   | ISO bytes don't match declared hash        |
+<!-- tiers:END:TRUST_TIER_TABLE -->
+
+This table is generated from the `TrustVerdict` enum in
+[`crates/rescue-tui/src/verdict.rs`](../crates/rescue-tui/src/verdict.rs)
+by the `tiers-docgen` devtool — run it after any enum change:
+
+```bash
+cargo run -p rescue-tui --bin tiers-docgen
+```
+
 ## What aegis-boot does NOT do
 
 - **It does not modify your laptop's firmware.** No MOK enrollment, no PK/KEK/db changes. Plug the stick in, boot, eject — your firmware is untouched.

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -129,6 +129,36 @@ Plug the stick into a target. Power on. Hit the firmware boot-menu key (`F12`/`F
 
 If you hit `SignatureRejected` for an ISO, it means the kernel inside that ISO isn't signed by a CA your firmware (or the operator's MOK keyring) trusts. The rescue-tui surfaces the `mokutil --import` recipe for the specific signing key; see [UNSIGNED_KERNEL.md](./UNSIGNED_KERNEL.md) for the full walkthrough.
 
+## rescue-tui keybindings
+
+Context-sensitive — the footer legend updates based on the current
+screen and focused pane. Press `?` inside the TUI for a help overlay.
+
+<!-- tiers:BEGIN:KEYBINDINGS -->
+| Key | Screens | Pane | Filter-editing | Description |
+| --- | ------- | ---- | -------------- | ----------- |
+| `?` | any | any | no | Show the help overlay with all keybindings |
+| `q` | any | any | no | Quit rescue-tui (returns control to the boot menu) |
+| `↑↓/jk` | List | any | no | Move the list cursor (pane=List) or scroll info pane (pane=Info) |
+| `Tab` | List | any | no | Toggle focus between the ISO list and the info pane |
+| `Enter` | List | List | no | Confirm the selected ISO (only valid in the list pane) |
+| `/` | List | any | no | Open the substring filter — typed chars match label + path |
+| `s` | List | any | no | Cycle sort order: name → size → distro → name |
+| `v` | List, Confirm | any | no | Re-compute sha256 of the selected ISO in a background thread |
+| `Enter` | List | any | yes | Commit the current filter and close the input |
+| `Esc` | List | any | yes | Close the filter input and clear the current filter |
+| `Enter` | Confirm | any | no | Kexec into the selected ISO (may trigger a trust challenge) |
+| `e` | Confirm | any | no | Edit the kernel command line before boot |
+| `Esc/h` | Confirm, Error | any | no | Return to the list without booting |
+| `Enter` | EditCmdline | any | no | Save the edited kernel command line and return to Confirm |
+| `Esc` | EditCmdline, Verifying, TrustChallenge | any | no | Discard edits and return to Confirm |
+| `F10` | Error | any | no | Write a failure-log bundle to AEGIS_ISOS for post-mortem analysis |
+| `boot+Enter` | TrustChallenge | any | no | Type the word 'boot' and press Enter to proceed past the trust challenge |
+<!-- tiers:END:KEYBINDINGS -->
+
+Generated from the `KEYBINDINGS` registry in
+[`crates/rescue-tui/src/keybindings.rs`](../crates/rescue-tui/src/keybindings.rs).
+
 ## What's next
 
 | Want to...                       | Try                                                   |


### PR DESCRIPTION
Replaces #470 (auto-closed). Closes #462. Final child of epic #455 — closes the epic on merge.