### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,52 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
-All changes are post-v0.16.0, landing on main over 2026-04-22. Headline themes: ADR 0003 cross-reboot persistence shipped end-to-end, MSRV bumped to Rust 1.88, first-class NixOS install path via flake, and the entire major-dep-bump backlog from #411 cleared (indicatif, toml, schemars, sha2).
+## [0.17.0] — 2026-04-24
+
+Headline themes: the rescue-tui UX overhaul from [epic #455](https://github.com/aegis-boot/aegis-boot/issues/455) (dual-pane layout, 6-tier trust model, every ISO on the stick is now visible with a descriptive verdict), ADR 0003 cross-reboot persistence shipped end-to-end, MSRV bumped to Rust 1.88, first-class NixOS install path via flake, and the entire major-dep-bump backlog from #411 cleared (indicatif, toml, schemars, sha2).
+
+### rescue-tui UX overhaul — dual-pane + all-ISOs-visible (#455 epic, 7 PRs)
+
+Triggered by [#454](https://github.com/aegis-boot/aegis-boot/issues/454) (a tester reported drag-dropped ISOs were "not obvious" in the TUI). The new UI surfaces every `.iso` file on `AEGIS_ISOS` with a tier verdict instead of hiding un-verifiable ones behind a count banner.
+
+**Trust-tier model** — 6 named tiers replace the 4-color coarse verdict:
+
+| Tier | Verdict             | Bootable | Meaning                                    |
+| ---- | ------------------- | -------- | ------------------------------------------ |
+| 1    | OperatorAttested    | yes      | Hash or sig verified vs trusted source     |
+| 2    | BareUnverified      | yes\*    | No sidecar — typed-confirm required        |
+| 3    | KeyNotTrusted       | yes\*    | Sig parses, signer untrusted               |
+| 4    | ParseFailed         | **no**   | iso-parser couldn't extract kernel         |
+| 5    | SecureBootBlocked   | **no**   | Kernel rejected by platform keyring        |
+| 6    | HashMismatch        | **no**   | ISO bytes don't match declared hash        |
+
+Design principle: *Secure Boot stays strict; operator attestation relaxes gracefully.* An ISO that fails signature verification is never bootable; an ISO that lacks operator attestation is bootable with friction proportional to the missing signal.
+
+**Dual-pane layout** — gitui-style: 40% ISO list on the left, 60% info pane on the right. `Tab` toggles focus. Info pane shows per-tier metadata (file, size, sha256, signer, kernel, initrd, cmdline, distro, quirks) plus a pre-wrapped `Reason:` block for tier 4/5/6. Long error strings pre-wrapped via `textwrap` to work around ratatui/ratatui#2342 (Paragraph wrap+scroll accounting bug). Focus border brightens on the active pane, dims on the inactive pane. Context-sensitive footer legend filters by current screen + pane + filter-editing state.
+
+**Programmatic docs** — new `tiers-docgen` binary in rescue-tui renders the tier table and keybinding reference as Markdown from the canonical in-code sources (`TrustVerdict` enum + `KEYBINDINGS` registry). Marker-pair rewriting in `docs/HOW_IT_WORKS.md`, `docs/TOUR.md`, and `crates/rescue-tui/README.md`. CI's new `tiers-drift` job enforces drift-freedom (same pattern as `constants-drift` / `cli-drift` / `manifest-schema-drift`).
+
+**ANSI preview** — dev-only `tui-screenshots` binary renders 10 curated fixtures (empty list, all 6 tiers, focus states, filter editing, help overlay, confirm screen, trust challenge) to ANSI-escaped stdout. `cat docs/screenshots/rescue-tui-preview.ansi` in a color terminal for visual review without a build+boot cycle.
+
+**API changes** — `iso_probe::discover()` now returns `DiscoveryReport { isos: Vec<DiscoveredIso>, failed: Vec<FailedIso> }`. `ProbeError::NoIsosFound` is now reserved for "zero `.iso` files found on disk" — a stick full of broken ISOs returns `Ok(report)` with populated `failed` so rescue-tui can render tier-4 rows. Paired iso-parser API `scan_directory_with_failures` adds the `ScanReport` shape; legacy `scan_directory` stays as a thin wrapper for backwards compat.
+
+PRs landed: [#463](https://github.com/aegis-boot/aegis-boot/pull/463) (design doc), [#464](https://github.com/aegis-boot/aegis-boot/pull/464) (DiscoveryReport API), [#471](https://github.com/aegis-boot/aegis-boot/pull/471) (6 tiers), [#472](https://github.com/aegis-boot/aegis-boot/pull/472) (dual-pane scaffold), [#473](https://github.com/aegis-boot/aegis-boot/pull/473) (info-pane content + tier-4 rows), [#474](https://github.com/aegis-boot/aegis-boot/pull/474) (keybinding registry), [#475](https://github.com/aegis-boot/aegis-boot/pull/475) (render coverage suite — 19 tests), [#476](https://github.com/aegis-boot/aegis-boot/pull/476) (tiers-docgen + CI drift check), [#477](https://github.com/aegis-boot/aegis-boot/pull/477) (ANSI preview tool).
+
+### `aegis-boot add --scan` — retroactive sidecar generation (#479)
+
+Complement to the epic: operators who drag-and-dropped ISOs onto `AEGIS_ISOS` from their host OS can now upgrade those tier-2 (BareUnverified) entries to tier-1 (OperatorAttested) with one command:
+
+```bash
+sudo aegis-boot add --scan /dev/sda2
+sudo aegis-boot add --scan /mnt/aegis-isos
+sudo aegis-boot add --scan                  # auto-detect AEGIS_ISOS
+```
+
+Walks the mount via `scan_isos` (#274 Phase 6a), classifies each `.iso` by sidecar state, streams sha256, writes coreutils-compatible `<hex>  <filename>\n` sidecars atomically (tempfile-in-same-dir + persist). Never overwrites an existing sidecar — a hash mismatch is surfaced as a **tamper signal** instead of auto-corrected. Direct-write-first, `sudo cp` fallback only on `PermissionDenied` / `ReadOnlyFilesystem` so unit tests and already-root flows stay prompt-free. Per-ISO attestation entries. Minisig generation is out of scope (would require the operator's private signing key). New `pub fn iso_probe::compute_iso_sha256(path)` exposes the streaming hasher.
+
+PR: [#480](https://github.com/aegis-boot/aegis-boot/pull/480). 18 new tests, 512 total in aegis-bootctl.
+
+### ⚠️ Breaking change for external schema consumers
 
 ### ⚠️ Breaking change for external schema consumers
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-bootctl"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aegis-wire-formats",
  "hex",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-wire-formats"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "schemars",
  "serde",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "hex",
  "iso-parser",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "kexec-loader"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "thiserror",
@@ -952,7 +952,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rescue-tui"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aegis-wire-formats",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["crates/iso-parser/fuzz"]
 # Release-cut flow: bump this one line + amend CHANGELOG, tag.
 # CI's doc-version drift-check (Phase 1c) greps an allowlist of
 # user-facing doc files and fails if any version literal diverges.
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -57,11 +57,11 @@ docgen = []
 [dependencies]
 serde = { workspace = true }
 serde_json = "1.0"
-iso-probe = { path = "../iso-probe", version = "0.16" }
+iso-probe = { path = "../iso-probe", version = "0.17" }
 # Signed attestation manifest types extracted for Phase 4a of #286.
 # This crate is the Rust + JSON Schema source of truth for the
 # on-disk aegis-boot-manifest.json wire format.
-aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
+aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.17" }
 # Atomic random-name temp files for write_sidecar_via_sudo's
 # stage-then-copy path. Use the runtime dep (not the dev-dep) so the
 # staging path is not predictable — closes the TOCTOU window semgrep

--- a/crates/iso-probe/Cargo.toml
+++ b/crates/iso-probe/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["filesystem", "embedded"]
 [lib]
 
 [dependencies]
-iso-parser = { path = "../iso-parser", version = "0.16" }
+iso-parser = { path = "../iso-parser", version = "0.17" }
 thiserror.workspace = true
 serde = { workspace = true }
 tracing.workspace = true

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -26,7 +26,7 @@ name = "tui-screenshots"
 path = "src/bin/tui_screenshots.rs"
 
 [dependencies]
-aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.16" }
+aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.17" }
 iso-probe = { path = "../iso-probe" }
 kexec-loader = { path = "../kexec-loader" }
 thiserror.workspace = true

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -514,7 +514,7 @@ Every other USB-imaging tool is silent after flash. The attestation receipt is t
 ```json
 {
   "schema_version": 1,
-  "tool_version": "0.16.0",
+  "tool_version": "0.17.0",
   "flashed_at": "2026-04-16T12:34:56Z",
   "operator": "william",
   "host": {
@@ -847,7 +847,7 @@ aegis-boot tour --help
 
 ## Versioning
 
-`aegis-boot --version` reports the workspace version (currently `0.16.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.17.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
 `aegis-boot --version --json` emits the same info as a stable envelope for scripted install verification or Homebrew-style version matching:
 
@@ -855,7 +855,7 @@ aegis-boot tour --help
 {
   "schema_version": 1,
   "tool": "aegis-boot",
-  "version": "0.16.0"
+  "version": "0.17.0"
 }
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -96,7 +96,7 @@ The flake pins to `nixos-unstable`; downgrade to a specific channel in your own 
 Sanity check:
 
 ```bash
-aegis-boot --version       # → aegis-boot v0.16.0
+aegis-boot --version       # → aegis-boot v0.17.0
 aegis-boot doctor          # 0–100 health score for host + stick
 ```
 
@@ -202,7 +202,7 @@ If the firmware refuses to show the USB entry, your boot mode might be CSM/Legac
 `rescue-tui` shows your ISOs with verification status:
 
 ```
-aegis-boot v0.16.0    SB:enforcing  TPM:available
+aegis-boot v0.17.0    SB:enforcing  TPM:available
 
   ▸ ubuntu-24.04.2-live-server-amd64.iso        1.6 GiB  [✓ sha256]
     alpine-3.20.3-x86_64.iso                     198 MiB  [no verify]

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -99,7 +99,7 @@ EXAMPLES:
   aegis-boot bug-report --output report.json --format json
   aegis-boot bug-report --include-stick /media/$USER/AEGIS_ISOS
 
-(aegis-boot v0.16.0)
+(aegis-boot v0.17.0)
 ```
 
 ## `aegis-boot compat`
@@ -220,11 +220,11 @@ aegis-boot fetch-image — download + verify a pre-built aegis-boot image
 
 USAGE:
   aegis-boot fetch-image                               # latest release, cosign auto-verify
-  aegis-boot fetch-image --version v0.16.0             # pin to a specific release
+  aegis-boot fetch-image --version v0.17.0             # pin to a specific release
   aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL
 
   --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)
-  --version TAG   Pin to a specific release tag (e.g. v0.16.0)
+  --version TAG   Pin to a specific release tag (e.g. v0.17.0)
   --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)
   --sha256 HEX    Required sha256; mismatch deletes the download + exits 1
   --no-cosign     Skip the cosign keyless signature check (air-gap, offline)


### PR DESCRIPTION
## Summary

Release v0.17.0. Headline themes:

- **rescue-tui UX overhaul** (epic #455, 9 PRs merged) — dual-pane layout, 6-tier trust model, every .iso on the stick is visible with a descriptive verdict + reason. Closes the loop on tester report #454.
- **\`aegis-boot add --scan\`** (#479 / PR #480) — retroactive sidecar generation so drag-and-dropped ISOs can upgrade from tier-2 to tier-1 without re-downloading.
- ADR 0003 cross-reboot persistence, MSRV → 1.88, NixOS flake package, #411 major-dep-bump backlog all in this window.

## What changes

- \`Cargo.toml\` workspace version: 0.16.0 → 0.17.0
- Intra-workspace pins (iso-parser, iso-probe, aegis-wire-formats): 0.16 → 0.17
- \`CHANGELOG.md\`: new \`[0.17.0] — 2026-04-24\` section with full epic breakdown
- \`docs/INSTALL.md\` + \`docs/CLI.md\`: version strings refreshed
- \`docs/reference/CLI_SYNOPSIS.md\`: regenerated from fresh release binary

## Gates

- [x] \`cargo test --workspace\` — 17 suites, ~670 tests
- [x] \`cargo fmt --check\` clean
- [x] \`check-doc-version.sh\` OK (4 patterns match 0.17.0)
- [x] \`constants-docgen --check\` clean
- [x] \`cli-docgen --check\` clean (18 subcommands)
- [x] \`tiers-docgen --check\` clean (4 markers)

## After merge

Tag \`v0.17.0\` and push — the release workflow builds cosign-signed artifacts and drafts the GitHub release.