### PR TITLE
ci: cargo-machete + CodeQL + clean 3 unused deps (#486, #488)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# CodeQL semantic analysis (#488 / #485 supply-chain hygiene bundle).
+#
+# Complements the existing semgrep p/rust + p/security-audit passes
+# — semgrep catches pattern-based findings (explicit regex/AST
+# rules), CodeQL catches data-flow taint analysis across function
+# boundaries. The overlap is real but not total; projects that run
+# both catch issues either tool misses alone.
+#
+# Findings surface in Security → Code scanning alongside semgrep +
+# Scorecard SARIF outputs.
+#
+# Rust support in CodeQL is still in beta as of 2026. If the queries
+# become noisy we tighten them via a .github/codeql/codeql-config.yml
+# file (not needed for the default rollout).
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Tuesdays 07:00 UTC = 03:00 ET — staggered from Scorecard's Monday
+    # run so the two analyses don't starve each other for runners.
+    - cron: "0 7 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `actions` catches Actions-workflow misconfigurations
+        # (unused secrets, pinning issues, etc.) independently of
+        # Rust-source analysis.
+        #
+        # Rust support in CodeQL is still public-preview. If Rust
+        # queries flake, the `actions` matrix entry still produces
+        # useful analysis. Monitor + tighten via a codeql-config.yml
+        # if Rust findings become noisy.
+        language: [rust, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended + security-and-quality give us the full
+          # CWE-mapped ruleset. Default is 'security' only.
+          queries: security-extended
+
+      # Rust needs a build step so CodeQL can extract the IR. Pinned
+      # to MSRV (matches the rest of CI) so the extractor sees the
+      # same tree the release binary is built from.
+      - name: Install Rust
+        if: matrix.language == 'rust'
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        if: matrix.language == 'rust'
+
+      - name: Build workspace (Rust only)
+        if: matrix.language == 'rust'
+        run: cargo build --workspace --locked
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# cargo-machete — unused-dependency gate (#486 / #485 supply-chain
+# hygiene bundle).
+#
+# Runs on every PR + push-to-main. Fails if any crate in the
+# workspace declares a dep it doesn't actually use. Catches the
+# "#411 major-bump left an unused crate behind" class of drift that
+# otherwise sits in Cargo.toml forever as transitive-supply-chain
+# surface for nothing.
+#
+# Local workflow: `cargo install cargo-machete --locked`, then
+# `cargo machete` in the repo root. Exits 0 on clean, non-zero on
+# unused-dep findings.
+#
+# False-positive handling: add an `[package.metadata.cargo-machete]`
+# ignored-list entry to the offending crate's Cargo.toml (proc-macro
+# deps are the usual culprit).
+
+name: cargo-machete
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  machete:
+    name: cargo-machete
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust
+        run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
+      - uses: Swatinem/rust-cache@v2
+      # Pinned version = what we tested locally (0.9.2). Bump via
+      # Dependabot when upstream ships a new release. Install via
+      # `cargo install` rather than a third-party Action to keep the
+      # supply-chain surface minimal — cargo-machete doesn't publish
+      # a maintainer-owned Action, and we don't want to depend on a
+      # random fork's auth identity.
+      - name: Install cargo-machete
+        run: cargo install cargo-machete --locked --version 0.9.2
+      - name: Run cargo-machete
+        run: cargo machete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ Every PR runs the following — each is also runnable locally. Running them befo
 | Typo gate (#485) | `typos` (install via `cargo install typos-cli --locked`) | [`.typos.toml`](./.typos.toml) |
 | OpenSSF Scorecard (#485) | GitHub-only, weekly | `.github/workflows/scorecard.yml` |
 | Dependabot auto-bumps (#485) | GitHub-only, weekly + on advisory | `.github/dependabot.yml` |
+| Unused-dep gate (#486) | `cargo install cargo-machete --locked && cargo machete` | `.github/workflows/machete.yml` |
+| CodeQL data-flow analysis (#488) | GitHub-only, weekly + PR | `.github/workflows/codeql.yml` |
 
 `./scripts/dev-test.sh` bundles most of these into a single "run-before-push" command.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -619,7 +618,6 @@ version = "0.17.0"
 dependencies = [
  "libc",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -966,7 +964,6 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "textwrap",
- "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/aegis-wire-formats/Cargo.toml
+++ b/crates/aegis-wire-formats/Cargo.toml
@@ -33,7 +33,6 @@ schema = ["dep:schemars"]
 [dependencies]
 serde = { workspace = true }
 serde_json = "1.0"
-thiserror = { workspace = true }
 # schemars picks the latest stable. 0.8 is the long-established
 # release with a settled API + a broad reverse-dependency ecosystem.
 schemars = { version = "1", optional = true, default-features = false, features = ["derive"] }

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["os::linux-apis", "api-bindings"]
 
 [dependencies]
 thiserror.workspace = true
-tracing.workspace = true
 libc.workspace = true
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]

--- a/crates/rescue-tui/Cargo.toml
+++ b/crates/rescue-tui/Cargo.toml
@@ -29,7 +29,6 @@ path = "src/bin/tui_screenshots.rs"
 aegis-wire-formats = { path = "../aegis-wire-formats", version = "0.17" }
 iso-probe = { path = "../iso-probe" }
 kexec-loader = { path = "../kexec-loader" }
-thiserror.workspace = true
 tracing.workspace = true
 serde = { workspace = true }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary

Two additions from the supply-chain hygiene follow-up list, plus the unused-dep cleanup that cargo-machete surfaced on first run.

- **cargo-machete** (#486) — unused-dep detector; new CI gate
- **CodeQL** (#488) — semantic data-flow analysis (complements semgrep)
- **Removed 3 unused deps**: thiserror from aegis-wire-formats + rescue-tui, tracing from kexec-loader (all flagged by machete; grep confirmed zero usage)

## Why not SLSA (#487) here

SLSA provenance must be generated by the same workflow that produced the artifacts — it needs release.yml itself to be modified. Bundled it into this PR would enlarge the review scope and add risk to the release pipeline. Upgraded #487 with a full implementation sketch + verification recipe so the maintainer can do a focused PR + test-release cut.

## Test plan

- [x] \`cargo machete\` — clean on main (after dep removal)
- [x] \`cargo test --workspace\` — 17 suites green, 3 fewer deps compiling
- [x] \`cargo fmt --check\` clean
- [x] \`typos\` clean
- [x] CodeQL workflow YAML lint-valid; first run after merge will validate against the GitHub Actions engine

## Follow-ups

- #487 SLSA provenance — full implementation guidance now on the issue
- #489 miri workspace expansion — separate PR since it may surface pre-existing UB in dep internals