### PR TITLE
feat(#497 piece 4): Windows --direct-install CLI dispatcher — closes #497 + #483

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+### Windows `--direct-install` CLI dispatcher (#497 piece 4 — closes #497 + parent #483)
+
+`aegis-boot flash --direct-install` now works on Windows, completing the [epic #419](https://github.com/aegis-boot/aegis-boot/issues/419) Windows direct-install adapter. The dispatcher lives in `windows_direct_install::flash_dispatcher` and composes: drive-arg parsing → source resolution (from `--out-dir` with env overrides) → pipeline::run (preflight → partition → format ESP + AEGIS_ISOS → stage_esp).
+
+- Drive identifier accepts `1`, `PhysicalDrive1`, or `\\.\PhysicalDrive1` — no quoting gymnastics.
+- If no drive arg is given, the dispatcher lists flashable candidates and exits with a remediation hint ("re-run with an explicit drive argument"). No interactive prompt — WinRM / remote SSH invocations often have a closed stdin, and a silent prompt-hang is worse than a clear message.
+- `--yes` is required on the first operator-facing invocation (destructive-action guard). Without it, the dispatcher surfaces the candidate list and exits 2.
+- Receipt-formatted per-stage timing report on success matches the shape of Linux's `flash_direct_install` ending output.
+- Pure core `run_direct_install_using(explicit_dev, out_dir, enumerate_fn, runner)` takes injected enumerator + `PhaseRunner`, so the full happy-path + 5 error-path branches are Linux-testable without PowerShell (15 new unit tests).
+
+macOS gets a clearer refusal: the cfg-gated error message now points at #418 (macOS adapter tracker) instead of the generic "Linux-only" text.
+
 ### Windows drive enumeration (#497 piece 3)
 
 New `windows_direct_install::drive_enumeration` module wraps `Get-Disk | ConvertTo-Json` so the CLI can list flashable physical drives, filtered to safe candidates (not disk 0, not `IsBoot`, not `IsSystem`, not read-only, ≥1 GiB). Pure-fn JSON parser + filter are unit-tested on Linux via canned output; the subprocess wrapper is Windows-gated. 14 tests cover the Win11-VM canned output shape, BOM-prefix tolerance, missing-optional-field tolerance, every filter predicate, stable ordering, human-readable size formatting, and `BusType` integer-enum mapping.

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -362,12 +362,20 @@ fn print_help() {
     println!("                     device as its ISO partition (#242). Rare — use when you");
     println!("                     deliberately want the small mkusb-default partition size.");
     println!("  --direct-install = bypass mkusb.sh + dd. Partition + format + stage the signed");
-    println!("                     boot chain in place. Linux: sgdisk + mkfs.{{fat,exfat}} + mtools.");
-    println!("                     Windows: diskpart + Format-Volume + windows-rs raw-write (#497).");
+    println!(
+        "                     boot chain in place. Linux: sgdisk + mkfs.{{fat,exfat}} + mtools."
+    );
+    println!(
+        "                     Windows: diskpart + Format-Volume + windows-rs raw-write (#497)."
+    );
     println!("                     ~30 sec vs ~4 min on USB 2.0. Mutually exclusive with --image.");
     println!("  --out-dir PATH   = directory holding the signed-chain files for --direct-install.");
-    println!("                     Default: ./out (mkusb.sh convention). Windows operators can also");
-    println!("                     override individual files via AEGIS_{{SHIM,GRUB,MM,KERNEL,INITRD}}_SRC.");
+    println!(
+        "                     Default: ./out (mkusb.sh convention). Windows operators can also"
+    );
+    println!(
+        "                     override individual files via AEGIS_{{SHIM,GRUB,MM,KERNEL,INITRD}}_SRC."
+    );
 }
 
 /// Build the typed `Plan` describing what `aegis-boot flash` would do

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -143,15 +143,15 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
         );
         return Err(2);
     }
-    // --direct-install is Linux-only — partition/format/stage helpers
-    // shell out to sgdisk + mkfs.fat + mkfs.exfat + mtools, all
-    // Linux-resident. Macros gate the module itself with
-    // #![cfg(target_os = "linux")] so any non-Linux build wouldn't even
-    // link the dispatcher. Refuse early with a clear message.
-    #[cfg(not(target_os = "linux"))]
+    // --direct-install: Linux shells out to sgdisk + mkfs.fat +
+    // mkfs.exfat + mtools; Windows (#497) composes diskpart + Format-
+    // Volume + windows-rs raw-write in crate::windows_direct_install.
+    // macOS remains unsupported (tracked as #418 — macOS adapter).
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     if direct_install {
         eprintln!(
-            "aegis-boot flash: --direct-install is Linux-only (sgdisk + mkfs.fat + mkfs.exfat + mtools)"
+            "aegis-boot flash: --direct-install is only supported on Linux + Windows. \
+             macOS support tracked in #418."
         );
         return Err(2);
     }
@@ -165,6 +165,23 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
             );
             return Err(1);
         }
+    }
+
+    // Windows --direct-install path: skips the Linux drive-selection
+    // + confirm-prompt code (both are /proc/partitions-shaped) and
+    // hands off to the Windows-native dispatcher which composes
+    // drive_enumeration + source_resolution + pipeline::run.
+    #[cfg(target_os = "windows")]
+    if direct_install {
+        if dry_run {
+            eprintln!(
+                "aegis-boot flash --direct-install on Windows: --dry-run \
+                 is not yet supported (no typed Plan shape for Windows)."
+            );
+            return Err(2);
+        }
+        let resolved_out_dir = out_dir.unwrap_or_else(|| PathBuf::from("./out"));
+        return run_windows_direct_install(explicit_dev, &resolved_out_dir, assume_yes);
     }
 
     // Step 1: select drive.
@@ -235,6 +252,67 @@ fn print_dry_run_plan(plan: &crate::plan::Plan) {
     println!("--dry-run: no changes were made. Re-run without --dry-run to execute.");
 }
 
+/// Windows `--direct-install` entry — thin wrapper around the
+/// Windows dispatcher that prints a confirm prompt (unless
+/// `--yes`), runs the pipeline, and translates the dispatcher's
+/// typed error into the right exit code.
+#[cfg(target_os = "windows")]
+fn run_windows_direct_install(
+    explicit_dev: Option<&str>,
+    out_dir: &Path,
+    assume_yes: bool,
+) -> Result<(), u8> {
+    use crate::windows_direct_install::flash_dispatcher::run_direct_install;
+
+    // Pre-confirm prompt — skip if --yes. We don't replicate the
+    // `select_drive` prompt because the dispatcher itself surfaces
+    // the candidate list when no explicit drive is given. This
+    // confirmation covers the case where the operator DID pass a
+    // drive; we want a last-chance "yes, destroy this disk" gate
+    // before we spawn diskpart.
+    if !assume_yes {
+        let Some(raw) = explicit_dev else {
+            // No drive given + no --yes — dispatcher will print the
+            // candidate list and bail with exit 2 below. Let it.
+            return finalize_windows_dispatch(run_direct_install(None, out_dir));
+        };
+        eprintln!(
+            "Windows --direct-install will destroy ALL partitions on {raw}. \
+             Re-run with --yes to confirm."
+        );
+        return Err(2);
+    }
+
+    finalize_windows_dispatch(run_direct_install(explicit_dev, out_dir))
+}
+
+#[cfg(target_os = "windows")]
+fn finalize_windows_dispatch(
+    result: Result<
+        crate::windows_direct_install::pipeline::DirectInstallReceipt,
+        crate::windows_direct_install::flash_dispatcher::DispatchError,
+    >,
+) -> Result<(), u8> {
+    use crate::windows_direct_install::flash_dispatcher::{DispatchError, format_receipt};
+    match result {
+        Ok(receipt) => {
+            println!("\nDirect-install complete.");
+            print!("{}", format_receipt(&receipt));
+            Ok(())
+        }
+        Err(err @ DispatchError::NeedsExplicitDrive(_)) => {
+            // Print the candidate list + remediation to stderr so
+            // operators see it even when stdout is redirected.
+            eprintln!("{err}");
+            Err(2)
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            Err(1)
+        }
+    }
+}
+
 fn print_post_flash_next_steps(drive: &Drive) {
     println!();
     println!("Done. Next steps:");
@@ -284,11 +362,12 @@ fn print_help() {
     println!("                     device as its ISO partition (#242). Rare — use when you");
     println!("                     deliberately want the small mkusb-default partition size.");
     println!("  --direct-install = bypass mkusb.sh + dd. Partition + format + stage the signed");
-    println!("                     boot chain in place via sgdisk + mkfs.{{fat,exfat}} + mtools.");
-    println!("                     ~30 sec vs ~4 min on USB 2.0. Linux only. (#274 Phase 3)");
-    println!("                     Mutually exclusive with --image.");
-    println!("  --out-dir PATH   = directory holding the aegis-boot initramfs.cpio.gz for");
-    println!("                     --direct-install. Default: ./out (mkusb.sh convention).");
+    println!("                     boot chain in place. Linux: sgdisk + mkfs.{{fat,exfat}} + mtools.");
+    println!("                     Windows: diskpart + Format-Volume + windows-rs raw-write (#497).");
+    println!("                     ~30 sec vs ~4 min on USB 2.0. Mutually exclusive with --image.");
+    println!("  --out-dir PATH   = directory holding the signed-chain files for --direct-install.");
+    println!("                     Default: ./out (mkusb.sh convention). Windows operators can also");
+    println!("                     override individual files via AEGIS_{{SHIM,GRUB,MM,KERNEL,INITRD}}_SRC.");
 }
 
 /// Build the typed `Plan` describing what `aegis-boot flash` would do

--- a/crates/aegis-cli/src/windows_direct_install/flash_dispatcher.rs
+++ b/crates/aegis-cli/src/windows_direct_install/flash_dispatcher.rs
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! #497 piece 4 — Windows `aegis-boot flash --direct-install`
+//! dispatcher. Composes drive enumeration + source resolution +
+//! the pipeline composer into the operator-facing CLI entry path.
+//!
+//! ## Operator flow
+//!
+//! ```text
+//! aegis-boot flash --direct-install <drive> --out-dir <path>
+//! ```
+//!
+//! - `<drive>` accepts `1`, `PhysicalDrive1`, or `\\.\PhysicalDrive1`.
+//!   Refusing to accept the raw `\\.\` prefix without escaping would
+//!   force operators into `cmd /c` quoting gymnastics.
+//! - `--out-dir` defaults to `./out` (matches the Linux path); contains
+//!   the 6 signed-chain files per [`super::source_resolution`].
+//!
+//! If `<drive>` is omitted, the dispatcher calls
+//! [`super::drive_enumeration::enumerate_flashable_drives`] and prints
+//! the flashable candidates for the operator to choose from — then
+//! exits with a hint to re-run with the chosen number. No interactive
+//! prompt: the common path is `WinRM` / SSH-invoked-from-Linux, where
+//! stdin is often closed, and a silent prompt hang is worse than a
+//! clear "re-run with arg" message.
+//!
+//! ## Why a separate module from `flash.rs`
+//!
+//! The Linux `flash_direct_install` is tightly bound to `sgdisk` +
+//! `mtools` + Debian-style signed-chain paths. Keeping Windows-side
+//! composition in `windows_direct_install/` keeps the host-specific
+//! code co-located with its phase modules and leaves `flash.rs` as
+//! the thin dispatcher that picks a platform implementation.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::windows_direct_install::drive_enumeration::PhysicalDisk;
+#[cfg(target_os = "windows")]
+use crate::windows_direct_install::drive_enumeration::enumerate_flashable_drives;
+#[cfg(target_os = "windows")]
+use crate::windows_direct_install::pipeline::WindowsPhaseRunner;
+use crate::windows_direct_install::pipeline::{
+    DirectInstallError, DirectInstallPlan, DirectInstallReceipt, DirectInstallStage, PhaseRunner,
+    run,
+};
+use crate::windows_direct_install::source_resolution::{
+    SourceResolutionError, build_staging_sources,
+};
+
+/// Parse an operator-supplied drive identifier into the physical
+/// disk number [`DirectInstallPlan`] takes. Accepts:
+///
+/// - `"1"` — bare integer
+/// - `"PhysicalDrive1"` — Windows-convention without the `\\.\` prefix
+/// - `r"\\.\PhysicalDrive1"` — full device path (escaped or not)
+/// - `"disk1"` — Linux-habit alias (some operators carry this over
+///   from `diskpart` `list disk` output which uses `Disk N`)
+pub(crate) fn parse_drive_id(raw: &str) -> Result<u32, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("aegis-boot flash: drive identifier is empty".into());
+    }
+    // Strip common prefixes, case-insensitive.
+    let lowered = trimmed.to_ascii_lowercase();
+    let digit_start = lowered
+        .strip_prefix(r"\\.\physicaldrive")
+        .or_else(|| lowered.strip_prefix("physicaldrive"))
+        .or_else(|| lowered.strip_prefix("disk"))
+        .unwrap_or(&lowered);
+    digit_start.parse::<u32>().map_err(|e| {
+        format!(
+            "aegis-boot flash: can't parse drive identifier {raw:?} as a physical-drive \
+             number: {e}. Expected `1`, `PhysicalDrive1`, or `\\\\.\\PhysicalDrive1`."
+        )
+    })
+}
+
+/// Top-level dispatch error: either the plan couldn't be built
+/// (source files missing, drive arg bogus) or the pipeline ran and
+/// aborted at one of its six stages.
+#[derive(Debug)]
+pub(crate) enum DispatchError {
+    /// `explicit_dev` was `None` — we enumerated candidates and want
+    /// the operator to re-run with a specific choice. Not really an
+    /// error as much as "we can't proceed non-interactively." Caller
+    /// should render the candidate list and exit with a typical
+    /// "usage" status (2).
+    NeedsExplicitDrive(Vec<PhysicalDisk>),
+    /// Drive arg supplied but unparseable.
+    BadDriveArg(String),
+    /// Source resolution failed (missing files, etc.).
+    Sources(SourceResolutionError),
+    /// Drive enumeration subprocess failed.
+    Enumeration(String),
+    /// Pipeline aborted at one of its stages; receipt reports which
+    /// stages actually ran.
+    Pipeline(Box<(DirectInstallError, DirectInstallReceipt)>),
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NeedsExplicitDrive(candidates) => {
+                writeln!(
+                    f,
+                    "aegis-boot flash --direct-install: no drive specified. \
+                     Candidates on this host:"
+                )?;
+                for d in candidates {
+                    writeln!(
+                        f,
+                        "  PhysicalDrive{:<3} {:<24} {:>10}  [{}]",
+                        d.number,
+                        d.friendly_name,
+                        d.human_size(),
+                        d.partition_style,
+                    )?;
+                }
+                write!(
+                    f,
+                    "Re-run with an explicit drive argument: \
+                     `aegis-boot flash --direct-install <N>`"
+                )
+            }
+            Self::BadDriveArg(detail) => write!(f, "{detail}"),
+            Self::Sources(e) => write!(f, "{e}"),
+            Self::Enumeration(detail) => {
+                write!(f, "aegis-boot flash --direct-install: {detail}")
+            }
+            Self::Pipeline(err_and_receipt) => {
+                let (err, receipt) = err_and_receipt.as_ref();
+                writeln!(f, "aegis-boot flash --direct-install: {err}")?;
+                write!(f, "{}", format_receipt(receipt))
+            }
+        }
+    }
+}
+
+/// Format the partial-progress receipt into a multi-line
+/// `Stage N done in XXXms` report matching the Linux flash path's
+/// ending lines.
+pub(crate) fn format_receipt(r: &DirectInstallReceipt) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let mut push = |stage: DirectInstallStage, d: Option<Duration>| {
+        if let Some(dur) = d {
+            let _ = writeln!(out, "  {:<22} {}", stage.name(), format_elapsed(dur));
+        }
+    };
+    push(
+        DirectInstallStage::PreflightElevation,
+        r.preflight_elevation,
+    );
+    push(
+        DirectInstallStage::PreflightBitLocker,
+        r.preflight_bitlocker,
+    );
+    push(DirectInstallStage::Partition, r.partition);
+    push(DirectInstallStage::FormatEsp, r.format_esp);
+    push(DirectInstallStage::FormatData, r.format_data);
+    push(DirectInstallStage::StageEsp, r.stage_esp);
+    let _ = writeln!(out, "  {:<22} {}", "total", format_elapsed(r.total()));
+    out
+}
+
+/// Human-readable elapsed time. Mirrors `flash::format_elapsed` —
+/// kept private here so the Linux-only gate on that one doesn't leak
+/// into the Windows dispatcher.
+fn format_elapsed(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 60.0 {
+        format!("{secs:.1}s")
+    } else {
+        let mins = d.as_secs() / 60;
+        let remaining = d.as_secs() % 60;
+        format!("{mins}m {remaining:02}s")
+    }
+}
+
+/// Shared pure core — runs the dispatcher against an injected
+/// enumerator + `PhaseRunner` so tests don't need `PowerShell`. The
+/// real `run_direct_install` on Windows supplies the production
+/// enumerator + `WindowsPhaseRunner`.
+pub(crate) fn run_direct_install_using<E>(
+    explicit_dev: Option<&str>,
+    out_dir: &Path,
+    enumerate: E,
+    runner: &dyn PhaseRunner,
+) -> Result<DirectInstallReceipt, DispatchError>
+where
+    E: FnOnce() -> Result<Vec<PhysicalDisk>, String>,
+{
+    // Drive selection: parse explicit arg, or enumerate + bail with
+    // the candidate list.
+    let Some(raw) = explicit_dev else {
+        let candidates = enumerate().map_err(DispatchError::Enumeration)?;
+        return Err(DispatchError::NeedsExplicitDrive(candidates));
+    };
+    let drive_num = parse_drive_id(raw).map_err(DispatchError::BadDriveArg)?;
+
+    // Source resolution.
+    let sources = build_staging_sources(out_dir).map_err(DispatchError::Sources)?;
+    let plan = DirectInstallPlan {
+        physical_drive: drive_num,
+        sources,
+    };
+
+    // Hand off to the composer; flatten Box-wrapped failure.
+    run(runner, &plan).map_err(DispatchError::Pipeline)
+}
+
+/// Top-level entry for the Windows-only CLI dispatch. Compiles only
+/// on Windows; the Linux / macOS builds skip this entirely by virtue
+/// of the cfg gate on the caller.
+#[cfg(target_os = "windows")]
+pub(crate) fn run_direct_install(
+    explicit_dev: Option<&str>,
+    out_dir: &Path,
+) -> Result<DirectInstallReceipt, DispatchError> {
+    run_direct_install_using(
+        explicit_dev,
+        out_dir,
+        enumerate_flashable_drives,
+        &WindowsPhaseRunner,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+    use crate::windows_direct_install::drive_enumeration::BusType;
+    use crate::windows_direct_install::format::FormatTarget;
+    use crate::windows_direct_install::preflight::BitLockerStatus;
+    use crate::windows_direct_install::raw_write::EspStagingSources;
+
+    struct MockRunner {
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl MockRunner {
+        fn new() -> Self {
+            Self {
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl PhaseRunner for MockRunner {
+        fn is_running_as_admin(&self) -> Result<bool, String> {
+            self.calls.borrow_mut().push("admin".into());
+            Ok(true)
+        }
+        fn check_bitlocker_status(&self, _d: u32) -> Result<BitLockerStatus, String> {
+            self.calls.borrow_mut().push("bitlocker".into());
+            Ok(BitLockerStatus::FullyDecrypted)
+        }
+        fn partition_via_diskpart(&self, _d: u32) -> Result<(), String> {
+            self.calls.borrow_mut().push("partition".into());
+            Ok(())
+        }
+        fn format_partition(&self, _d: u32, _t: FormatTarget) -> Result<(), String> {
+            self.calls.borrow_mut().push("format".into());
+            Ok(())
+        }
+        fn stage_esp(&self, _d: u32, _s: &EspStagingSources) -> Result<(), String> {
+            self.calls.borrow_mut().push("stage".into());
+            Ok(())
+        }
+    }
+
+    /// Populate a tempdir with the 6 default-named signed-chain files.
+    /// Returns the tempdir handle (drop removes the dir).
+    fn prepared_out_dir() -> tempfile::TempDir {
+        use crate::windows_direct_install::source_resolution::ENV_DEFAULT_PAIRS;
+        let dir = tempfile::tempdir().unwrap();
+        for (_, filename) in ENV_DEFAULT_PAIRS {
+            std::fs::write(dir.path().join(filename), b"stub").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn parse_drive_id_accepts_bare_integer() {
+        assert_eq!(parse_drive_id("1").unwrap(), 1);
+        assert_eq!(parse_drive_id("42").unwrap(), 42);
+    }
+
+    #[test]
+    fn parse_drive_id_accepts_physicaldrive_prefix() {
+        assert_eq!(parse_drive_id("PhysicalDrive1").unwrap(), 1);
+        assert_eq!(parse_drive_id("physicaldrive3").unwrap(), 3);
+    }
+
+    #[test]
+    fn parse_drive_id_accepts_full_device_path() {
+        assert_eq!(parse_drive_id(r"\\.\PhysicalDrive2").unwrap(), 2);
+        assert_eq!(parse_drive_id(r"\\.\physicaldrive7").unwrap(), 7);
+    }
+
+    #[test]
+    fn parse_drive_id_accepts_disk_alias() {
+        assert_eq!(parse_drive_id("disk1").unwrap(), 1);
+        assert_eq!(parse_drive_id("Disk5").unwrap(), 5);
+    }
+
+    #[test]
+    fn parse_drive_id_rejects_empty() {
+        assert!(parse_drive_id("").is_err());
+        assert!(parse_drive_id("   ").is_err());
+    }
+
+    #[test]
+    fn parse_drive_id_rejects_non_numeric() {
+        assert!(parse_drive_id("PhysicalDrive").is_err());
+        assert!(parse_drive_id("sda").is_err());
+        assert!(parse_drive_id("C:").is_err());
+    }
+
+    #[test]
+    fn run_direct_install_happy_path_invokes_every_phase() {
+        let dir = prepared_out_dir();
+        let runner = MockRunner::new();
+        // Enumerator: shouldn't be called — explicit arg given.
+        let receipt = run_direct_install_using(
+            Some("1"),
+            dir.path(),
+            || panic!("enumerator must not run when explicit drive given"),
+            &runner,
+        )
+        .expect("happy path should succeed");
+
+        assert!(receipt.preflight_elevation.is_some());
+        assert!(receipt.preflight_bitlocker.is_some());
+        assert!(receipt.partition.is_some());
+        assert!(receipt.format_esp.is_some());
+        assert!(receipt.format_data.is_some());
+        assert!(receipt.stage_esp.is_some());
+        // 5 phase methods (format gets called twice for ESP + data).
+        let calls = runner.calls.borrow().clone();
+        assert_eq!(
+            calls,
+            vec![
+                "admin",
+                "bitlocker",
+                "partition",
+                "format",
+                "format",
+                "stage"
+            ]
+        );
+    }
+
+    #[test]
+    fn run_direct_install_without_drive_returns_needs_explicit_with_candidates() {
+        let dir = prepared_out_dir();
+        let runner = MockRunner::new();
+        let candidate = PhysicalDisk {
+            number: 1,
+            friendly_name: "SanDisk Cruzer".into(),
+            size_bytes: 8 * 1024 * 1024 * 1024,
+            bus_type: BusType::Usb,
+            is_boot: false,
+            is_system: false,
+            is_offline: false,
+            is_read_only: false,
+            partition_style: "RAW".into(),
+        };
+        let err =
+            run_direct_install_using(None, dir.path(), || Ok(vec![candidate.clone()]), &runner)
+                .unwrap_err();
+
+        match err {
+            DispatchError::NeedsExplicitDrive(ref disks) => {
+                assert_eq!(disks.len(), 1);
+                assert_eq!(disks[0].number, 1);
+            }
+            _ => panic!("expected NeedsExplicitDrive, got {err:?}"),
+        }
+        // Runner must NOT have been invoked — no destructive action
+        // fires when the operator hasn't picked a drive yet.
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_direct_install_propagates_bad_drive_arg() {
+        let dir = prepared_out_dir();
+        let runner = MockRunner::new();
+        let err = run_direct_install_using(
+            Some("C:"),
+            dir.path(),
+            || panic!("enumerator must not run when parse fails"),
+            &runner,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DispatchError::BadDriveArg(_)));
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_direct_install_propagates_source_missing() {
+        // Empty out_dir — all 6 files absent.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = MockRunner::new();
+        let err =
+            run_direct_install_using(Some("1"), dir.path(), || Ok(vec![]), &runner).unwrap_err();
+        assert!(matches!(err, DispatchError::Sources(_)));
+        // Runner must not run — sources missing means no destructive
+        // action fires.
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_direct_install_wraps_enumeration_failure() {
+        let dir = prepared_out_dir();
+        let runner = MockRunner::new();
+        let err = run_direct_install_using(
+            None,
+            dir.path(),
+            || Err("spawn powershell: not found".into()),
+            &runner,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DispatchError::Enumeration(_)));
+    }
+
+    #[test]
+    fn format_receipt_includes_total_line() {
+        let r = DirectInstallReceipt {
+            preflight_elevation: Some(Duration::from_millis(50)),
+            preflight_bitlocker: Some(Duration::from_millis(200)),
+            partition: Some(Duration::from_millis(2000)),
+            format_esp: Some(Duration::from_millis(500)),
+            format_data: Some(Duration::from_millis(500)),
+            stage_esp: Some(Duration::from_millis(800)),
+        };
+        let out = format_receipt(&r);
+        assert!(out.contains("preflight:elevation"));
+        assert!(out.contains("stage_esp"));
+        assert!(out.contains("total"));
+    }
+
+    #[test]
+    fn format_receipt_skips_unrun_stages_but_still_prints_total() {
+        // Partition failed — ESP + data + stage never ran.
+        let r = DirectInstallReceipt {
+            preflight_elevation: Some(Duration::from_millis(50)),
+            preflight_bitlocker: Some(Duration::from_millis(200)),
+            partition: Some(Duration::from_millis(2000)),
+            format_esp: None,
+            format_data: None,
+            stage_esp: None,
+        };
+        let out = format_receipt(&r);
+        assert!(out.contains("partition:diskpart"));
+        assert!(!out.contains("format:esp"));
+        assert!(!out.contains("stage_esp"));
+        assert!(out.contains("total"));
+    }
+
+    #[test]
+    fn format_elapsed_formats_sub_minute_and_multi_minute() {
+        assert_eq!(format_elapsed(Duration::from_millis(1500)), "1.5s");
+        assert_eq!(format_elapsed(Duration::from_secs(125)), "2m 05s");
+    }
+
+    #[test]
+    fn dispatch_error_display_for_needs_explicit_lists_candidates() {
+        let err = DispatchError::NeedsExplicitDrive(vec![PhysicalDisk {
+            number: 1,
+            friendly_name: "SanDisk Cruzer".into(),
+            size_bytes: 8 * 1024 * 1024 * 1024,
+            bus_type: BusType::Usb,
+            is_boot: false,
+            is_system: false,
+            is_offline: false,
+            is_read_only: false,
+            partition_style: "RAW".into(),
+        }]);
+        let s = format!("{err}");
+        assert!(s.contains("no drive specified"));
+        assert!(s.contains("PhysicalDrive1"));
+        assert!(s.contains("SanDisk Cruzer"));
+        assert!(s.contains("Re-run with an explicit drive argument"));
+    }
+}

--- a/crates/aegis-cli/src/windows_direct_install/flash_dispatcher.rs
+++ b/crates/aegis-cli/src/windows_direct_install/flash_dispatcher.rs
@@ -89,7 +89,7 @@ pub(crate) enum DispatchError {
     /// should render the candidate list and exit with a typical
     /// "usage" status (2).
     NeedsExplicitDrive(Vec<PhysicalDisk>),
-    /// Drive arg supplied but unparseable.
+    /// Drive arg supplied but unparsable.
     BadDriveArg(String),
     /// Source resolution failed (missing files, etc.).
     Sources(SourceResolutionError),

--- a/crates/aegis-cli/src/windows_direct_install/mod.rs
+++ b/crates/aegis-cli/src/windows_direct_install/mod.rs
@@ -16,6 +16,7 @@
 //! reviewable from Linux.
 
 pub(crate) mod drive_enumeration;
+pub(crate) mod flash_dispatcher;
 pub(crate) mod format;
 pub(crate) mod partition;
 pub(crate) mod pipeline;

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -262,11 +262,12 @@ USAGE: aegis-boot flash [DEVICE] [--dry-run] [--yes] [--image PATH] [--no-progre
                      device as its ISO partition (#242). Rare — use when you
                      deliberately want the small mkusb-default partition size.
   --direct-install = bypass mkusb.sh + dd. Partition + format + stage the signed
-                     boot chain in place via sgdisk + mkfs.{fat,exfat} + mtools.
-                     ~30 sec vs ~4 min on USB 2.0. Linux only. (#274 Phase 3)
-                     Mutually exclusive with --image.
-  --out-dir PATH   = directory holding the aegis-boot initramfs.cpio.gz for
-                     --direct-install. Default: ./out (mkusb.sh convention).
+                     boot chain in place. Linux: sgdisk + mkfs.{fat,exfat} + mtools.
+                     Windows: diskpart + Format-Volume + windows-rs raw-write (#497).
+                     ~30 sec vs ~4 min on USB 2.0. Mutually exclusive with --image.
+  --out-dir PATH   = directory holding the signed-chain files for --direct-install.
+                     Default: ./out (mkusb.sh convention). Windows operators can also
+                     override individual files via AEGIS_{SHIM,GRUB,MM,KERNEL,INITRD}_SRC.
 ```
 
 ## `aegis-boot init`


### PR DESCRIPTION
Closes #497. Closes #483. Completes the #419 epic.

## Summary

\`aegis-boot flash --direct-install\` now works on Windows. The dispatcher lives in \`windows_direct_install::flash_dispatcher\` and composes the four prior Phase modules (preflight, partition, format, raw_write) through the #496 pipeline composer + #498 source resolver + #499 drive enumerator.

## Operator UX

\`\`\`
aegis-boot flash --direct-install 1 --out-dir ./out --yes
\`\`\`

Drive arg accepts \`1\`, \`PhysicalDrive1\`, or \`\\.\\PhysicalDrive1\` (case-insensitive prefix stripping; no quoting gymnastics).

If no drive is given, the dispatcher lists flashable candidates and exits 2 with a remediation hint. No interactive prompt — WinRM / remote SSH invocations often have closed stdin.

## flash.rs wiring

- macOS refusal tightened: now points at #418 (macOS adapter tracker)
- Windows direct-install skips the Linux \`select_drive\` + \`confirm_destructive\` (both \`/proc/partitions\`-shaped) and hands off to the Windows dispatcher
- \`--yes\` required for destructive invocations (destructive-action guard)
- \`--dry-run\` on Windows returns exit 2 with a clear message (typed Plan shape for Windows is a follow-up)

## Help text

\`--direct-install\` names both Linux + Windows backends. \`--out-dir\` help lists the 5 Windows env-var overrides.

## Test coverage

15 new tests, all Linux-executable through dependency injection:
- \`parse_drive_id\` accepts every supported format, rejects bogus input
- Happy path invokes all 6 phase methods (5 distinct, format twice)
- No drive → \`NeedsExplicitDrive\` with populated candidates; no destructive action fires
- Bad arg → \`BadDriveArg\`; no destructive action
- Sources missing / enumeration failure propagate cleanly
- \`format_receipt\` / \`format_elapsed\` output shape

## Test plan

- [x] \`cargo clippy -p aegis-bootctl --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p aegis-bootctl --locked\` — all pass
- [x] \`cargo check -p aegis-bootctl --target x86_64-pc-windows-gnu --all-targets\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)