### PR TITLE
fix(#502): cross-platform 3 Linux-biased tests + Windows cache-dir fallback

### DIFF
--- a/.github/workflows/windows-cargo-check.yml
+++ b/.github/workflows/windows-cargo-check.yml
@@ -98,20 +98,13 @@ jobs:
         # API surface, serde wiring, clippy-gated code paths).
         run: cargo check -p aegis-bootctl --all-targets --locked
 
-      - name: cargo test — windows_direct_install module
-        # Runs only the ~70 tests under windows_direct_install::* —
-        # the 18 raw_write + 13 pipeline + 10 source_resolution + 14
-        # drive_enumeration + 15 flash_dispatcher tests that cover
-        # the #419 Windows surface directly. The full aegis-bootctl
-        # suite has ~5 pre-existing Linux-path-biased tests (look for
-        # `ls` in PATH, use POSIX /tmp paths, etc.) that fail on
-        # Windows for reasons unrelated to this workflow's signal.
-        # A full-suite run is tracked as #502.
-        #
+      - name: cargo test (full aegis-bootctl suite)
+        # Full suite — #502 fixed the 5 Linux-biased tests (colon
+        # in filenames, `ls` probe, HOME fallback for cache dir).
         # Skips the `#[ignore]`-gated raw_write_roundtrip integration
         # test — that one needs a real scratch disk and is exercised
         # manually on the VM.
-        run: cargo test -p aegis-bootctl windows_direct_install --locked
+        run: cargo test -p aegis-bootctl --locked
 
       - name: cargo clippy (Windows-native lint)
         # Some clippy lints (struct_excessive_bools, borrow_as_ptr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+### Cross-platform test fixes + Windows cache-dir fallback (#502)
+
+Three tests were previously Linux-biased; #502 makes them run cleanly on Windows and broadens the #501 full-suite gate to all 593 aegis-bootctl tests:
+
+- `bug_report::tests::read_stick_logs_parses_valid_and_skips_malformed` — filename had `:` in it (ISO-8601 timestamp), which NTFS forbids. Renamed to dashes; the in-file JSON still carries the colon form.
+- `doctor::tests::check_command_present_with_pkg_finds_existing_binary` — probed for `ls` in PATH; now uses `cmd` on Windows, `ls` elsewhere.
+- `fetch_image::default_cache_path` tests — depended on POSIX `XDG_CACHE_HOME` / `HOME`. The function now also respects `LOCALAPPDATA` + `USERPROFILE` fallbacks (Windows-standard cache conventions), which fixes the tests AND makes the real tool behave correctly on Windows end-user installs.
+
 ### Windows-2022 CI gate (#420 stub)
 
 New `windows-cargo-check.yml` workflow runs `cargo check -p aegis-bootctl --all-targets` + `cargo test -p aegis-bootctl --locked` on a `windows-2022` GitHub-hosted runner. Catches MSVC-vs-GNU drift the cross-compile-from-Linux gate misses + exercises the 70+ new aegis-cli tests (pipeline, source_resolution, drive_enumeration, flash_dispatcher) on a real Windows host. Clippy runs with `continue-on-error` until the pre-existing Windows-gated-code backlog clears. First piece of the full #420 multi-OS matrix.

--- a/crates/aegis-cli/src/bug_report.rs
+++ b/crates/aegis-cli/src/bug_report.rs
@@ -1025,8 +1025,12 @@ mod tests {
           "failure_class": "kexec_failure",
           "failure_hash": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         }"#;
+        // Filename uses dashes not colons — NTFS forbids `:` in
+        // paths (reserved for alternate data streams). The
+        // collected_at JSON field still carries the ISO-8601 colon
+        // form; only the on-disk filename is Windows-safe.
         std::fs::write(
-            log_dir.join("2026-04-20T12:00:00Z-abcdef012345.json"),
+            log_dir.join("2026-04-20T12-00-00Z-abcdef012345.json"),
             valid,
         )
         .unwrap();

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -1378,15 +1378,21 @@ mod tests {
 
     #[test]
     fn check_command_present_with_pkg_finds_existing_binary() {
-        // `ls` is present on every supported platform's PATH — use
-        // it as a known-good probe to verify the Pass path of the
-        // pkg-aware variant.
+        // Known-good probe per platform — `ls` is universal on
+        // POSIX; `cmd` is present on every Windows install (including
+        // server runners). Using a platform-specific binary avoids
+        // `ls` not resolving via `where` on Windows (#502).
+        let probe = if cfg!(target_os = "windows") {
+            "cmd"
+        } else {
+            "ls"
+        };
         let mut r = Report::new();
-        check_command_present_with_pkg(&mut r, "ls", "coreutils", "canary");
+        check_command_present_with_pkg(&mut r, probe, "coreutils", "canary");
         assert_eq!(r.rows.len(), 1);
         assert!(
             matches!(r.rows[0].0, Verdict::Pass),
-            "expected Pass for `ls`, got {:?}",
+            "expected Pass for `{probe}`, got {:?}",
             r.rows[0].0
         );
         assert!(r.rows[0].2.contains("canary"));

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -1379,11 +1379,13 @@ mod tests {
     #[test]
     fn check_command_present_with_pkg_finds_existing_binary() {
         // Known-good probe per platform — `ls` is universal on
-        // POSIX; `cmd` is present on every Windows install (including
-        // server runners). Using a platform-specific binary avoids
-        // `ls` not resolving via `where` on Windows (#502).
+        // POSIX; `cmd.exe` is present on every Windows install. The
+        // `.exe` suffix is required because `crate::cmd_path::which`
+        // does not currently auto-append `PATHEXT` extensions on
+        // Windows (tracked as a separate improvement — the doctor
+        // surface for Windows operators is still a gap).
         let probe = if cfg!(target_os = "windows") {
-            "cmd"
+            "cmd.exe"
         } else {
             "ls"
         };

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -521,12 +521,27 @@ fn is_valid_sha256_hex(s: &str) -> bool {
 /// filename includes a sha256 prefix when one was supplied so distinct
 /// pinned images don't collide.
 fn default_cache_path(url: &str, expected_sha256: Option<&str>) -> Result<PathBuf, u8> {
+    // Lookup order: XDG_CACHE_HOME (POSIX dev convention) → HOME →
+    // LOCALAPPDATA (Windows cache convention) → USERPROFILE. The
+    // LOCALAPPDATA path is where Windows apps are supposed to put
+    // cache data per Microsoft's conventions; USERPROFILE is the
+    // last-resort fallback for old Windows versions / constrained
+    // runner environments where LOCALAPPDATA isn't exported.
     let cache_home = std::env::var_os("XDG_CACHE_HOME")
         .map(PathBuf::from)
         .or_else(|| {
             std::env::var_os("HOME").map(|h| {
                 let mut p = PathBuf::from(h);
                 p.push(".cache");
+                p
+            })
+        })
+        .or_else(|| std::env::var_os("LOCALAPPDATA").map(PathBuf::from))
+        .or_else(|| {
+            std::env::var_os("USERPROFILE").map(|u| {
+                let mut p = PathBuf::from(u);
+                p.push("AppData");
+                p.push("Local");
                 p
             })
         })


### PR DESCRIPTION
Closes #502. Broadens the #501 Windows CI gate to full 593-test suite.

## Fixes

- **bug_report**: filename had \`:\` in it (ISO-8601 timestamp), NTFS forbids. Renamed to dashes; JSON body still carries colon form.
- **doctor**: probed for \`ls\` in PATH. Picks \`cmd\` on Windows, \`ls\` elsewhere.
- **fetch_image::default_cache_path**: used XDG_CACHE_HOME/HOME only. Now also respects LOCALAPPDATA + USERPROFILE. Fixes 3 tests AND makes real tool work on Windows end-users.

## Workflow broadened

\`.github/workflows/windows-cargo-check.yml\`'s test step goes from narrowed \`cargo test -p aegis-bootctl windows_direct_install\` back to full \`cargo test -p aegis-bootctl --locked\`. Every future Windows PR now gets strict validation of all 593 tests.

## Test plan

- [x] \`cargo test -p aegis-bootctl --locked\` on Linux: 593 passed, 0 failed
- [x] \`cargo clippy -p aegis-bootctl --all-targets -- -D warnings\` — clean
- [x] \`cargo check -p aegis-bootctl --target x86_64-pc-windows-gnu\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI — full 593-test suite green on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)