### PR TITLE
chore(scorecard): pin all 76 GitHub Actions refs to SHAs

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -43,11 +43,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@main
-
+        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba  # main
       # Tap this repo first — `brew audit` no longer accepts paths;
       # it requires a tapped name. The first `brew tap <user>/<name>
       # <local-path>` also exercises what operators will type

--- a/.github/workflows/catalog-revalidate.yml
+++ b/.github/workflows/catalog-revalidate.yml
@@ -30,7 +30,6 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Run catalog-revalidate.sh
         run: bash scripts/catalog-revalidate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
       run:
         working-directory: crates/iso-parser
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install toolchain
         run: |
           rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt,clippy
           rustup override set ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: "crates/iso-parser -> target"
       - run: cargo fmt --check
@@ -42,14 +42,14 @@ jobs:
     name: aegis-cli (Linux + macOS + Windows cross-check)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: |
           rustup toolchain install 1.88.0 --profile minimal --component rustfmt,clippy
           rustup override set 1.88.0
           rustup target add x86_64-apple-darwin
           rustup target add x86_64-pc-windows-gnu
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Format + lint aegis-cli
         run: |
           cargo fmt --check
@@ -70,10 +70,10 @@ jobs:
     name: aegis-fitness audit
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Run fitness audit (threshold 80)
         # Stage 8 of dev-test.sh — repo + scripts + docs hygiene.
         # Threshold lowered from the dev-test default (90) to 80 because
@@ -87,11 +87,11 @@ jobs:
     name: cargo-deny (advisories + licenses + bans + sources)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       # Workspace-level policy enforced via deny.toml at the repo root.
       # Gates every PR + push-to-main so a dep-bump that pulls in a GPL /
       # AGPL / LGPL / unknown-license crate fails CI before merge.
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb  # v2
         with:
           command: check advisories licenses bans sources
 
@@ -99,7 +99,7 @@ jobs:
     name: Generate CycloneDX SBOM
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
       - name: Install cargo-cyclonedx
@@ -108,7 +108,7 @@ jobs:
         working-directory: crates/iso-parser
         run: cargo cyclonedx --format json
       - name: Upload SBOM
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: sbom-cyclonedx
           path: crates/iso-parser/**/*.cdx.json
@@ -119,7 +119,7 @@ jobs:
     name: Secret scanning (gitleaks)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -138,9 +138,9 @@ jobs:
       # setuptools 81+ removal leaves `latest` exposed to a sudden break).
       image: returntocorp/semgrep:1.160.0
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - run: semgrep scan --config=p/rust --config=p/security-audit --error --sarif --output semgrep.sarif .
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         if: always()
         with:
           name: semgrep-sarif
@@ -151,8 +151,8 @@ jobs:
     name: Nix flake smoke-build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: cachix/install-nix-action@v31
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b  # v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -174,7 +174,7 @@ jobs:
     name: Doc version drift-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - run: ./scripts/check-doc-version.sh
 
   # Shared-constants drift-check (Phase 2 of #288 / #286).
@@ -186,10 +186,10 @@ jobs:
     name: Doc constants drift-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p aegis-bootctl --bin constants-docgen --features docgen --locked -- --check
 
   # CLI subcommand + synopsis drift-check (Phase 3a + 3b of #289 / #286).
@@ -204,10 +204,10 @@ jobs:
     name: Doc CLI subcommand drift-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Build aegis-boot binary
         run: cargo build -p aegis-bootctl --release --locked
       - name: Check CLI doc drift
@@ -224,10 +224,10 @@ jobs:
     name: Manifest JSON schema drift-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p aegis-wire-formats --features schema --bin aegis-wire-formats-schema-docgen --locked -- --check
 
   # rescue-tui trust-tier + keybinding drift-check (Phase 7 of #455 / #462).
@@ -241,8 +241,8 @@ jobs:
     name: Doc trust-tier + keybinding drift-check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p rescue-tui --bin tiers-docgen --locked -- --check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,10 +53,9 @@ jobs:
         language: [rust, actions]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
         with:
           languages: ${{ matrix.language }}
           # security-extended + security-and-quality give us the full
@@ -70,7 +69,7 @@ jobs:
         if: matrix.language == 'rust'
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         if: matrix.language == 'rust'
 
       - name: Build workspace (Rust only)
@@ -78,6 +77,6 @@ jobs:
         run: cargo build --workspace --locked
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/crates-publish-dryrun.yml
+++ b/.github/workflows/crates-publish-dryrun.yml
@@ -35,15 +35,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust (pinned to workspace MSRV)
         run: |
           rustup toolchain install 1.88.0 --profile minimal
           rustup override set 1.88.0
 
-      - uses: Swatinem/rust-cache@v2
-
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: cargo publish --dry-run -p iso-parser
         # Zero unpublished path deps → registry resolution succeeds
         # without needing iso-parser on the real registry yet.

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -69,8 +69,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust toolchain (pinned)
         run: |
           rustup toolchain install 1.88.0 --profile minimal --no-self-update
@@ -78,7 +77,7 @@ jobs:
           rustc --version
 
       - name: Mint short-lived crates.io token (OIDC)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@63a7064947ceca9989005e118db3a5fecdc9259f  # v1
         id: cio_auth
 
       # Publish in dependency order: leaf crates first, then dependents.

--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -28,8 +28,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install signed boot chain + image tooling
         # Matches mkusb.yml's deps so the byte-parity diff has identical
         # source files for both paths. Adds util-linux for losetup +
@@ -230,7 +229,7 @@ jobs:
 
       - name: Upload direct-install image + boot log
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: direct-install-image
           path: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,12 +23,12 @@ jobs:
       matrix:
         target: [validate_path, distribution_from_paths]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install nightly toolchain
         run: |
           rustup toolchain install nightly --profile minimal
           rustup override set nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: "crates/iso-parser/fuzz -> target"
       - name: Install cargo-fuzz
@@ -40,7 +40,7 @@ jobs:
         run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=$DURATION
       - name: Upload crashes on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: fuzz-crashes-${{ matrix.target }}
           path: |

--- a/.github/workflows/initramfs.yml
+++ b/.github/workflows/initramfs.yml
@@ -16,8 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
-
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -70,7 +69,7 @@ jobs:
           fi
 
       - name: Upload initramfs artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: initramfs
           path: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,8 +17,7 @@ jobs:
       AEGIS_INTEGRATION_ROOT: "1"
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install build + fixture tools
         run: |
           sudo apt-get update

--- a/.github/workflows/kexec-e2e.yml
+++ b/.github/workflows/kexec-e2e.yml
@@ -19,8 +19,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install runtime + fixture-build tools
         run: |
           sudo apt-get update

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -40,8 +40,7 @@ jobs:
     name: lychee markdown link check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       # lychee-action@v2 is the official maintained wrapper. Pinned
       # to a SHA-specific tag to avoid supply-chain surprises on the
       # scheduled cadence. Bump the ref when upstream ships a stable
@@ -54,7 +53,7 @@ jobs:
       # exclude in the same PR that tags the first 1.0.0 publish.
       - name: Run lychee
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
         env:
           # github.com responds 500 to unauthenticated link-check
           # requests under rate-limit pressure. Passing the default
@@ -94,7 +93,7 @@ jobs:
       # is the signal).
       - name: Create issue on broken-link rot (scheduled only)
         if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != '0'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd  # v5
         with:
           title: "linkcheck: broken links surfaced on scheduled scan"
           content-filepath: ./lychee-report.md
@@ -104,7 +103,7 @@ jobs:
 
       - name: Upload report as artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: lychee-report
           path: ./lychee-report.md

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -34,10 +34,10 @@ jobs:
     name: cargo-machete
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
         run: rustup toolchain install 1.88.0 --profile minimal && rustup override set 1.88.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       # Pinned version = what we tested locally (0.9.2). Bump via
       # Dependabot when upstream ships a new release. Install via
       # `cargo install` rather than a third-party Action to keep the

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -86,8 +86,7 @@ jobs:
             test-args: "-p aegis-wire-formats --lib"
             informational: true
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust nightly + miri
         # Miri only ships on nightly. Pinning the toolchain name, not
         # a specific date, so we track the rolling nightly — but we'll
@@ -96,7 +95,7 @@ jobs:
           rustup toolchain install nightly --profile minimal --component miri
           rustup override set nightly
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: miri-${{ matrix.crate }}
 

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -23,8 +23,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install signed boot chain + image tooling
         run: |
           sudo apt-get update
@@ -102,7 +101,7 @@ jobs:
           fi
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: aegis-boot-img
           path: |

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -21,8 +21,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install QEMU + OVMF (with MS-enrolled vars)
         run: |
           sudo apt-get update
@@ -44,8 +43,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install signed boot chain + tooling
         run: |
           sudo apt-get update

--- a/.github/workflows/qemu-smoke.yml
+++ b/.github/workflows/qemu-smoke.yml
@@ -16,8 +16,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install QEMU + kernel + initramfs toolchain
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
           "$HOME/.cargo/bin/rustup" target add x86_64-unknown-linux-musl
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
         with:
           cosign-release: "v2.4.1"
 
@@ -316,7 +316,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
@@ -341,7 +341,7 @@ jobs:
           "$HOME/.cargo/bin/rustc" -vV | grep '^host: aarch64-apple-darwin$'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
         with:
           cosign-release: "v2.4.1"
 
@@ -433,7 +433,7 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           ref: main
           # Token with write — the default GITHUB_TOKEN suffices because

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -21,8 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
-
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Build image
         run: docker build -t aegis-boot:builder -f Dockerfile.locked .
 
@@ -68,7 +67,7 @@ jobs:
 
       - name: Upload verification artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: build-hashes
           path: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,12 +47,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde  # v2.4.2
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
@@ -65,7 +65,7 @@ jobs:
       # Keep the raw SARIF as a workflow artifact — useful for local
       # drilldown when a check regresses.
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: scorecard-sarif
           path: scorecard-results.sarif
@@ -75,6 +75,6 @@ jobs:
       # SARIF (same code-scanning pane). Each Scorecard check becomes
       # an entry there when it's non-passing.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
         with:
           sarif_file: scorecard-results.sarif

--- a/.github/workflows/sign-identity-transition.yml
+++ b/.github/workflows/sign-identity-transition.yml
@@ -46,11 +46,9 @@ jobs:
           echo "Must type 'SIGN' in the workflow_dispatch input to proceed." >&2
           exit 1
 
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
-
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
       - name: Sign identity-transition.json
         run: |
           cosign sign-blob --yes \

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -27,11 +27,10 @@ jobs:
     name: typos
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       # crate-ci/typos-action is the upstream-maintained wrapper around
       # the typos CLI. Pinned version = 1.45.1 to match the typos-cli
       # version developers are expected to install locally. Bump both
       # together via Dependabot.
       - name: Run typos
-        uses: crate-ci/typos@v1.45.1
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83  # v1.45.1

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -29,8 +29,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install deps (QEMU + OVMF + signed boot chain + tooling)
         run: |
           sudo apt-get update
@@ -170,7 +169,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: update-rotate-artifacts
           path: |

--- a/.github/workflows/windows-cargo-check.yml
+++ b/.github/workflows/windows-cargo-check.yml
@@ -77,8 +77,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
-
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust (MSRV pinned — matches Linux CI)
         # Match the exact MSRV the rest of CI pins to so a Windows
         # pass here means Linux will agree on the toolchain surface.
@@ -86,7 +85,7 @@ jobs:
           rustup toolchain install 1.88.0 --profile minimal --component clippy
           rustup default 1.88.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           # Separate cache key from the Linux jobs — MSVC artifacts
           # don't share with Linux GNU artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ## [Unreleased]
 
+### Pin all GitHub Actions refs to SHAs (Scorecard `Pinned-Dependencies`)
+
+76 action-ref pins across 24 workflows. Every `uses:` reference is now `repo@<40-char-sha>  # <tag>` form — a transactional constant that supply-chain attackers can't retroactively retarget via tag-move. Closes the 72 `Pinned-Dependencies` + 24 `actions/unpinned-tag` Scorecard / CodeQL findings raised by #490 + #488. Dependabot's `github-actions` package-ecosystem config (from #490) already auto-bumps both the SHA + the trailing comment on new releases, so this is zero operational overhead.
+
 ### Windows `PATHEXT` support in `cmd_path::which` (#504)
 
 `crate::cmd_path::which` now auto-appends `PATHEXT` extensions on Windows so operators can type `aegis-boot doctor` and see `cosign` / `curl` / `diskpart` resolve without having to spell out `.exe`. On POSIX the stem is used verbatim (no extension auto-append) — preserving existing Linux behavior.


### PR DESCRIPTION
Clears the 72 \`Pinned-Dependencies\` + 24 \`actions/unpinned-tag\` Scorecard / CodeQL findings raised after #490 turned the supply-chain workflow on.

## What changes

76 action references across 24 workflow files converted from tag-only (\`actions/checkout@v5\`) to \`REPO@<40-char-sha>  # TAG\` form. Every \`uses:\` in \`.github/workflows/\` is now content-addressable.

## Why pin

Tag refs resolve dynamically at job run time. If a supply-chain attacker gets write access to \`actions/checkout\` and retargets \`v5\` at a malicious commit, every CI run pulls the backdoor. A pinned SHA is a content-addressable constant — attacker has to break SHA-1 on a commit authored by a trusted maintainer to pivot it.

## How pins stay current

Dependabot's \`github-actions\` package-ecosystem config (from #490) watches these. On each action release, Dependabot opens a PR rewriting both the SHA and the trailing comment. Zero operational overhead vs unpinned tags.

## Test plan

- [x] Verification grep shows zero residual unpinned refs
- [ ] CI — every pinned SHA actually resolves; workflows still run as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)