### PR TITLE
chore(keys): add maintainer epoch-1 minisign keypair (ADR 0002)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ test-isos/
 # commit.
 crates/aegis-cli/CHANGELOG.md
 crates/aegis-cli/man/
+
+# Secret-key material — must never be committed. Public keys + epoch
+# metadata live in keys/ and are tracked; secret keys live in the
+# maintainer's password-store (outside the repo). See
+# docs/architecture/KEY_MANAGEMENT.md (ADR 0002).
+keys/*.key
+keys/*.key.*
+keys/maintainer-epoch-*.key

--- a/keys/canonical-epoch.json
+++ b/keys/canonical-epoch.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "epoch": 1,
+  "anchor": "sha256:139baf8e741e3159b7891870fd78f4be48663ea8eef2e960ad15199b078da66e",
+  "note": "Epoch 1 — initial maintainer-held minisign keypair. Generated 2026-04-24T14:09:30-04:00. Secret key + passphrase + proof-of-control canary are stored in maintainer's pass at aegis-boot/epoch-1/{secret-key,passphrase,canary-txt,canary-sig}. See docs/architecture/KEY_MANAGEMENT.md (ADR 0002)."
+}

--- a/keys/historical-anchors.json
+++ b/keys/historical-anchors.json
@@ -1,0 +1,10 @@
+[
+  {
+    "epoch": 1,
+    "pubkey_file": "keys/maintainer-epoch-1.pub",
+    "pubkey_fingerprint": "RWSldhpvdTOXAKMBeOheDkE8N2rCPsD9Duct4n2ToDOf/cRqRijjpF/I",
+    "valid_from": "2026-04-24T14:09:30-04:00",
+    "expires_at": null,
+    "note": "Initial maintainer-held key, solo-maintainer epoch. No scheduled rotation; rotate only on compromise per ADR 0002 §3.4."
+  }
+]

--- a/keys/maintainer-epoch-1.pub
+++ b/keys/maintainer-epoch-1.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 9733756F1A76A5
+RWSldhpvdTOXAKMBeOheDkE8N2rCPsD9Duct4n2ToDOf/cRqRijjpF/I


### PR DESCRIPTION
Generates the epoch-1 trust anchor ADR 0002 / #421 requires.

## Files landing

- \`keys/maintainer-epoch-1.pub\` — minisign public key, committed
- \`keys/canonical-epoch.json\` — \`{ epoch: 1, anchor: sha256:139baf8e… }\`
- \`keys/historical-anchors.json\` — append-only epoch log
- \`.gitignore\` — defensive block on \`keys/*.key*\`

## Secret-key custody

Secret key is maintainer-held + passphrase-protected at the minisign layer. At-rest storage is in \`pass\` at \`aegis-boot/epoch-1/{secret-key,passphrase,canary-txt,canary-sig}\`, encrypted under a fresh GPG keypair generated in the same session. (The prior GPG keypair's passphrase was forgotten; \`~/.password-store\` was rebuilt. CredHub + r910's \`creds.yml\` held the source-of-truth for all existing pass entries, so the rebuild was lossless.)

A recovery bundle (GPG pubkey + revocation cert + passphrase + README) lives at \`~/Downloads/pass-recovery/\` on the maintainer's workstation until the maintainer moves it to durable offline storage.

## Validation

End-to-end verified:

1. Canary \`aegis-boot epoch-1 canary, generated 2026-04-24T14:08:06-04:00 by william@framework\` was signed with the freshly-generated key.
2. The same canary verified against \`keys/maintainer-epoch-1.pub\` — the same public key committed in this PR.
3. Round-trip after pass-rebuild: retrieved the secret key + passphrase via \`pass show aegis-boot/epoch-1/{secret-key,passphrase}\`, signed a fresh canary, verified against the same pubkey. Exit 0 + "Signature and comment signature verified".

## Unblocks

- #421 — runtime trust-anchor loader can \`include_bytes!(\"../../keys/maintainer-epoch-1.pub\")\` at build time.
- #417 — Rufus-style \`DownloadSignedFile\` pattern can verify the bundle manifest against this key.
- #487 — SLSA provenance test release cut has a trust root to sign against.

## Test plan

- [x] minisign signed + verified canary round-trips under the new key
- [x] \`cargo test -p aegis-bootctl --locked\` still green (no code paths touched — docs/keys only)
- [ ] CI — no workflows consume \`keys/\` yet, so this should be green on the usual gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)