### PR TITLE
feat(aegis-trust): new crate — ADR 0002 runtime trust anchor (#421 PR A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aegis-trust"
+version = "0.17.0"
+dependencies = [
+ "minisign",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "aegis-wire-formats"
 version = "0.17.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kexec-loader",
     "crates/aegis-fitness",
     "crates/aegis-cli",
+    "crates/aegis-trust",
     "crates/aegis-wire-formats",
 ]
 exclude = ["crates/iso-parser/fuzz"]

--- a/crates/aegis-trust/Cargo.toml
+++ b/crates/aegis-trust/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "aegis-trust"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ADR 0002 runtime trust anchor for aegis-boot — epoch-aware minisign verification + monotonic seen-epoch state"
+readme = "README.md"
+
+# Files packaged for `cargo publish`. `keys/` and the workspace
+# `Cargo.toml` live outside the crate dir, so include paths via
+# `include =` don't apply — `build.rs` resolves them via workspace
+# discovery at compile time. See `build.rs` for the path chain.
+include = ["src/**/*", "build.rs", "README.md", "Cargo.toml"]
+
+[lib]
+
+[dependencies]
+minisign = { version = "0.9", default-features = false }
+serde = { workspace = true }
+serde_json = "1.0"
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.14"
+
+[lints]
+workspace = true

--- a/crates/aegis-trust/README.md
+++ b/crates/aegis-trust/README.md
@@ -1,0 +1,32 @@
+# aegis-trust
+
+Runtime trust anchor for aegis-boot — the Rust library that implements [ADR 0002](../../docs/architecture/KEY_MANAGEMENT.md)'s epoch-aware minisign verification model.
+
+## What it is
+
+A small, focused crate (~400 LOC + tests) that answers two questions at runtime:
+
+1. **Is this signed body trustworthy?** — `TrustAnchor::verify_with_epoch(body, sig, epoch)` runs the rotation-aware check: epoch is at or above the binary-embedded floor, at or above the locally-seen floor, and the signature verifies under the epoch's pubkey.
+2. **What's the current epoch floor?** — `TrustAnchor::current_floor()` returns `max(MIN_REQUIRED_EPOCH, seen_epoch)`, the value the binary refuses to accept below.
+
+## Who uses it
+
+- **#417** — runtime signed-chain downloader; verifies the bundle manifest before flashing.
+- **#349 successor** — attestation manifest verify path; migrates off the bare `minisign::PublicKey` handle.
+- **`aegis-boot doctor`** — surfaces binary + local + remote epoch values and flags drift.
+
+## What it reads at build time
+
+- `keys/canonical-epoch.json` — the workspace-root file committed alongside `keys/maintainer-epoch-1.pub`. `build.rs` reads the `epoch` field and emits it as `AEGIS_MIN_REQUIRED_EPOCH`, which the crate exposes as `pub const MIN_REQUIRED_EPOCH: u32`.
+
+## What it reads at runtime
+
+- `keys/historical-anchors.json` — embedded via `include_str!` at build time so the binary ships the full epoch history without file-system dependencies.
+- `keys/maintainer-epoch-<N>.pub` — each epoch's pubkey is embedded the same way.
+- `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch` — read-and-written at verify time; monotonic u32.
+
+## What it does NOT do
+
+- Key generation (maintainer tooling; see `docs/architecture/KEY_MANAGEMENT.md`).
+- Network fetches to validate freshness against a canonical source (tracked as a follow-up once a public trust-anchor-status endpoint exists).
+- Sign anything — only verify.

--- a/crates/aegis-trust/build.rs
+++ b/crates/aegis-trust/build.rs
@@ -1,0 +1,138 @@
+// Build scripts fail the build via panic on error — the workspace-
+// wide `unwrap_used`/`expect_used = deny` is inappropriate here (a
+// build-time panic IS the correct failure mode).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Reads `keys/canonical-epoch.json` at build time and emits
+//! `cargo:rustc-env=AEGIS_MIN_REQUIRED_EPOCH=<N>` so the crate can
+//! `env!("AEGIS_MIN_REQUIRED_EPOCH")` into a compile-time `u32`
+//! constant (`MIN_REQUIRED_EPOCH`).
+//!
+//! Also emits a `cargo:rerun-if-changed` directive so bumping the
+//! epoch in-repo forces a rebuild of anything that consumes the
+//! constant (the binary, the tests, any downstream crate).
+//!
+//! Path resolution walks up from `CARGO_MANIFEST_DIR` until it finds
+//! a `keys/canonical-epoch.json` file — same discovery pattern as
+//! `aegis-cli/build.rs` uses for the CHANGELOG. Works for the
+//! normal in-workspace build (`keys/` at workspace root, two dirs
+//! up from `crates/aegis-trust/`), for the `cargo publish`-packaged
+//! tarball (we bail gracefully if no keys/ is found), and for
+//! out-of-tree consumers via `cargo install --path` (same-workspace
+//! discovery still works).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+
+    // Walk up from the manifest dir looking for `keys/canonical-epoch.json`.
+    // 5 levels is enough for any plausible workspace layout.
+    let mut probe = manifest.clone();
+    let mut found: Option<PathBuf> = None;
+    for _ in 0..5 {
+        let candidate = probe.join("keys").join("canonical-epoch.json");
+        if candidate.is_file() {
+            found = Some(candidate);
+            break;
+        }
+        if !probe.pop() {
+            break;
+        }
+    }
+
+    // Locating via the workspace root is the common path; if we're being
+    // built from a published crate tarball with no `keys/` adjacent,
+    // fall back to emitting epoch=0 so downstream code can at least
+    // compile. Consumers of the out-of-workspace build are responsible
+    // for using the `AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE` env var at
+    // build time; the fallback-to-0 default is a deliberate "unsafe
+    // default" marker that the runtime can detect and refuse.
+    let epoch: u64 = match (
+        std::env::var("AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE"),
+        found.as_ref(),
+    ) {
+        (Ok(v), _) => v
+            .parse()
+            .expect("AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE must parse as u64"),
+        (Err(_), Some(p)) => parse_epoch_json(p),
+        (Err(_), None) => {
+            // Emit a build warning so the operator sees the fallback path.
+            println!(
+                "cargo:warning=aegis-trust: no keys/canonical-epoch.json found in parent tree; \
+                 AEGIS_MIN_REQUIRED_EPOCH defaulting to 0 (unsafe). Set \
+                 AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE=<N> in the environment to override."
+            );
+            0
+        }
+    };
+
+    assert!(
+        u32::try_from(epoch).is_ok(),
+        "epoch {epoch} does not fit in u32"
+    );
+    println!("cargo:rustc-env=AEGIS_MIN_REQUIRED_EPOCH={epoch}");
+
+    if let Some(path) = found.as_ref() {
+        // Re-run the build script if the canonical-epoch file changes.
+        // Absolute path because cargo's rerun-if-changed resolves
+        // relative to the crate root, not the workspace root.
+        println!("cargo:rerun-if-changed={}", path.display());
+
+        // Also re-run if the historical-anchors file changes — our
+        // runtime-loaded list. build.rs doesn't consume it directly,
+        // but downstream code pulls it via include_str!, which cargo
+        // doesn't track automatically.
+        if let Some(anchors) = path.parent().map(|p| p.join("historical-anchors.json")) {
+            if anchors.is_file() {
+                println!("cargo:rerun-if-changed={}", anchors.display());
+            }
+        }
+    }
+
+    // The workspace root path is needed at compile time by `include_str!`
+    // calls in the source (for the pubkey + historical-anchors files).
+    // Emit it as an env var so the source can `concat!(env!("AEGIS_KEYS_DIR"), "/...")`.
+    let keys_dir = found
+        .as_ref()
+        .and_then(|p| p.parent())
+        .map_or_else(|| manifest.join("../../keys"), Path::to_path_buf);
+    println!("cargo:rustc-env=AEGIS_KEYS_DIR={}", keys_dir.display());
+}
+
+/// Naive JSON scanner for the specific shape
+/// `"epoch":\s*<integer>` — avoids pulling `serde_json` into the
+/// build-script dep graph. The file is maintainer-authored from a
+/// template; the shape is stable (see `keys/canonical-epoch.json`).
+/// Rejects anything ambiguous (multiple `epoch` keys, missing value).
+fn parse_epoch_json(path: &Path) -> u64 {
+    let body = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let mut matches: Vec<u64> = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        // Match lines like `"epoch": 1,` or `"epoch":1`
+        if let Some(rest) = trimmed.strip_prefix("\"epoch\"") {
+            let after_colon = rest
+                .trim_start()
+                .strip_prefix(':')
+                .unwrap_or_else(|| panic!("malformed `epoch` line in {}: {line}", path.display()))
+                .trim()
+                .trim_end_matches(',')
+                .trim();
+            let n: u64 = after_colon.parse().unwrap_or_else(|e| {
+                panic!("parse epoch value in {} ({line}): {e}", path.display())
+            });
+            matches.push(n);
+        }
+    }
+    match matches.as_slice() {
+        [e] => *e,
+        [] => panic!("{} has no `\"epoch\":` line", path.display()),
+        more => panic!(
+            "{} has {} `\"epoch\":` lines; expected exactly 1",
+            path.display(),
+            more.len()
+        ),
+    }
+}

--- a/crates/aegis-trust/src/anchor.rs
+++ b/crates/aegis-trust/src/anchor.rs
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Build-time-embedded trust anchor + runtime verify.
+//!
+//! The anchor is NOT read from disk at runtime — both the epoch
+//! history (`historical-anchors.json`) and each epoch's pubkey
+//! (`maintainer-epoch-<N>.pub`) are baked in via `include_str!` at
+//! build time. That means:
+//!
+//!   * The binary ships a self-contained trust chain that cannot be
+//!     silently swapped by a filesystem attacker.
+//!   * Rotating keys (new epoch) requires a new binary release —
+//!     exactly the property ADR 0002 §3.4 demands.
+//!   * The `keys/` directory on disk is the maintainer-facing source
+//!     of truth, consumed by `build.rs`; operators don't need it.
+
+use minisign::{PublicKeyBox, SignatureBox};
+use serde::Deserialize;
+
+use crate::errors::TrustAnchorError;
+
+/// One epoch's entry from `keys/historical-anchors.json`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct EpochEntry {
+    /// Monotonic u32. Epoch 1 is the initial maintainer-held key.
+    pub epoch: u32,
+    /// Path the pubkey lives at in the repo. Informational — the
+    /// crate doesn't resolve it at runtime (pubkey bytes are
+    /// `include_str!`-embedded instead).
+    pub pubkey_file: String,
+    /// The pubkey's base64 line (second line of a minisign `.pub` file).
+    /// This is the canonical on-wire identifier.
+    pub pubkey_fingerprint: String,
+    /// RFC3339 timestamp of when this epoch was declared valid.
+    pub valid_from: String,
+    /// RFC3339 timestamp of expiry, or `null` for "valid until
+    /// superseded by a later epoch."
+    pub expires_at: Option<String>,
+    /// Free-text maintainer note.
+    #[serde(default)]
+    pub note: String,
+}
+
+/// The built-in historical-anchors list, embedded at build time.
+/// `AEGIS_KEYS_DIR` points at the workspace's `keys/` directory.
+const EMBEDDED_ANCHORS_JSON: &str =
+    include_str!(concat!(env!("AEGIS_KEYS_DIR"), "/historical-anchors.json"));
+
+/// Epoch-1 pubkey, the only one for the initial release. When a
+/// new epoch is minted, add a corresponding `include_str!` line
+/// below and a matching branch in [`TrustAnchor::pubkey_for_epoch`].
+/// This is deliberately NOT loaded dynamically — every epoch must
+/// be a reviewed, committed change to this file.
+const EMBEDDED_EPOCH_1_PUB: &str =
+    include_str!(concat!(env!("AEGIS_KEYS_DIR"), "/maintainer-epoch-1.pub"));
+
+/// Runtime trust anchor. Holds the parsed epoch history + a view of
+/// the binary's `MIN_REQUIRED_EPOCH`.
+///
+/// Cheap to construct: no I/O, no network. [`TrustAnchor::load`]
+/// exists as a single-call setup for callers that want to handle
+/// the (rare) embedded-JSON-parse-failure case.
+#[derive(Debug, Clone)]
+pub struct TrustAnchor {
+    epochs: Vec<EpochEntry>,
+    min_required: u32,
+}
+
+impl TrustAnchor {
+    /// Parse the build-time-embedded anchor list.
+    ///
+    /// # Errors
+    ///
+    /// - [`TrustAnchorError::UnsafeDefaultEpoch`] if the binary was
+    ///   compiled without a discoverable `keys/canonical-epoch.json`
+    ///   (sentinel value `MIN_REQUIRED_EPOCH == 0`).
+    /// - [`TrustAnchorError::AnchorsParseFailure`] if the embedded
+    ///   `historical-anchors.json` couldn't deserialize.
+    pub fn load() -> Result<Self, TrustAnchorError> {
+        Self::load_with_floor(crate::MIN_REQUIRED_EPOCH)
+    }
+
+    /// Testing/injection hook: build a `TrustAnchor` with an explicit
+    /// `min_required` floor instead of the binary-embedded constant.
+    /// Production callers should use [`TrustAnchor::load`].
+    ///
+    /// # Errors
+    ///
+    /// Same as [`TrustAnchor::load`].
+    pub fn load_with_floor(min_required: u32) -> Result<Self, TrustAnchorError> {
+        if min_required == 0 {
+            return Err(TrustAnchorError::UnsafeDefaultEpoch);
+        }
+        let epochs: Vec<EpochEntry> = serde_json::from_str(EMBEDDED_ANCHORS_JSON)
+            .map_err(|e| TrustAnchorError::AnchorsParseFailure(e.to_string()))?;
+        Ok(Self {
+            epochs,
+            min_required,
+        })
+    }
+
+    /// Returns the binary-embedded `MIN_REQUIRED_EPOCH` this anchor
+    /// was loaded with. Exposed so doctor-style surfaces can show it
+    /// without reaching through to the crate-level constant.
+    #[must_use]
+    pub fn min_required(&self) -> u32 {
+        self.min_required
+    }
+
+    /// Read-only view of the embedded epoch history.
+    #[must_use]
+    pub fn epochs(&self) -> &[EpochEntry] {
+        &self.epochs
+    }
+
+    /// Lookup a specific epoch's metadata.
+    #[must_use]
+    pub fn epoch(&self, epoch: u32) -> Option<&EpochEntry> {
+        self.epochs.iter().find(|e| e.epoch == epoch)
+    }
+
+    /// Resolve the minisign pubkey bytes for the given epoch.
+    ///
+    /// Currently only epoch 1 is hard-wired (the initial release);
+    /// adding epoch 2 means adding a second `include_str!` branch
+    /// below plus the corresponding `keys/maintainer-epoch-2.pub`
+    /// file. That edit is the reviewed moment ADR 0002 gates
+    /// rotation on — no dynamic lookup by design.
+    fn pubkey_for_epoch(epoch: u32) -> Option<&'static str> {
+        match epoch {
+            1 => Some(EMBEDDED_EPOCH_1_PUB),
+            _ => None,
+        }
+    }
+
+    /// Core verify. Runs the full rotation-aware check:
+    ///
+    ///   1. `payload_epoch >= self.min_required` (binary floor).
+    ///   2. `payload_epoch >= seen_epoch` (local install floor).
+    ///   3. `payload_epoch` is registered in the embedded anchor list.
+    ///   4. The embedded pubkey for that epoch validates `sig` over `body`.
+    ///
+    /// Returns the matched [`EpochEntry`] on success so callers can
+    /// log the epoch they trusted (useful in audit trails).
+    ///
+    /// # Errors
+    ///
+    /// One of [`TrustAnchorError::EpochBelowBinaryFloor`],
+    /// [`TrustAnchorError::EpochBelowSeenFloor`],
+    /// [`TrustAnchorError::UnknownEpoch`],
+    /// [`TrustAnchorError::PubkeyParseFailure`], or
+    /// [`TrustAnchorError::SignatureInvalid`] — distinct variants
+    /// let callers render distinct operator messages.
+    pub fn verify_with_epoch(
+        &self,
+        body: &[u8],
+        sig: &[u8],
+        payload_epoch: u32,
+        seen_epoch: u32,
+    ) -> Result<&EpochEntry, TrustAnchorError> {
+        if payload_epoch < self.min_required {
+            return Err(TrustAnchorError::EpochBelowBinaryFloor {
+                payload_epoch,
+                required: self.min_required,
+            });
+        }
+        if payload_epoch < seen_epoch {
+            return Err(TrustAnchorError::EpochBelowSeenFloor {
+                payload_epoch,
+                seen_epoch,
+            });
+        }
+
+        let entry = self
+            .epoch(payload_epoch)
+            .ok_or(TrustAnchorError::UnknownEpoch { payload_epoch })?;
+
+        let pubkey_text = Self::pubkey_for_epoch(payload_epoch)
+            .ok_or(TrustAnchorError::UnknownEpoch { payload_epoch })?;
+        let pk_box = PublicKeyBox::from_string(pubkey_text).map_err(|e| {
+            TrustAnchorError::PubkeyParseFailure {
+                epoch: payload_epoch,
+                detail: e.to_string(),
+            }
+        })?;
+        let pk = pk_box
+            .into_public_key()
+            .map_err(|e| TrustAnchorError::PubkeyParseFailure {
+                epoch: payload_epoch,
+                detail: e.to_string(),
+            })?;
+
+        let sig_box = SignatureBox::from_string(std::str::from_utf8(sig).map_err(|e| {
+            TrustAnchorError::SignatureInvalid {
+                payload_epoch,
+                detail: format!("signature bytes are not UTF-8: {e}"),
+            }
+        })?)
+        .map_err(|e| TrustAnchorError::SignatureInvalid {
+            payload_epoch,
+            detail: e.to_string(),
+        })?;
+
+        let mut cursor = std::io::Cursor::new(body);
+        minisign::verify(&pk, &sig_box, &mut cursor, true, false, false).map_err(|e| {
+            TrustAnchorError::SignatureInvalid {
+                payload_epoch,
+                detail: e.to_string(),
+            }
+        })?;
+
+        Ok(entry)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_anchors_parse() {
+        let anchor = TrustAnchor::load_with_floor(1).unwrap();
+        assert!(
+            !anchor.epochs().is_empty(),
+            "need at least epoch 1 registered"
+        );
+        let e1 = anchor.epoch(1).expect("epoch 1 must exist");
+        assert_eq!(e1.epoch, 1);
+        assert!(
+            e1.pubkey_fingerprint.starts_with("RWS"),
+            "minisign fingerprints start with RWS, got {:?}",
+            e1.pubkey_fingerprint
+        );
+    }
+
+    #[test]
+    fn unsafe_default_epoch_rejected_at_load() {
+        let err = TrustAnchor::load_with_floor(0).unwrap_err();
+        assert_eq!(err, TrustAnchorError::UnsafeDefaultEpoch);
+    }
+
+    #[test]
+    fn verify_refuses_payload_below_binary_floor() {
+        // Pin floor at 5; payload claims epoch 1 → below floor.
+        let anchor = TrustAnchor::load_with_floor(5).unwrap();
+        let err = anchor
+            .verify_with_epoch(b"body", b"sig-does-not-matter", 1, 0)
+            .unwrap_err();
+        match err {
+            TrustAnchorError::EpochBelowBinaryFloor {
+                payload_epoch: 1,
+                required: 5,
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_refuses_payload_below_seen_floor() {
+        // Binary floor 1, but local seen_epoch has advanced to 7.
+        // Payload claims epoch 3 → below seen.
+        let anchor = TrustAnchor::load_with_floor(1).unwrap();
+        let err = anchor.verify_with_epoch(b"body", b"sig", 3, 7).unwrap_err();
+        match err {
+            TrustAnchorError::EpochBelowSeenFloor {
+                payload_epoch: 3,
+                seen_epoch: 7,
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_refuses_unknown_epoch() {
+        // Only epoch 1 is registered. Payload claims epoch 9.
+        let anchor = TrustAnchor::load_with_floor(1).unwrap();
+        let err = anchor.verify_with_epoch(b"body", b"sig", 9, 0).unwrap_err();
+        match err {
+            TrustAnchorError::UnknownEpoch { payload_epoch: 9 } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_refuses_malformed_signature() {
+        let anchor = TrustAnchor::load_with_floor(1).unwrap();
+        let err = anchor
+            .verify_with_epoch(b"body", b"not a valid minisig", 1, 0)
+            .unwrap_err();
+        match err {
+            TrustAnchorError::SignatureInvalid {
+                payload_epoch: 1, ..
+            } => {}
+            other => panic!("wrong error: {other:?}"),
+        }
+    }
+
+    /// End-to-end: sign a body with the committed epoch-1 secret
+    /// key, verify it through the `TrustAnchor`. Uses the actual
+    /// in-repo key material, so this test is the closest thing to
+    /// the production flow we can do without `pass show`.
+    ///
+    /// Gated on `AEGIS_TRUST_E2E_SECRET_KEY` (a path to the decrypted
+    /// secret-key file) + `AEGIS_TRUST_E2E_PASSPHRASE` (the minisign
+    /// passphrase). CI doesn't set these, so the test auto-skips;
+    /// the maintainer runs it via `pass show ... | tee` pipeline.
+    #[test]
+    #[ignore = "requires maintainer key material via AEGIS_TRUST_E2E_SECRET_KEY + AEGIS_TRUST_E2E_PASSPHRASE"]
+    fn verify_roundtrip_against_committed_key() {
+        use std::env;
+        use std::fs;
+        let (Ok(key_path), Ok(passphrase)) = (
+            env::var("AEGIS_TRUST_E2E_SECRET_KEY"),
+            env::var("AEGIS_TRUST_E2E_PASSPHRASE"),
+        ) else {
+            eprintln!("AEGIS_TRUST_E2E_* unset — skipping");
+            return;
+        };
+        let raw = fs::read_to_string(&key_path).unwrap();
+        let sk_box = minisign::SecretKeyBox::from_string(&raw).unwrap();
+        let sk = sk_box.into_secret_key(Some(passphrase)).unwrap();
+
+        let body = b"aegis-trust verify-roundtrip canary";
+        let sig_box =
+            minisign::sign(None, &sk, &mut std::io::Cursor::new(body), None, None).expect("sign");
+        let sig_str = sig_box.into_string();
+
+        let anchor = TrustAnchor::load_with_floor(1).unwrap();
+        let entry = anchor
+            .verify_with_epoch(body, sig_str.as_bytes(), 1, 0)
+            .expect("verify");
+        assert_eq!(entry.epoch, 1);
+    }
+}

--- a/crates/aegis-trust/src/errors.rs
+++ b/crates/aegis-trust/src/errors.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use thiserror::Error;
+
+/// Every way the trust-anchor layer can refuse to validate a signed
+/// body. Each variant corresponds to a specific failure mode ADR 0002
+/// calls out; surfacing distinct variants lets callers render distinct
+/// operator messages (`aegis-boot doctor` uses the variant type as
+/// the row category).
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TrustAnchorError {
+    /// Build-time discovery of `keys/canonical-epoch.json` failed and
+    /// the binary was compiled against the epoch=0 fallback sentinel.
+    /// Verification must refuse — the embedded `MIN_REQUIRED_EPOCH`
+    /// doesn't reflect a real trust root.
+    #[error(
+        "binary was built with AEGIS_MIN_REQUIRED_EPOCH=0 (the unsafe-default sentinel). \
+         Rebuild in-workspace, or set AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE=<N> at build time."
+    )]
+    UnsafeDefaultEpoch,
+
+    /// The epoch carried in a signed payload is below the binary's
+    /// embedded `MIN_REQUIRED_EPOCH` floor. Refuse — the signer is
+    /// claiming a key we no longer trust.
+    #[error("payload epoch {payload_epoch} is below binary floor (MIN_REQUIRED_EPOCH={required})")]
+    EpochBelowBinaryFloor {
+        /// Epoch the payload claimed.
+        payload_epoch: u32,
+        /// The binary's built-in `MIN_REQUIRED_EPOCH` floor.
+        required: u32,
+    },
+
+    /// The epoch is below the local install's monotonic `seen_epoch`
+    /// counter. Refuse — someone is trying to roll back to an older
+    /// key-epoch than this install has already accepted something from.
+    #[error("payload epoch {payload_epoch} is below locally-seen floor (seen_epoch={seen_epoch})")]
+    EpochBelowSeenFloor {
+        /// Epoch the payload claimed.
+        payload_epoch: u32,
+        /// Monotonic `seen_epoch` value from the local state file.
+        seen_epoch: u32,
+    },
+
+    /// No entry in `historical-anchors.json` matches the claimed
+    /// epoch. Either the payload is forged or the binary is out of
+    /// date with the canonical anchor list.
+    #[error("no trust anchor registered for epoch {payload_epoch}")]
+    UnknownEpoch {
+        /// Epoch the payload claimed.
+        payload_epoch: u32,
+    },
+
+    /// The signature failed cryptographic verification under the
+    /// epoch's public key. Classic "bad signature" refusal.
+    #[error("signature verification failed for epoch {payload_epoch}: {detail}")]
+    SignatureInvalid {
+        /// Epoch the payload claimed.
+        payload_epoch: u32,
+        /// Underlying minisign error string.
+        detail: String,
+    },
+
+    /// The pubkey file embedded in the binary couldn't be parsed as
+    /// a minisign public key. Indicates build-time corruption or an
+    /// out-of-date pubkey format; operator must rebuild.
+    #[error("embedded pubkey for epoch {epoch} failed to parse: {detail}")]
+    PubkeyParseFailure {
+        /// Epoch whose pubkey failed to parse.
+        epoch: u32,
+        /// Underlying minisign-parse error string.
+        detail: String,
+    },
+
+    /// `historical-anchors.json` embedded at build time couldn't be
+    /// deserialized. Same root cause as `PubkeyParseFailure`.
+    #[error("embedded historical-anchors.json failed to parse: {0}")]
+    AnchorsParseFailure(String),
+
+    /// Reading or writing the `seen-epoch` state file failed.
+    /// Differentiated from the above because it's an install-local
+    /// issue (filesystem permissions, `$XDG_STATE_HOME` wrong), not a
+    /// trust-chain issue.
+    #[error("seen-epoch state I/O error: {0}")]
+    SeenEpochIo(String),
+}

--- a/crates/aegis-trust/src/lib.rs
+++ b/crates/aegis-trust/src/lib.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![doc = include_str!("../README.md")]
+
+mod anchor;
+mod errors;
+mod seen_epoch;
+
+pub use anchor::{EpochEntry, TrustAnchor};
+pub use errors::TrustAnchorError;
+pub use seen_epoch::{SeenEpochState, load_seen_epoch, store_seen_epoch};
+
+/// Minimum epoch this binary trusts. Baked in at build time from
+/// `keys/canonical-epoch.json` via `build.rs`; falls back to `0`
+/// (an unsafe sentinel) when the keys directory isn't discoverable
+/// from the build-manifest dir. Callers of [`TrustAnchor::load`]
+/// get a `TrustAnchorError::UnsafeDefaultEpoch` if they end up with
+/// this fallback at runtime.
+pub const MIN_REQUIRED_EPOCH: u32 = {
+    // Parse env at compile time. Rust's parse-from-str requires
+    // const-fn support that's gated; use a small custom parser.
+    const fn parse_u32(s: &str) -> u32 {
+        let bytes = s.as_bytes();
+        let mut n: u32 = 0;
+        let mut i = 0;
+        while i < bytes.len() {
+            let d = bytes[i];
+            assert!(
+                d >= b'0' && d <= b'9',
+                "non-digit in AEGIS_MIN_REQUIRED_EPOCH"
+            );
+            n = n * 10 + (d - b'0') as u32;
+            i += 1;
+        }
+        n
+    }
+    parse_u32(env!("AEGIS_MIN_REQUIRED_EPOCH"))
+};
+
+/// Computes the effective floor for verification calls: the greater
+/// of [`MIN_REQUIRED_EPOCH`] (binary-embedded) and the monotonically-
+/// advancing `seen_epoch` value the local install has observed.
+///
+/// Separate from [`TrustAnchor::verify_with_epoch`] so callers that
+/// want to surface drift (e.g. `aegis-boot doctor`) can query the
+/// floor without actually running a verify.
+#[must_use]
+pub fn effective_floor(seen_epoch: u32) -> u32 {
+    MIN_REQUIRED_EPOCH.max(seen_epoch)
+}

--- a/crates/aegis-trust/src/seen_epoch.rs
+++ b/crates/aegis-trust/src/seen_epoch.rs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Monotonic `seen-epoch` state file per ADR 0002 §3.5.
+//!
+//! The file lives at `$XDG_STATE_HOME/aegis-boot/trust/seen-epoch`
+//! (or `~/.local/state/aegis-boot/trust/seen-epoch` if XDG is unset)
+//! and stores a single decimal u32. Every successful verify CAN
+//! advance it via [`store_seen_epoch`]; loads via [`load_seen_epoch`]
+//! return `0` when the file doesn't exist yet (first-run semantics).
+//!
+//! The critical invariant: **the value on disk never regresses.**
+//! [`store_seen_epoch`] reads the current value first and refuses
+//! to write a lower one — a rollback attempt gets rejected even if
+//! the caller passes a bad input.
+
+use std::fs;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+use crate::errors::TrustAnchorError;
+
+/// Pure data type — what's in the seen-epoch state file. Separate
+/// from the file I/O so callers can construct synthetic values for
+/// tests or for `aegis-boot doctor`'s "what's the current floor"
+/// read without touching the filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SeenEpochState {
+    /// Highest trust-epoch this install has ever observed.
+    /// Monotonic — never decreases once set.
+    pub epoch: u32,
+}
+
+impl Default for SeenEpochState {
+    /// First-run default — zero means "never observed any epoch."
+    /// [`crate::effective_floor`] still bounds below by
+    /// [`crate::MIN_REQUIRED_EPOCH`], so this default doesn't
+    /// bypass the binary trust floor.
+    fn default() -> Self {
+        Self { epoch: 0 }
+    }
+}
+
+/// Resolve the on-disk path per XDG conventions. Injected for tests
+/// via [`seen_epoch_path_in`].
+#[must_use]
+pub fn seen_epoch_path() -> PathBuf {
+    seen_epoch_path_in(
+        std::env::var("XDG_STATE_HOME").ok().as_deref(),
+        std::env::var("HOME").ok().as_deref(),
+    )
+}
+
+/// Inner form — takes the two env vars explicitly so tests can
+/// pass synthetic values without mutating the process env.
+#[must_use]
+pub fn seen_epoch_path_in(xdg_state: Option<&str>, home: Option<&str>) -> PathBuf {
+    let base: PathBuf = match (xdg_state, home) {
+        (Some(x), _) if !x.is_empty() => PathBuf::from(x),
+        (_, Some(h)) if !h.is_empty() => {
+            let mut p = PathBuf::from(h);
+            p.push(".local");
+            p.push("state");
+            p
+        }
+        _ => {
+            // Unusual environment — fall back to a relative `.state`
+            // dir. Not ideal, but better than silently misfiling.
+            PathBuf::from(".state")
+        }
+    };
+    base.join("aegis-boot").join("trust").join("seen-epoch")
+}
+
+/// Read the seen-epoch counter from disk. Returns
+/// [`SeenEpochState::default`] if the file doesn't exist yet.
+///
+/// Treats any parse failure (corrupted file, unexpected contents)
+/// as a hard error rather than silently falling back to 0 — a
+/// corrupted file is a signal worth flagging, not smoothing over.
+///
+/// # Errors
+///
+/// [`TrustAnchorError::SeenEpochIo`] on read failure or parse
+/// failure (file exists but isn't a bare u32).
+pub fn load_seen_epoch() -> Result<SeenEpochState, TrustAnchorError> {
+    load_seen_epoch_from(&seen_epoch_path())
+}
+
+/// Explicit-path variant for tests.
+///
+/// # Errors
+///
+/// Same as [`load_seen_epoch`].
+pub fn load_seen_epoch_from(path: &Path) -> Result<SeenEpochState, TrustAnchorError> {
+    match fs::read_to_string(path) {
+        Ok(body) => {
+            let trimmed = body.trim();
+            let epoch: u32 = trimmed.parse().map_err(|e| {
+                TrustAnchorError::SeenEpochIo(format!(
+                    "{}: parse {trimmed:?} as u32: {e}",
+                    path.display()
+                ))
+            })?;
+            Ok(SeenEpochState { epoch })
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(SeenEpochState::default()),
+        Err(e) => Err(TrustAnchorError::SeenEpochIo(format!(
+            "{}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+/// Advance the seen-epoch counter on disk. Refuses to write a value
+/// lower than what's already there — monotonicity is ADR 0002's
+/// defense against rollback attacks.
+///
+/// Creates the parent directory if needed. Uses a stage-then-rename
+/// pattern so a mid-write crash can't leave a truncated file that
+/// would then parse-fail on the next load.
+///
+/// # Errors
+///
+/// [`TrustAnchorError::SeenEpochIo`] if reading the current value,
+/// creating the parent dir, writing the staging file, fsyncing, or
+/// renaming fails.
+pub fn store_seen_epoch(new: u32) -> Result<SeenEpochState, TrustAnchorError> {
+    store_seen_epoch_at(&seen_epoch_path(), new)
+}
+
+/// Explicit-path variant for tests.
+///
+/// # Errors
+///
+/// Same as [`store_seen_epoch`].
+pub fn store_seen_epoch_at(path: &Path, new: u32) -> Result<SeenEpochState, TrustAnchorError> {
+    let current = load_seen_epoch_from(path)?;
+    let next = current.epoch.max(new);
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| {
+            TrustAnchorError::SeenEpochIo(format!("mkdir {}: {e}", parent.display()))
+        })?;
+    }
+
+    // Stage-then-rename: write to `path.tmp`, rename over `path`.
+    // Rename is atomic on the same filesystem so either the old
+    // value or the new value is visible, never a truncated file.
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = fs::File::create(&tmp)
+            .map_err(|e| TrustAnchorError::SeenEpochIo(format!("create {}: {e}", tmp.display())))?;
+        writeln!(f, "{next}")
+            .map_err(|e| TrustAnchorError::SeenEpochIo(format!("write {}: {e}", tmp.display())))?;
+        f.sync_all()
+            .map_err(|e| TrustAnchorError::SeenEpochIo(format!("fsync {}: {e}", tmp.display())))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| {
+        TrustAnchorError::SeenEpochIo(format!(
+            "rename {} -> {}: {e}",
+            tmp.display(),
+            path.display()
+        ))
+    })?;
+
+    Ok(SeenEpochState { epoch: next })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_prefers_xdg_state_home() {
+        let p = seen_epoch_path_in(Some("/x"), Some("/h"));
+        assert_eq!(p, PathBuf::from("/x/aegis-boot/trust/seen-epoch"));
+    }
+
+    #[test]
+    fn path_falls_back_to_home_plus_dot_local_state() {
+        let p = seen_epoch_path_in(None, Some("/home/op"));
+        assert_eq!(
+            p,
+            PathBuf::from("/home/op/.local/state/aegis-boot/trust/seen-epoch")
+        );
+    }
+
+    #[test]
+    fn path_empty_xdg_treated_as_unset() {
+        let p = seen_epoch_path_in(Some(""), Some("/home/op"));
+        assert_eq!(
+            p,
+            PathBuf::from("/home/op/.local/state/aegis-boot/trust/seen-epoch")
+        );
+    }
+
+    #[test]
+    fn load_returns_default_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("nonexistent");
+        let state = load_seen_epoch_from(&p).unwrap();
+        assert_eq!(state, SeenEpochState::default());
+        assert_eq!(state.epoch, 0);
+    }
+
+    #[test]
+    fn load_parses_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("seen-epoch");
+        std::fs::write(&p, "42\n").unwrap();
+        assert_eq!(load_seen_epoch_from(&p).unwrap().epoch, 42);
+    }
+
+    #[test]
+    fn load_refuses_corrupted_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("seen-epoch");
+        std::fs::write(&p, "not a number").unwrap();
+        match load_seen_epoch_from(&p) {
+            Err(TrustAnchorError::SeenEpochIo(_)) => {}
+            other => panic!("expected SeenEpochIo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn store_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("aegis-boot/trust/seen-epoch");
+        assert!(!p.exists());
+        let s = store_seen_epoch_at(&p, 3).unwrap();
+        assert_eq!(s.epoch, 3);
+        assert_eq!(load_seen_epoch_from(&p).unwrap().epoch, 3);
+    }
+
+    #[test]
+    fn store_monotonic_refuses_rollback() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("seen-epoch");
+        store_seen_epoch_at(&p, 5).unwrap();
+        // Try to regress to 3 — stored value should stay at 5.
+        let s = store_seen_epoch_at(&p, 3).unwrap();
+        assert_eq!(s.epoch, 5, "rollback must be refused");
+        assert_eq!(load_seen_epoch_from(&p).unwrap().epoch, 5);
+    }
+
+    #[test]
+    fn store_advances_on_higher_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("seen-epoch");
+        store_seen_epoch_at(&p, 1).unwrap();
+        store_seen_epoch_at(&p, 2).unwrap();
+        store_seen_epoch_at(&p, 7).unwrap();
+        store_seen_epoch_at(&p, 7).unwrap(); // idempotent
+        store_seen_epoch_at(&p, 5).unwrap(); // ignored
+        assert_eq!(load_seen_epoch_from(&p).unwrap().epoch, 7);
+    }
+
+    #[test]
+    fn store_is_atomic_no_tmp_leftover_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("seen-epoch");
+        store_seen_epoch_at(&p, 42).unwrap();
+        let tmp = p.with_extension("tmp");
+        assert!(
+            !tmp.exists(),
+            "stage file should be renamed, not left behind"
+        );
+    }
+}


### PR DESCRIPTION
First half of #421. Ships the \`aegis-trust\` crate implementing ADR 0002's epoch-aware minisign verification model. Zero integration into aegis-cli yet — the \`aegis-boot doctor\` surface from §5 of #421 lands in PR B on top of this.

## What the crate does

- **Build-time**: \`build.rs\` reads \`keys/canonical-epoch.json\` and emits \`AEGIS_MIN_REQUIRED_EPOCH\` → exposed as \`pub const MIN_REQUIRED_EPOCH: u32\`.
- **Runtime**: \`TrustAnchor::load()\` + \`verify_with_epoch(body, sig, epoch, seen)\` does the full rotation-aware check:
  1. payload epoch ≥ binary floor
  2. payload epoch ≥ local seen-epoch (monotonic)
  3. epoch in registered anchor list
  4. minisign sig validates under the epoch's embedded pubkey
- **State**: \`seen-epoch\` file at \`\$XDG_STATE_HOME/aegis-boot/trust/seen-epoch\` with stage-then-rename atomic writes + rollback refusal.

## Trust-chain hardening

\`historical-anchors.json\` + \`maintainer-epoch-1.pub\` are \`include_str!\`-embedded at build time. The binary ships a self-contained trust chain — no filesystem-swap attack surface at runtime. Adding epoch 2 later means a reviewed commit that adds another \`include_str!\` line + a branch in \`pubkey_for_epoch\`. That's the only path to rotation.

## Error model

Distinct \`TrustAnchorError\` variants for every failure mode so the upcoming doctor rows can render specific operator messages: \`UnsafeDefaultEpoch\`, \`EpochBelowBinaryFloor\`, \`EpochBelowSeenFloor\`, \`UnknownEpoch\`, \`SignatureInvalid\`, \`PubkeyParseFailure\`, \`AnchorsParseFailure\`, \`SeenEpochIo\`.

## Test coverage

- **16 unit tests passing**: 5 on TrustAnchor (load + every verify failure path), 11 on seen_epoch (path resolution, read + write, monotonic refusal, stage-then-rename atomicity).
- **1 ignored E2E** that round-trips a real sign+verify against the in-repo epoch-1 key (gated on \`AEGIS_TRUST_E2E_{SECRET_KEY,PASSPHRASE}\` env vars; maintainer runs locally via \`pass show | tee\`).

## Out-of-workspace build fallback

When \`keys/\` isn't discoverable from \`CARGO_MANIFEST_DIR\` (e.g. \`cargo publish\` tarball), build.rs emits \`AEGIS_MIN_REQUIRED_EPOCH=0\` with a \`cargo:warning=\` banner. Runtime refuses the sentinel with \`UnsafeDefaultEpoch\` — unsafe-default-is-detectable rather than silently wrong. Override via \`AEGIS_MIN_REQUIRED_EPOCH_OVERRIDE=<N>\` for intentional out-of-workspace consumers.

## Test plan

- [x] \`cargo test -p aegis-trust --locked\` — 16 passed, 1 ignored (E2E, as designed)
- [x] \`cargo clippy -p aegis-trust --all-targets -- -D warnings\` — clean
- [x] \`cargo check --workspace --locked\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI end-to-end

## Next — PR B

Adds \`aegis-boot doctor\` rows that consume \`aegis-trust\`: binary \`MIN_REQUIRED_EPOCH\`, local \`seen-epoch\`, drift detection. Follows immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)