### PR TITLE
fix(rescue-tui): clear clippy baseline + add CI step (#519)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,27 @@ jobs:
         # PowerShell-output parser is exercised via committed fixtures.
         run: cargo check -p aegis-bootctl --target x86_64-pc-windows-gnu --all-targets
 
+  rescue-tui:
+    # rescue-tui isn't part of the workspace-wide `Test` job because
+    # that job is scoped to `crates/iso-parser` (see working-directory
+    # + workspaces:). Without this dedicated job, rescue-tui's clippy
+    # baseline silently drifts between releases. Issue #519.
+    name: rescue-tui clippy
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - name: Install Rust
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt,clippy
+          rustup override set 1.88.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+      - name: Format + lint rescue-tui
+        run: |
+          cargo fmt --check
+          cargo clippy -p rescue-tui --all-targets -- -D warnings
+      - name: Run rescue-tui tests
+        run: cargo test -p rescue-tui --locked
+
   fitness:
     name: aegis-fitness audit
     runs-on: ubuntu-22.04

--- a/crates/rescue-tui/src/bin/tui_screenshots.rs
+++ b/crates/rescue-tui/src/bin/tui_screenshots.rs
@@ -28,9 +28,10 @@ use rescue_tui::render::draw;
 use rescue_tui::state::{AppState, Pane, Screen};
 
 type DynError = Box<dyn std::error::Error>;
+type Scenario = (&'static str, &'static str, Box<dyn Fn() -> AppState>);
 
 fn main() -> Result<(), DynError> {
-    let scenarios: Vec<(&str, &str, Box<dyn Fn() -> AppState>)> = vec![
+    let scenarios: Vec<Scenario> = vec![
         (
             "01-empty-list",
             "Empty stick — no ISOs, no failed parses. Rescue-shell entry still available.",
@@ -110,9 +111,10 @@ fn render_ansi(state: &AppState, cols: u16, rows: u16) -> String {
 }
 
 fn buffer_to_ansi(buf: &Buffer, cols: u16) -> String {
+    let cols_usize = usize::from(cols);
     let mut out = String::new();
     for (i, cell) in buf.content.iter().enumerate() {
-        if i > 0 && (i as u16).is_multiple_of(cols) {
+        if i > 0 && cols_usize > 0 && i.is_multiple_of(cols_usize) {
             out.push_str("\x1b[0m\n");
         }
         push_style(&mut out, cell.fg, cell.bg, cell.modifier);
@@ -163,7 +165,6 @@ fn fg_code(c: Color) -> String {
 
 fn bg_code(c: Color) -> String {
     match c {
-        Color::Reset => String::new(),
         Color::Rgb(r, g, b) => format!("\x1b[48;2;{r};{g};{b}m"),
         Color::Indexed(i) => format!("\x1b[48;5;{i}m"),
         _ => String::new(),

--- a/crates/rescue-tui/src/docgen.rs
+++ b/crates/rescue-tui/src/docgen.rs
@@ -27,6 +27,8 @@
 //! [`TrustVerdict`]: crate::verdict::TrustVerdict
 //! [`KEYBINDINGS`]: crate::keybindings::KEYBINDINGS
 
+use std::fmt::Write as _;
+
 use crate::keybindings::{KEYBINDINGS, ScreenKind};
 use crate::verdict::TrustVerdict;
 
@@ -40,19 +42,20 @@ pub fn render_tier_table() -> String {
     out.push_str("| ---- | ------------------- | ----- | -------- | ------------------------------------------ |\n");
     for (i, v) in tier_variants().into_iter().enumerate() {
         let bootable = if v.is_bootable() { "yes" } else { "**no**" };
-        out.push_str(&format!(
-            "| {tier:<4} | {label:<19} | `{glyph}` | {bootable:<8} | {reason:<42} |\n",
+        let _ = writeln!(
+            out,
+            "| {tier:<4} | {label:<19} | `{glyph}` | {bootable:<8} | {reason:<42} |",
             tier = i + 1,
             label = v.label(),
             glyph = v.glyph(),
             bootable = bootable,
             reason = tier_short_meaning(&v)
-        ));
+        );
     }
     out
 }
 
-/// Canonical ordering of the 6 TrustVerdict variants (tier 1 → 6).
+/// Canonical ordering of the 6 `TrustVerdict` variants (tier 1 → 6).
 /// Constructed with placeholder payloads for variants that carry
 /// data — the docgen surface only looks at label/color/glyph/
 /// bootable so payload content doesn't affect the rendered table.
@@ -103,6 +106,7 @@ pub fn render_keybinding_table() -> String {
         } else {
             k.screens
                 .iter()
+                .copied()
                 .map(screen_short_name)
                 .collect::<Vec<_>>()
                 .join(", ")
@@ -113,20 +117,21 @@ pub fn render_keybinding_table() -> String {
             None => "any",
         };
         let filter = if k.while_filter_editing { "yes" } else { "no" };
-        out.push_str(&format!(
-            "| `{key}` | {screens} | {pane} | {filter} | {desc} |\n",
+        let _ = writeln!(
+            out,
+            "| `{key}` | {screens} | {pane} | {filter} | {desc} |",
             key = k.key,
             screens = screens,
             pane = pane,
             filter = filter,
             desc = k.description
-        ));
+        );
     }
     out
 }
 
-fn screen_short_name(s: &ScreenKind) -> String {
-    match s {
+fn screen_short_name(s: ScreenKind) -> String {
+    let name = match s {
         ScreenKind::List => "List",
         ScreenKind::Confirm => "Confirm",
         ScreenKind::EditCmdline => "EditCmdline",
@@ -136,8 +141,8 @@ fn screen_short_name(s: &ScreenKind) -> String {
         ScreenKind::Help => "Help",
         ScreenKind::ConfirmQuit => "ConfirmQuit",
         ScreenKind::Quitting => "Quitting",
-    }
-    .to_string()
+    };
+    name.to_string()
 }
 
 /// Marker pair used to delimit regenerable regions in doc files.

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -542,6 +542,13 @@ where
 /// for tracing — terminals usually ignore it with `TERM=dumb`). Every
 /// screen transition also emits an `ANN:` line to stderr so
 /// brltty/speakup can mirror it to braille/speech.
+///
+/// Intentionally a single large state-machine function — the
+/// accessibility contract pairs each `ANN:` stderr line with the
+/// next stdin prompt, which is awkward to split across helpers
+/// without ending up with tighter coupling than the original prose.
+/// Opt out of the too-many-lines lint here, not refactor cosmetics.
+#[allow(clippy::too_many_lines)]
 fn run_text_mode(state: &mut AppState) -> Result<u8, Box<dyn std::error::Error>> {
     use std::io::Write;
     let mut out = std::io::stdout().lock();

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -620,27 +620,16 @@ fn split_list_chrome(frame: &mut Frame<'_>, area: Rect, state: &AppState) -> (Re
     }
 }
 
-fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
-    use crate::state::ViewEntry;
-    if state.isos.is_empty() && state.failed_isos.is_empty() {
-        draw_empty_list(frame, area, state);
-        return;
-    }
-
-    // Chrome: (filter/sort hint line) on top, (main body) below. The
-    // main body is now a 40/60 horizontal split between the ISO list
-    // (left) and the info pane (right). (#458)
-    let (info_line_area, body_area) = split_list_chrome(frame, area, state);
-    let panes = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-        .split(body_area);
-    let (list_area, info_pane_area) = (panes[0], panes[1]);
-
-    // Design-review #102: filter-mode visual was too subtle (trailing
-    // `_` the only indicator). Now: when editing, render a reversed-
-    // style banner with "FILTER:" prefix so it's unmistakable, plus a
-    // blinking caret span. Committed filter keeps the quieter style.
+/// Render the top-of-list-chrome info line (filter banner while
+/// editing, else the committed sort/filter hint). Extracted from
+/// [`draw_list`] so that function stays under the clippy
+/// too-many-lines gate.
+///
+/// Design-review #102: filter-mode visual was too subtle (trailing
+/// `_` the only indicator). When editing, a reversed-style banner
+/// with "FILTER:" prefix plus a blinking caret makes the mode
+/// unmistakable. Committed filter keeps the quieter style.
+fn render_list_info_line(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     if state.filter_editing {
         let styled = Line::from(vec![
             Span::styled(
@@ -660,7 +649,7 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
                 state.sort_order.summary()
             )),
         ]);
-        frame.render_widget(Paragraph::new(styled), info_line_area);
+        frame.render_widget(Paragraph::new(styled), area);
     } else {
         let info_line = if state.filter.is_empty() {
             format!(
@@ -674,8 +663,28 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
                 state.sort_order.summary()
             )
         };
-        frame.render_widget(Paragraph::new(info_line), info_line_area);
+        frame.render_widget(Paragraph::new(info_line), area);
     }
+}
+
+fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usize) {
+    use crate::state::ViewEntry;
+    if state.isos.is_empty() && state.failed_isos.is_empty() {
+        draw_empty_list(frame, area, state);
+        return;
+    }
+
+    // Chrome: (filter/sort hint line) on top, (main body) below. The
+    // main body is now a 40/60 horizontal split between the ISO list
+    // (left) and the info pane (right). (#458)
+    let (info_line_area, body_area) = split_list_chrome(frame, area, state);
+    let panes = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(body_area);
+    let (list_area, info_pane_area) = (panes[0], panes[1]);
+
+    render_list_info_line(frame, info_line_area, state);
 
     // Full entries view includes the rescue-shell synthetic row at
     // the end, even when the ISO list is empty (#90).
@@ -763,11 +772,10 @@ fn draw_list(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: usiz
 /// selected. (#459)
 fn render_failed_iso_list_item<'a>(failed: &iso_probe::FailedIso) -> ListItem<'a> {
     let glyph = "[!]"; // tier-4 marker
-    let name = failed
-        .iso_path
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| failed.iso_path.display().to_string());
+    let name = failed.iso_path.file_name().map_or_else(
+        || failed.iso_path.display().to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
     // Short reason for the list row — full reason lives in the info pane.
     let short = {
         let r = &failed.reason;
@@ -889,8 +897,7 @@ fn info_pane_iso_lines<'a>(
         "Initrd:   ",
         iso.initrd
             .as_ref()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "(none)".to_string()),
+            .map_or_else(|| "(none)".to_string(), |p| p.display().to_string()),
     ));
     lines.push(labeled(
         "Cmdline:  ",
@@ -965,7 +972,7 @@ fn info_pane_iso_lines<'a>(
     lines
 }
 
-/// Helper: render the info-pane line set for a tier-4 (ParseFailed)
+/// Helper: render the info-pane line set for a tier-4 (`ParseFailed`)
 /// row. Routes through [`TrustVerdict::from_failed`] so the tier
 /// label, color, and reason come from the same canonical source the
 /// rest of the UI uses. (#459)
@@ -1084,7 +1091,7 @@ fn windows_redirect_lines<'a>(state: &AppState, content_width: usize) -> Vec<Lin
 }
 
 /// Build a `"Label: value"` info-pane line with the label in bold.
-fn labeled<'a>(label: &'a str, value: String) -> Line<'a> {
+fn labeled(label: &str, value: String) -> Line<'_> {
     Line::from(vec![
         Span::styled(label, Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(value),
@@ -1092,9 +1099,10 @@ fn labeled<'a>(label: &'a str, value: String) -> Line<'a> {
 }
 
 fn filename_str(p: &std::path::Path) -> String {
-    p.file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| p.display().to_string())
+    p.file_name().map_or_else(
+        || p.display().to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    )
 }
 
 /// Short verification summary for the info pane's sha256 row. Avoids

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -407,7 +407,7 @@ impl AppState {
     ///    filtered by the active substring filter.
     /// 2. Parse-failed ISOs (tier 4) in alphabetical order — always
     ///    surfaced so the operator sees every file on the stick. Also
-    ///    subject to the substring filter (matches against iso_path).
+    ///    subject to the substring filter (matches against `iso_path`).
     /// 3. The synthetic [`ViewEntry::RescueShell`] — always present so
     ///    operators have an escape hatch to a signed busybox shell.
     #[must_use]

--- a/crates/rescue-tui/src/verdict.rs
+++ b/crates/rescue-tui/src/verdict.rs
@@ -114,8 +114,7 @@ impl TrustVerdict {
             Self::KeyNotTrusted => {
                 "signature parses but key is not in AEGIS_TRUSTED_KEYS".to_string()
             }
-            Self::ParseFailed { reason } => reason.clone(),
-            Self::SecureBootBlocked { reason } => reason.clone(),
+            Self::ParseFailed { reason } | Self::SecureBootBlocked { reason } => reason.clone(),
             Self::HashMismatch {
                 expected,
                 actual,
@@ -149,9 +148,8 @@ impl TrustVerdict {
             Self::OperatorAttested => "[+]",
             Self::KeyNotTrusted => "[~]",
             Self::BareUnverified => "[ ]",
-            Self::ParseFailed { .. } => "[!]",
+            Self::ParseFailed { .. } | Self::HashMismatch { .. } => "[!]",
             Self::SecureBootBlocked { .. } => "[X]",
-            Self::HashMismatch { .. } => "[!]",
         }
     }
 
@@ -248,7 +246,7 @@ impl TrustVerdict {
 }
 
 /// Truncate a long hex digest to the first 12 chars with an ellipsis —
-/// keeps the HashMismatch reason line readable in narrow terminals.
+/// keeps the `HashMismatch` reason line readable in narrow terminals.
 fn short_hex(hex: &str) -> String {
     if hex.len() <= 14 {
         return hex.to_string();


### PR DESCRIPTION
## Summary

Resolves [#519](https://github.com/aegis-boot/aegis-boot/issues/519) — rescue-tui had 14 pre-existing clippy errors that CI never caught because the \`Test\` job scopes clippy to \`crates/iso-parser\`. This PR clears the baseline + wires the missing gate.

## CI change

New dedicated \`rescue-tui clippy\` job mirroring the \`aegis-cli\` pattern. From this point forward, any new clippy warning in rescue-tui fails a PR.

## Source changes (all mechanical)

- \`verdict.rs\`: merge two \`match_same_arms\` pairs; one doc backtick fix.
- \`state.rs\`: one doc backtick fix.
- \`render.rs\`: three \`map_or_else\` conversions, lifetime elision on \`labeled\`, one doc backtick, \`draw_list\` stays under the 100-line cap by extracting \`render_list_info_line\`.
- \`docgen.rs\`: two \`format_push_string\` → \`writeln!\`; \`screen_short_name\` by value; doc backtick.
- \`bin/tui_screenshots.rs\`: \`type Scenario\` alias; drop redundant match arm in \`bg_code\`; fix \`cast_possible_truncation\` via \`usize::from(cols) + is_multiple_of\`.
- \`main.rs\`: narrow \`#[allow(clippy::too_many_lines)]\` on \`run_text_mode\` with prose rationale — the a11y state machine doesn't split cleanly.

## Gates

- \`cargo test -p rescue-tui\` — 187 passed (176 lib + 7 + 4)
- \`cargo clippy -p rescue-tui --all-targets -- -D warnings\` ✓ (was 14 errors)
- \`cargo fmt --check\` ✓

## Test plan

- [x] Clippy clean locally
- [x] All 187 tests pass locally
- [ ] New \`rescue-tui clippy\` CI job turns green
- [ ] Rest of CI matrix unaffected

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)