### PR TITLE
fix(ci/release): narrow workflow-level permissions to least privilege

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,19 @@ on:
         description: "Tag to build (e.g. v0.12.0)"
         required: true
 
+# Workflow-level permissions follow the OSSF Scorecard
+# "Token-Permissions" principle of least privilege: read-only by
+# default. Every job that needs to mutate the repo (release asset
+# upload, Formula commit) has to opt in explicitly with its own
+# `permissions:` block — that way a future job added in this
+# workflow won't silently inherit write access it doesn't need.
 permissions:
-  contents: write
+  contents: read
   # Required for cosign keyless signing via GitHub OIDC. The token is
   # used by sigstore/cosign-installer + cosign sign-blob to fetch a
-  # signing certificate bound to this workflow's identity.
+  # signing certificate bound to this workflow's identity. Every build
+  # job that cosign-signs artifacts needs this — cheaper to grant at
+  # the workflow level than to duplicate it into three jobs.
   id-token: write
 
 jobs:
@@ -26,6 +34,13 @@ jobs:
     # + exfat data partition. 30 min gives headroom on slower-than-
     # average GHA runners without masking a genuine hang.
     timeout-minutes: 30
+    # contents:write is required for `gh release create` +
+    # `gh release upload` below. Explicit at the job level so the
+    # workflow-top stays read-only per the Scorecard principle of
+    # least privilege; id-token:write is inherited from the workflow.
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Addresses the OSSF Scorecard \`Token-Permissions\` alerts (#137, #138) surfaced via CodeQL. Workflow top-level used to default to \`contents: write\` — every job silently inherited write access even when it only needed read. Narrowing the workflow top to \`contents: read\` means future jobs fail closed unless they explicitly opt into write.

## Jobs that actually need write

| Job | Permission change | Why |
| --- | --- | --- |
| \`build-and-release\` | **NEW**: explicit \`contents: write\` | \`gh release create\` + \`gh release upload\` |
| \`build-macos-arm64\` | unchanged (already explicit) | macOS asset upload |
| \`bump-brew-formula\` | unchanged (already explicit) | Commits Formula bump to main |

## What this does + doesn't close

- **Closes**: the implicit broader-than-needed workflow-level grant that all three jobs were inheriting. A future fourth job added here can't silently leverage write — it has to opt in with its own \`permissions:\` block.
- **Does NOT close**: the three job-level \`contents: write\` alerts, because those grants are load-bearing. A \`gh release upload\` that runs without \`contents: write\` simply fails.

## Behavior change

None on the happy path — the three write-holding jobs keep their existing grants. The only observable difference is that a brand-new job accidentally added to this workflow without explicit \`permissions:\` would now fail closed with a permission error rather than silently commit/upload.

## Test plan

- [x] YAML syntactically valid (\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"\`)
- [ ] CI green (no workflow-file lint job that I'm aware of, but every other workflow file continues to parse)
- [ ] Next release cut (manual \`workflow_dispatch\` or tag push) still uploads artifacts + signs + bumps formula. Deferred to whenever the maintainer next cuts a release.

Refs: CodeQL alerts 137 + 138 (\`Token-Permissions\`, Scorecard SARIF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)