### PR TITLE
test(ci): Node 24 opt-in sweep (#409 early-May gate, throwaway)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,15 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  # #409 opt-in test (2026-04-24): force every JavaScript-based GitHub
+  # Action to run on Node.js 24 instead of the Node.js 20 default.
+  # GitHub will flip this to the default on 2026-06-02 and fully
+  # remove Node 20 on 2026-09-16; running a full CI sweep now surfaces
+  # any action that breaks under Node 24 while there's still headroom
+  # to pin a fix. If this sweep is green, #409 can close as "auto-
+  # cutover will be a no-op on this repo." If anything fails, pin the
+  # specific action to a Node 24 release.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test:


### PR DESCRIPTION
## Draft / throwaway

Per the \"early-May 2026\" guidance in #409: push one branch with \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` set at the workflow level, observe the full CI matrix, decide what (if anything) to pin before the 2026-06-02 auto-cutover.

**Not intended to merge by default.** Green → close the PR + close #409 as \"auto-upgrade will be a no-op on this repo.\" Red → identify which composite action(s) need pinning and fix forward on a separate branch.

## What this tests

One env var at the workflow top of \`.github/workflows/ci.yml\`. \`ci.yml\` is the canary — every other workflow uses the same set of composite actions (actions/checkout, Swatinem/rust-cache, upload-artifact v5, the gh-actions cargo-deny / semgrep / nix / gitleaks / typos wrappers). A break under Node 24 would surface on at least one job in this matrix.

## Follow-ups

- If green: close this PR + close #409 with a comment linking the green run.
- If red: file a proper \`fix(ci): pin <action> for Node 24\` PR that bumps the specific SHA pin (we already pin to 40-char SHAs per #490, so this is one-line per affected action).

Refs: #409, 2026-06-02 GitHub Actions Node 20 auto-upgrade deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)