### PR TITLE
feat(aegis-cli): diskutil subprocess wrapper for macOS (#418 Phase 2)

### DIFF
--- a/crates/aegis-cli/src/macos_direct_install/partition.rs
+++ b/crates/aegis-cli/src/macos_direct_install/partition.rs
@@ -187,6 +187,42 @@ fn is_valid_whole_disk_id(s: &str) -> bool {
     rest.bytes().all(|b| b.is_ascii_digit())
 }
 
+/// Partition the target disk via `diskutil`, fed the argv produced
+/// by [`build_diskutil_plan`]. macOS-only — the \[`cfg`\] gate means
+/// Linux + Windows builds never pull in this function, but the
+/// `x86_64-apple-darwin` CI cross-compile step catches compile
+/// errors on every PR.
+///
+/// macOS's `diskutil` doesn't require root for external / removable
+/// drives (operator-session privilege is enough); if the target is
+/// internal or in use, `diskutil` itself surfaces the actionable
+/// error. The subprocess's stderr is propagated unchanged to the
+/// caller — we don't try to translate `diskutil`'s messages.
+///
+/// # Errors
+///
+/// Returns the subprocess exit code + stderr as a `String` on any
+/// non-zero exit or spawn failure. Sibling of
+/// [`crate::windows_direct_install::partition::partition_via_diskpart`].
+#[cfg(target_os = "macos")]
+pub(crate) fn partition_via_diskutil(plan: &DiskutilPartitionPlan) -> Result<(), String> {
+    use std::process::Command;
+
+    let out = Command::new("/usr/sbin/diskutil")
+        .args(&plan.argv)
+        .output()
+        .map_err(|e| format!("spawn /usr/sbin/diskutil: {e}"))?;
+
+    if !out.status.success() {
+        return Err(format!(
+            "diskutil exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {


### PR DESCRIPTION
## Summary

Runtime sibling of Phase 1's pure-fn \`build_diskutil_plan\` — adds \`partition_via_diskutil()\` behind \`#[cfg(target_os = \"macos\")]\`. Mirrors \`windows_direct_install::partition::partition_via_diskpart\`.

## Scope

~40 LOC. Spawns \`/usr/sbin/diskutil\` with \`plan.argv\`, propagates stderr verbatim on non-zero exit so operator-facing messages come straight from diskutil rather than through a lossy taxonomy.

## Why no new unit tests

Same rationale as the Windows sibling: the subprocess wrapper can't run on Linux CI. Coverage comes from:

- **Phase 1 pure-fn tests** pin the argv contract (12 tests, PR #529)
- **CI cross-compile** (\`cargo check --target x86_64-apple-darwin\`) catches compile errors every PR
- **Runtime testing** lives with the macOS-host maintainer workflow — the Phase 3 \`--direct-install\` CLI surface will gate on an e2e smoke test against a USB device when that lands

## Gates

- \`cargo clippy -p aegis-bootctl --all-targets -- -D warnings\` ✓
- \`cargo test -p aegis-bootctl macos_direct_install\` — 12 passed (Phase 1 unaffected)
- \`cargo check -p aegis-bootctl --target x86_64-apple-darwin --all-targets\` — clean (the cfg-gated code compiles)
- \`cargo fmt --check\` ✓

## What's left for #418

- **Phase 3**: ESP staging via \`hdiutil attach\` + loopback \`cp\` (mirror of \`windows_direct_install::raw_write\` for the data-partition side)
- **Phase 4**: flash-pipeline dispatcher wiring + \`aegis-boot flash --direct-install\` macOS surface
- **Phase 5**: macos-14 CI smoke gate (#420)

Refs: #418 Phase 2, #367 Phase D, PR #529 (Phase 1), #447 (Windows pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)