### PR TITLE
fix(add): print missing-arg error before help (closes #540)

### DIFF
--- a/crates/aegis-cli/src/inventory.rs
+++ b/crates/aegis-cli/src/inventory.rs
@@ -166,12 +166,24 @@ pub fn run_add(args: &[String]) -> ExitCode {
 // extracting helpers would fragment the control flow for no clarity win.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn try_run_add(args: &[String]) -> Result<(), u8> {
-    if args.is_empty()
-        || args.first().map(String::as_str) == Some("--help")
+    if args.first().map(String::as_str) == Some("--help")
         || args.first().map(String::as_str) == Some("-h")
     {
         print_add_help();
-        return if args.is_empty() { Err(2) } else { Ok(()) };
+        return Ok(());
+    }
+    if args.is_empty() {
+        // #540 — when invoked with no args, surface a missing-argument
+        // line on stderr BEFORE the help text. The pre-fix behavior
+        // dumped help with no context, which a first-time operator
+        // could mistake for a successful no-op. Mirrors the pattern
+        // `fetch` already uses.
+        eprintln!(
+            "aegis-boot add: missing required <iso-or-slug> argument.\n\
+             Try `aegis-boot add --help`, or pick a slug from `aegis-boot recommend`."
+        );
+        print_add_help();
+        return Err(2);
     }
 
     let AddArgs {


### PR DESCRIPTION
## Summary

Third Tier-1 fix from UX review epic #537. \`aegis-boot add\` with no positional argument used to silently print help and exit 2 — first-time operators who scrolled back saw only help and could mistake it for a no-op success.

## Behavior

| Invocation | Before | After |
| --- | --- | --- |
| \`aegis-boot add\` | exit 2, help only | exit 2, error line + help |
| \`aegis-boot add --help\` | exit 0, help only | unchanged |
| \`aegis-boot add -h\` | exit 0, help only | unchanged |
| \`aegis-boot add <iso>\` | unchanged add flow | unchanged |

The new error line:

\`\`\`
aegis-boot add: missing required <iso-or-slug> argument.
Try \`aegis-boot add --help\`, or pick a slug from \`aegis-boot recommend\`.
\`\`\`

Mirrors the pattern \`aegis-boot fetch\` already uses for the same class of input — \"first line on stderr names the missing arg, then help follows.\"

## Gates

- \`cargo clippy -p aegis-bootctl --all-targets -- -D warnings\` ✓
- \`cargo test -p aegis-bootctl inventory\` — 54 passed (unchanged)
- \`cargo fmt --check\` ✓

Refs: epic #537, issue #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)