### PR TITLE
feat(fetch-image): wire NEXT ACTION into 3 failure paths (#542 follow-up)

### DIFF
--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -91,9 +91,12 @@ fn try_run(args: &[String]) -> Result<PathBuf, u8> {
     };
 
     if !is_safe_https_url(&url) {
-        eprintln!(
-            "aegis-boot fetch-image: refusing URL '{url}' — only https:// URLs are accepted \
-             (signed-chain integrity assumes TLS)."
+        crate::userfacing::eprint_with_next(
+            "fetch-image",
+            format!(
+                "refusing URL '{url}' — only https:// URLs are accepted (signed-chain integrity assumes TLS)"
+            ),
+            "pass an https:// URL via --url, or run without --url to use the latest official release",
         );
         return Err(2);
     }
@@ -122,12 +125,14 @@ fn try_run(args: &[String]) -> Result<PathBuf, u8> {
     if let Some(expected) = parsed.expected_sha256.as_deref() {
         let got = compute_sha256(&out_path)?;
         if !got.eq_ignore_ascii_case(expected) {
-            eprintln!("aegis-boot fetch-image: sha256 mismatch");
-            eprintln!("  expected: {expected}");
-            eprintln!("  got:      {got}");
             // Remove the file so a second run doesn't accidentally
             // skip the download + believe the cached bytes.
             let _ = std::fs::remove_file(&out_path);
+            crate::userfacing::eprint_with_next(
+                "fetch-image",
+                format!("sha256 mismatch — expected {expected}, got {got}"),
+                "confirm --url points at the release that produced --sha256 (release-page checksums + a fresh `--url` per release pair to the same hash)",
+            );
             return Err(1);
         }
         eprintln!("aegis-boot fetch-image: sha256 verified");
@@ -149,7 +154,11 @@ fn try_run(args: &[String]) -> Result<PathBuf, u8> {
     if parsed.cosign_disabled {
         eprintln!("aegis-boot fetch-image: cosign verification skipped (--no-cosign)");
     } else if let Err(detail) = try_cosign_verify(&url, &out_path) {
-        eprintln!("aegis-boot fetch-image: {detail}");
+        crate::userfacing::eprint_with_next(
+            "fetch-image",
+            detail,
+            "confirm --url points at an official release on github.com/aegis-boot/aegis-boot. For air-gapped / offline contexts where Sigstore lookups would fail, pass --no-cosign (sha256 still verifies if --sha256 is supplied)",
+        );
         return Err(1);
     }
 


### PR DESCRIPTION
## Summary

Builds on the \`eprint_with_next\` helper that landed in #553. Wires three more fetch-image failure paths through the helper, closing the gap the UX-review discovery agent flagged: fetch-image's verification failures used to print the detail and exit with no remediation guidance.

## Wired paths

| Failure | NEXT ACTION |
| --- | --- |
| \`refusing URL '...' — only https:// accepted\` | \"pass an https:// URL via --url, or run without --url to use the latest official release\" |
| \`sha256 mismatch — expected X, got Y\` | \"confirm --url points at the release that produced --sha256 (release-page checksums + a fresh \`--url\` per release pair to the same hash)\" |
| \`cosign verification FAILED — ...\` | \"confirm --url points at an official release on github.com/aegis-boot/aegis-boot. For air-gapped / offline contexts, pass --no-cosign (sha256 still verifies if --sha256 is supplied)\" |

## Why this matters

Each was an explicit gap from the discovery audit. Operators hitting cosign verification failure used to see the failure detail and exit code 1 with no path forward — now they're told exactly which flag to add or which assumption to check.

## Validation point

This PR is the \"second subcommand\" check the consensus vote suggested — proving the helper composes cleanly across subcommands without needing changes to the helper itself. Confirmed: zero helper-side edits, three failure paths each took ~5 LOC.

## Gates

- \`cargo clippy -p aegis-bootctl --all-targets -- -D warnings\` ✓
- \`cargo test -p aegis-bootctl fetch_image\` — 27 passed (unchanged)
- \`cargo fmt --check\` ✓

Refs: epic #537, issue #542, PR #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)