### PR TITLE
docs: ADRs 0003-0006 — defer netboot, golden-image, recovery-distinct-type, rebrand (closes #565 #566 #567 #568)

### DIFF
--- a/docs/adr/0003-defer-netboot-daemon.md
+++ b/docs/adr/0003-defer-netboot-daemon.md
@@ -1,0 +1,60 @@
+# ADR 0003: Defer the full netboot daemon — `aegis-netbootd` is post-v1.0
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Deciders:** 6-agent `consensus_vote` (`higher_order`) on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556) — Architect, Security, AI/ML, PM, DevEx, Contrarian all recommended deferring in their reasoning.
+**Tracking issue:** [#565](https://github.com/aegis-boot/aegis-boot/issues/565)
+
+## Context
+
+A substantive plan from gpt5.5 proposed extending aegis-boot with a full netboot delivery path: an `aegis-netbootd` daemon serving generated iPXE menus, HTTP-served kernel/initrd/cmdline profiles, optional iPXE chainloading, a local mirrored asset cache, optional TFTP / proxy-DHCP adapters, and eventual UEFI HTTP boot endpoints. The plan framed this as the second of two delivery paths under an "Aegis Boot" umbrella.
+
+Audit of the codebase found:
+
+- **Zero existing scaffolding.** No iPXE / PXE / TFTP / DHCP / HTTP-boot mentions anywhere in `crates/`, no TODO comments, no design notes.
+- **Explicit roadmap deferral.** [`ROADMAP.md`](../../ROADMAP.md) line 22: *"Network boot / PXE — explicitly out of scope for v1.0; reconsider if real users ask."*
+- **No demand signal.** No GitHub issue from any operator describing a netboot need; no maintainer commitment to operate a netboot lab.
+
+## Decision
+
+**Defer the netboot daemon.** No `aegis-netbootd` binary, no `aegis-netboot` crate, no iPXE menu rendering function in this milestone.
+
+The compatible foundation will be laid by [#557 (M1A)](https://github.com/aegis-boot/aegis-boot/issues/557): `BootEntryKind::Netboot` is reserved as a documented enum variant so a future netboot epic can attach without re-architecting the boot-entry model.
+
+## Re-entry criteria
+
+Reconsider netboot when ALL of:
+
+1. **≥2 distinct user issues** mention a netboot need (not "would be nice"; a concrete deployment scenario).
+2. **A maintainer commits** to operating a netboot lab in their own infrastructure for development and CI testing.
+3. **OR** an enterprise commitment that includes both a deployment to test against and a maintainer to land + maintain the work.
+
+Either path produces a new epic that cites this ADR and reopens the design.
+
+## Rationale (from the consensus_vote)
+
+- **Architect:** *"10-crate refactor compounded by inventing demand for netboot/iPXE/PXE that the ROADMAP explicitly defers… textbook DRY violation… YAGNI at scale."*
+- **Security:** *"Implementing full netboot opens the system to network-based attacks such as rogue DHCP, PXE spoofing, and MITM on boot streams, which is unjustified given the ROADMAP explicitly defers this to post-v1.0."*
+- **DevEx:** *"Substantial API and tooling surface without improving the primary user workflow enough to justify the learning and maintenance cost."*
+- **PM:** *"No user signal, no build."*
+- **Contrarian:** *"Textbook example of second-system syndrome."*
+
+## What stays in scope
+
+- The `BootEntryKind` enum reserves a `Netboot` variant for future use ([#557](https://github.com/aegis-boot/aegis-boot/issues/557)).
+- The architecture doc ([#569](https://github.com/aegis-boot/aegis-boot/issues/569)) frames netboot as a deferred delivery, not a missing one.
+- This ADR.
+
+## What stays out
+
+- iPXE menu rendering function (failed YAGNI test in the consensus vote — even as a "validate the direction" probe, the panel rejected it as speculative scaffolding).
+- A `aegis-netboot` crate.
+- A separate `aegis-netbootd` binary.
+- TFTP / proxy-DHCP / UEFI HTTP boot adapters.
+- Mirrored asset cache for netboot delivery.
+
+## References
+
+- Plan that proposed the daemon: provided to the maintainer 2026-04-25.
+- Codebase audit: parallel-Explore subagents on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556).
+- ROADMAP.md line 22.

--- a/docs/adr/0004-defer-golden-image-registry.md
+++ b/docs/adr/0004-defer-golden-image-registry.md
@@ -1,0 +1,57 @@
+# ADR 0004: Defer the golden-image registry / drift-detection subsystem
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Deciders:** Audit-driven decision on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556) — flagged as greenfield + speculative by all 6 agents in the higher-order consensus vote.
+**Tracking issue:** [#566](https://github.com/aegis-boot/aegis-boot/issues/566)
+
+## Context
+
+The gpt5.5 plan proposed a "golden-image validation" subsystem comparing systems against expected baselines: OS / version, Secure Boot state, disk-encryption expectations, partition layout, installed bootloader, recovery partition, firmware expectations, baseline provisioning. Outputs would include pass/fail reports, drift reports, JSON for automation, Markdown for humans.
+
+Audit of the codebase found:
+
+- **One narrow precedent**: [`update.rs`](../../crates/aegis-cli/src/update.rs) computes a per-file ESP sha256 diff for in-place update eligibility. That's point-in-time comparison against a freshly-built reference, not a stored baseline.
+- **Zero registry**, zero drift-detection state, zero "expected baseline" type.
+- **No active operator workflow** has surfaced that needs full baseline tracking. ROADMAP.md doesn't mention it.
+
+## Decision
+
+**Defer the golden-image registry.** No baseline-store crate, no drift-report generator, no compliance-audit subcommand in this milestone.
+
+The current `update --eligibility` path is sufficient for the v1.0 use case (in-place signed-chain rotation). The raw material for a future drift-detection layer already exists in `Manifest.esp_files[]` and `Attestation.target.image_sha256` — no schema change is needed to start that work later.
+
+## Re-entry criteria
+
+Reconsider when:
+
+1. An operator files a concrete workflow describing the comparison they need: *which fields*, *against what reference*, *on what cadence*.
+2. AND that workflow can't be served by `update --eligibility` plus `verify --stick`.
+
+A future epic that re-opens this records the specific operator scenarios it serves.
+
+## Rationale
+
+- **YAGNI**: speculative scaffolding before a concrete operator requirement.
+- **Existing primitives suffice**: the data we'd need to compute drift (ESP file hashes, attestation manifest, ISO sidecars) is already captured. A future drift layer is a *consumer* of existing data, not a producer of new data.
+- **Scope discipline**: the gpt5.5 plan bundled this with 5 other large feature areas in one push; treating it as a separate epic preserves the option to design it well when the requirement is clear.
+
+## What stays in scope
+
+- `update --eligibility` (existing) — point-in-time ESP comparison for the in-place update path.
+- `verify --stick` (existing) — re-hash all ISOs against their sidecars.
+- `Attestation` JSON written per flash (existing) — captures the source-side baseline at flash time.
+- This ADR.
+
+## What stays out
+
+- A `aegis-baseline` crate or registry.
+- A `aegis-boot drift` subcommand.
+- A "golden image" JSON Schema / wire format.
+- Cron-style continuous-validation tooling.
+
+## References
+
+- [`crates/aegis-cli/src/update.rs`](../../crates/aegis-cli/src/update.rs) — the existing point-in-time ESP diff.
+- Codebase audit: parallel-Explore subagents on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556).
+- ADR 0002 (KEY_MANAGEMENT) for the trust-anchor model that any future drift layer would have to respect.

--- a/docs/adr/0005-defer-recovery-profiles-distinct-type.md
+++ b/docs/adr/0005-defer-recovery-profiles-distinct-type.md
@@ -1,0 +1,58 @@
+# ADR 0005: Recovery profiles are not yet a distinct typed subsystem
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Deciders:** Audit-driven decision on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556) — the "first-class profile type" framing is rejected; a future "fourth profile slug" within the existing `Profile` array is the cheap re-entry path.
+**Tracking issue:** [#567](https://github.com/aegis-boot/aegis-boot/issues/567)
+
+## Context
+
+The gpt5.5 plan proposed recovery profiles as a first-class typed subsystem with submodes: disk triage, file recovery, malware triage, memory capture, evidence collection, network troubleshooting, secure wipe. Outputs would include `recovery-report.json`, `evidence-manifest.json`, `hashes.sha256`, `operator-notes.md`.
+
+Audit of the codebase found:
+
+- **Existing profile scaffolding**: [`crates/aegis-cli/src/init.rs`](../../crates/aegis-cli/src/init.rs) defines a `Profile` struct (name + description + slugs array) plus three profiles: `panic-room`, `minimal`, `server`. Recovery is conceptually a fourth slug, not a new type.
+- **`bug-report` exists** but it's an operator-bug-draft generator with PII redaction, not an incident-response evidence-capture pipeline.
+- **No specific operator workflow** has surfaced that requires the listed evidence-manifest fields. The list reads as a "what could a recovery toolkit emit?" enumeration, not a "what does this specific operator need to recover from?" answer.
+
+## Decision
+
+**Defer recovery profiles as a distinct typed subsystem.** No new `RecoveryProfile` type, no `aegis-boot recover` subcommand, no `evidence-manifest.json` schema in this milestone.
+
+An operator who needs a recovery USB today can already use `aegis-boot init --profile minimal` (Alpine 3.20 with their tools of choice added) plus `aegis-boot bug-report` for the operator-evidence side.
+
+## Re-entry criteria
+
+Reconsider when ALL of:
+
+1. An operator describes a specific incident-response scenario in a GitHub issue (not "could be useful" — a real incident or near-miss).
+2. AND that scenario calls for evidence-manifest fields the existing `Attestation` + `bug-report` outputs don't already cover.
+3. AND a maintainer commits to the schema review + ongoing evolution (incident-response output formats are notoriously hard to evolve; the schema lock has long-tail consequences).
+
+The cheap path forward, when re-entry happens: add `recovery` as a fourth slug in the existing `Profile` array. Promote to its own type only if the data model genuinely needs it — `Profile { slugs: [...] }` may be enough.
+
+## Rationale
+
+- **YAGNI**: "what would a recovery toolkit emit?" is a poor design driver. Real incident-response workflows are specific.
+- **Existing primitive is sufficient**: a fourth `Profile` covers 80% of the operator value (a curated stick of recovery ISOs).
+- **Schema-lock cost**: an incident-response wire format is hard to revise once operators start scripting against it. Premature commitment is expensive.
+
+## What stays in scope
+
+- The existing `Profile` struct + 3 profiles.
+- `bug-report` for operator-side evidence.
+- `Attestation` for flash-time provenance.
+- This ADR.
+
+## What stays out
+
+- `RecoveryProfile` as a distinct type.
+- `evidence-manifest.json` wire format.
+- `aegis-boot recover` subcommand.
+- Disk-triage / memory-capture / malware-triage submodes as built-in workflows.
+
+## References
+
+- [`crates/aegis-cli/src/init.rs`](../../crates/aegis-cli/src/init.rs) — existing `Profile` struct + array.
+- [`crates/aegis-cli/src/bug_report.rs`](../../crates/aegis-cli/src/bug_report.rs) — existing operator-evidence path.
+- Codebase audit: parallel-Explore subagents on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556).

--- a/docs/adr/0006-no-usb-netboot-rebrand.md
+++ b/docs/adr/0006-no-usb-netboot-rebrand.md
@@ -1,0 +1,57 @@
+# ADR 0006: aegis-boot stays one product (no "Aegis Boot USB" + "Aegis Netboot" rebrand)
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Deciders:** 6-agent `consensus_vote` on [epic #556](https://github.com/aegis-boot/aegis-boot/issues/556). The Developer Experience role rejected the rebrand most strongly; the rest of the panel concurred in their reasoning.
+**Tracking issue:** [#568](https://github.com/aegis-boot/aegis-boot/issues/568)
+
+## Context
+
+The gpt5.5 plan proposed a rebrand: "Aegis Boot" as an umbrella platform, with two delivery sub-products:
+
+- **Aegis Boot USB** — portable trusted USB boot workflows
+- **Aegis Netboot** — trusted PXE / iPXE / UEFI HTTP boot workflows
+
+Implementation: split into ~10 crates including `aegis-boot-usb`, `aegis-netboot`, `aegis-netbootd`. CLI surface to remain unified via `aegis-boot {usb, netboot, verify, doctor, pack}`.
+
+## Decision
+
+**Keep aegis-boot as one product, one CLI binary, one umbrella name.** No "Aegis Boot USB" / "Aegis Netboot" rebrand.
+
+The umbrella concept itself is correct and worth landing in [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) ([#569](https://github.com/aegis-boot/aegis-boot/issues/569)) — but as one product with one current delivery (USB) and one deferred delivery (netboot, per ADR 0003), not as two parallel sub-products.
+
+## Re-entry criteria
+
+Reconsider the rebrand when:
+
+1. ADR 0003 re-enters AND netboot ships to ≥1 real operator. At that point a sub-brand may help disambiguate the two delivery paths.
+2. OR a future product expansion (e.g., a SaaS attestation receiver, a hardened-kernel build service) needs naming separation.
+
+Until then, the rebrand is documentation churn with no operator value.
+
+## Rationale (from the consensus_vote)
+
+- **DevEx (most strongly):** *"From a developer-experience perspective, the rebrand and crate split add substantial API and tooling surface without improving the primary user workflow enough to justify the learning and maintenance cost. The audit shows most of the plan overlaps existing crates and concepts, so the proposal mostly redistributes logic developers already need to understand instead of reducing complexity."*
+- **PM:** *"Operator value: rebrand to 'Aegis Boot USB + Aegis Netboot' helps no current user (ROADMAP confirms no netboot demand) and creates documentation/marketing churn."*
+- **Architect:** *"10-crate refactor compounded by a 10-crate release-coordination tax. Reversibility favors B decisively — additive changes can always be extended; premature crate splits are expensive to undo."*
+
+A sub-brand implies a maturity level the netboot path doesn't have (it's deferred entirely per ADR 0003). Adopting the sub-brand before the underlying product exists is marketing in advance of substance.
+
+## What stays in scope
+
+- One product: `aegis-boot`.
+- One CLI binary: `aegis-boot`.
+- One umbrella concept (per [#569](https://github.com/aegis-boot/aegis-boot/issues/569)): trusted boot, recovery, and provisioning tooling, with USB as the current delivery.
+- This ADR.
+
+## What stays out
+
+- "Aegis Boot USB" / "Aegis Netboot" as parallel sub-product names.
+- `aegis-boot-usb` and `aegis-netboot` as separate crates (audit found `aegis-boot-usb` would be an extraction of existing flash + detect logic with no obvious win; `aegis-netboot` is greenfield and ADR 0003 defers it).
+- `aegis-netbootd` as a separate binary (ADR 0003).
+- A "platform" framing in marketing copy (we're a tool; let it grow into a platform if real demand arrives).
+
+## References
+
+- [ADR 0003](./0003-defer-netboot-daemon.md) — defers the netboot daemon, which is the prerequisite for ever needing a sub-brand.
+- [#569](https://github.com/aegis-boot/aegis-boot/issues/569) — the umbrella-concept architecture-doc section that lands the framing without the rebrand.


### PR DESCRIPTION
## Summary

Four ADRs landing the consensus-vote outcome from epic #556. A substantive plan from gpt5.5 proposed a 10-crate refactor + a USB/Netboot rebrand + 6 new feature areas. Codebase audit found 7 of 10 crates overlap existing code and 4 of 6 features have meaningful scaffolding. The genuinely-new pieces are documented as deferred-with-criteria here.

| ADR | Decision | Re-entry trigger |
| --- | --- | --- |
| 0003 — netboot daemon | Defer | ≥2 user requests OR maintainer netboot-lab commitment |
| 0004 — golden-image registry | Defer | Concrete operator scenario describing what comparison they need |
| 0005 — recovery profiles as distinct type | Defer | Real incident-response use case + maintainer schema-evolution commitment |
| 0006 — USB/Netboot rebrand | Defer | ADR 0003 re-enters AND netboot ships to ≥1 real operator |

## Why ADRs first

The consensus_vote (higher_order, 6 roles) on epic #556 was unanimous-by-reasoning for the additive milestone-1 scope. Locking those decisions in ADRs **before** any code work means future contributors can reopen each call cleanly when conditions change — without re-litigating the audit + vote.

Each ADR cites the actual reasoning from the voting roles (Architect, Security, AI/ML, PM, DevEx, Contrarian), the raw codebase audit findings, and explicit re-entry criteria. They don't say "no" — they say "not yet, here's what would change our mind."

## Doc-only PR

No code changes, no risk. Adds 4 markdown files in \`docs/adr/\`. Pre-existing ADR 0001 + 0002 unchanged.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] All cross-references between ADRs are valid
- [ ] CI green (doc-only; should pass every job)

Refs: epic #556, gpt5.5 plan provided 2026-04-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)