### PR TITLE
docs(architecture): umbrella-concept section + ADR 0003-0006 cross-refs (closes #569)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,42 @@
 
 One-page mental model for contributors. For decision rationale see [ADR 0001](./adr/0001-runtime-architecture.md). For threat boundaries see [THREAT_MODEL.md](../THREAT_MODEL.md).
 
+## What aegis-boot is
+
+aegis-boot is **trusted boot, recovery, and provisioning tooling** — a CLI that takes a blank USB stick to a booted ISO with the chain of trust visible at every step.
+
+Concretely, the value proposition is:
+
+- **Sign-time + flash-time provenance** — the on-stick `Manifest` records what was written; the host-side `Attestation` records who flashed it, where from, and what verified.
+- **Boot-time enforcement** — `KEXEC_SIG` rejects unsigned kernels under Secure Boot, with a `mokutil`-paste-ready remedy when the operator has the signing key.
+- **Operator-facing trust verdicts** — rescue-tui surfaces a six-tier verdict (verified / unverified / hash-mismatch / parse-failed / boot-blocked) without burying the trust state in logs.
+
+USB is the delivery mechanism today. Network boot (PXE / iPXE / UEFI HTTP boot) is a deferred delivery — see [ADR 0003](./adr/0003-defer-netboot-daemon.md) for why and the explicit re-entry criteria.
+
+### What aegis-boot is NOT
+
+Honest framing helps operators choose the right tool:
+
+- **Not a Ventoy clone.** Ventoy boots arbitrary ISOs by patching them or chainloading their loaders; aegis-boot kexec's a verified rescue kernel into the chosen ISO, preserving Secure Boot end-to-end.
+- **Not a desktop-distro launcher.** The target is admins flashing rescue / install / provisioning media on demand, not "always have 30 distros on a stick."
+- **Not a container scanner / generic security tool.** The trust we model is boot-chain trust (UEFI → shim → grub → kernel → ISO kexec), not application-layer trust.
+- **Not a password manager / secret vault.** Operators bring their own.
+- **Not an enterprise imaging-suite replacement.** No central server, no inventory, no policy engine. Single-operator workflows are the design center.
+
+### Umbrella concept (forward-looking)
+
+The shape is one product with multiple delivery types. Today only the ISO-on-USB delivery is implemented. Future delivery types are reserved as variants on [`BootEntryKind`](../crates/iso-parser/src/lib.rs) (issue #557 — landed alongside this section) and gated by ADRs:
+
+| Delivery | Status | Re-entry |
+| --- | --- | --- |
+| ISO on USB | Shipping | — |
+| Netboot (PXE / iPXE / UEFI HTTP boot) | Deferred | [ADR 0003](./adr/0003-defer-netboot-daemon.md) — ≥2 user requests OR maintainer netboot-lab commitment |
+| Recovery profiles as a distinct typed subsystem | Deferred | [ADR 0005](./adr/0005-defer-recovery-profiles-distinct-type.md) — concrete operator scenario + schema-evolution commitment |
+| Provisioning profiles (kickstart / autoinstall / cloud-init refs) | Deferred | Same ADR 0005 |
+| Golden-image baseline / drift detection | Deferred | [ADR 0004](./adr/0004-defer-golden-image-registry.md) — concrete comparison workflow |
+
+There is no "Aegis Boot USB" / "Aegis Netboot" sub-brand split. The CLI stays unified as `aegis-boot`. See [ADR 0006](./adr/0006-no-usb-netboot-rebrand.md) for the rebrand decision.
+
 ## Boot chain
 
 ```


### PR DESCRIPTION
## Summary

Lands the framing the gpt5.5 plan got right: aegis-boot is **one product** (trusted boot, recovery, provisioning) with **USB as the current delivery** and **netboot as a deferred delivery**.

Adds a "What aegis-boot is" section near the top of \`docs/ARCHITECTURE.md\` covering:

- One-paragraph value proposition.
- A "What aegis-boot is NOT" list (Ventoy clone, container scanner, password manager, enterprise imaging suite) — direct from the gpt5.5 plan's honest framing.
- A delivery-type table mapping each future capability to its controlling ADR.

## Cross-references

The new section links every future-delivery row to its ADR:

| Delivery | Status | Re-entry ADR |
| --- | --- | --- |
| ISO on USB | Shipping | — |
| Netboot | Deferred | ADR 0003 |
| Recovery profiles as distinct type | Deferred | ADR 0005 |
| Provisioning profiles | Deferred | ADR 0005 |
| Golden-image / drift | Deferred | ADR 0004 |

Plus a pointer to ADR 0006 (rebrand decision) and to PR #571's \`BootEntryKind\` as the forward-compat hook every future variant will attach to.

## Doc-only

No code changes, no risk. Adds 36 lines to \`docs/ARCHITECTURE.md\`. Existing sections unchanged.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] All ADR cross-references resolve (PR #570 lands first or in parallel)
- [ ] CI green (doc-only)

Refs: epic #556, issue #569, depends on PR #570 (ADRs) + PR #571 (BootEntryKind) for the full cross-reference web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)