### PR TITLE
feat(doctor): full block-device inventory (closes #560)

### DIFF
--- a/crates/aegis-cli/src/detect/linux.rs
+++ b/crates/aegis-cli/src/detect/linux.rs
@@ -6,7 +6,7 @@
 //! devices. Filters out system drives, `NVMe`, loop devices, and anything
 //! not flagged as removable by the kernel.
 
-use super::Drive;
+use super::{BlockDevice, BlockDeviceTransport, Drive};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -58,6 +58,89 @@ pub fn list_removable_drives() -> Vec<Drive> {
     drives
 }
 
+/// Scan `/sys/block` for ALL block devices an operator might care about,
+/// regardless of removable bit. Used by `doctor` to surface a full disk
+/// inventory (#560).
+///
+/// Includes: `sd*` (SCSI/SATA/USB), `nvme*n*` (`NVMe` namespaces), `vd*`
+/// (virtio), `mmcblk*` (SD/eMMC). Excludes: `loop*`, `ram*`, `dm-*`,
+/// `sr*` (optical), `zram*` — none of which are persistent installable
+/// targets and would just clutter the inventory row.
+///
+/// Best-effort: missing sysfs files surface as `Unknown` transport,
+/// `(unknown model)` text, or `0` size. The doctor row is informational
+/// only, never a Fail trigger.
+#[must_use]
+pub fn list_block_devices() -> Vec<BlockDevice> {
+    let Ok(entries) = fs::read_dir("/sys/block") else {
+        return Vec::new();
+    };
+    let mut devices: Vec<BlockDevice> = entries
+        .flatten()
+        .filter_map(|entry| build_block_device(&entry.path()))
+        .collect();
+    devices.sort_by(|a, b| a.dev.cmp(&b.dev));
+    devices
+}
+
+fn build_block_device(sysdir: &Path) -> Option<BlockDevice> {
+    let name_os = sysdir.file_name()?;
+    let name = name_os.to_string_lossy().into_owned();
+    if !is_inventoried_block_device(&name) {
+        return None;
+    }
+    let model = read_sysfs_str(&sysdir.join("device/model"))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(unknown model)".to_string());
+    let size_bytes = read_sysfs_int_u64(&sysdir.join("size")).unwrap_or(0) * 512;
+    let removable = read_sysfs_int(&sysdir.join("removable")) == Some(1);
+    let transport = classify_transport(sysdir, &name);
+    Some(BlockDevice {
+        dev: PathBuf::from(format!("/dev/{name}")),
+        model,
+        size_bytes,
+        removable,
+        transport,
+    })
+}
+
+fn is_inventoried_block_device(name: &str) -> bool {
+    // Whitelist persistent storage prefixes; drop pseudo / volatile / optical.
+    name.starts_with("sd")
+        || name.starts_with("nvme")
+        || name.starts_with("vd")
+        || name.starts_with("mmcblk")
+        || name.starts_with("xvd")
+}
+
+fn classify_transport(sysdir: &Path, name: &str) -> BlockDeviceTransport {
+    if name.starts_with("nvme") {
+        return BlockDeviceTransport::Nvme;
+    }
+    if name.starts_with("vd") || name.starts_with("xvd") {
+        return BlockDeviceTransport::Virtio;
+    }
+    if name.starts_with("mmcblk") {
+        return BlockDeviceTransport::Mmc;
+    }
+    // For sd* the bus type is reported under device/../subsystem (a symlink
+    // pointing into /sys/bus/{usb,scsi,ata,...}). Read the resolved target's
+    // last component as the transport label.
+    let subsystem = sysdir.join("device/subsystem");
+    if let Ok(resolved) = fs::read_link(&subsystem) {
+        if let Some(last) = resolved.file_name() {
+            return match last.to_string_lossy().as_ref() {
+                "usb" => BlockDeviceTransport::Usb,
+                "scsi" => BlockDeviceTransport::Scsi,
+                "ata" | "sata" => BlockDeviceTransport::Sata,
+                _ => BlockDeviceTransport::Unknown,
+            };
+        }
+    }
+    BlockDeviceTransport::Unknown
+}
+
 fn read_sysfs_str(path: &Path) -> Option<String> {
     fs::read_to_string(path).ok()
 }
@@ -68,4 +151,63 @@ fn read_sysfs_int(path: &Path) -> Option<i64> {
 
 fn read_sysfs_int_u64(path: &Path) -> Option<u64> {
     read_sysfs_str(path)?.trim().parse().ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::missing_panics_doc)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_inventoried_keeps_persistent_prefixes() {
+        for keep in ["sda", "sdb1", "nvme0n1", "vda", "xvdc", "mmcblk0"] {
+            assert!(
+                is_inventoried_block_device(keep),
+                "expected {keep} to be inventoried"
+            );
+        }
+    }
+
+    #[test]
+    fn is_inventoried_drops_pseudo_and_optical() {
+        for drop in ["loop0", "ram0", "dm-0", "sr0", "zram0"] {
+            assert!(
+                !is_inventoried_block_device(drop),
+                "expected {drop} to be excluded"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_transport_dispatches_on_name_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Name-only dispatch covers nvme/virtio/mmc without needing sysfs
+        // symlinks.
+        assert_eq!(
+            classify_transport(tmp.path(), "nvme0n1"),
+            BlockDeviceTransport::Nvme
+        );
+        assert_eq!(
+            classify_transport(tmp.path(), "vda"),
+            BlockDeviceTransport::Virtio
+        );
+        assert_eq!(
+            classify_transport(tmp.path(), "xvdc"),
+            BlockDeviceTransport::Virtio
+        );
+        assert_eq!(
+            classify_transport(tmp.path(), "mmcblk0"),
+            BlockDeviceTransport::Mmc
+        );
+    }
+
+    #[test]
+    fn classify_transport_returns_unknown_for_sd_without_subsystem() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No device/subsystem symlink → Unknown (graceful fallback).
+        assert_eq!(
+            classify_transport(tmp.path(), "sda"),
+            BlockDeviceTransport::Unknown
+        );
+    }
 }

--- a/crates/aegis-cli/src/detect/mod.rs
+++ b/crates/aegis-cli/src/detect/mod.rs
@@ -68,6 +68,7 @@ pub fn list_block_devices() -> Option<Vec<BlockDevice>> {
 /// per device. Includes both removable (USB sticks, SD cards) and fixed
 /// (`NVMe`, SATA SSDs) media — `removable` distinguishes them.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
 pub struct BlockDevice {
     /// Block device path (e.g. `/dev/nvme0n1`, `/dev/sda`).
     pub dev: PathBuf,
@@ -84,7 +85,7 @@ pub struct BlockDevice {
 impl BlockDevice {
     /// Human-readable capacity (mirrors `Drive::size_human`).
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, dead_code)]
     pub fn size_human(&self) -> String {
         let gb = self.size_bytes as f64 / 1_073_741_824.0;
         if gb >= 1.0 {
@@ -100,7 +101,13 @@ impl BlockDevice {
 /// prefix or — for SCSI/SATA `sd*` devices — the resolved
 /// `device/subsystem` symlink target. `Unknown` when neither yields a
 /// definitive answer; the doctor row still surfaces the device.
+///
+/// `dead_code` is allowed because the constructor lives in the
+/// Linux-only `detect::linux` module — on macOS/Windows the variants are
+/// reachable through public API but never constructed in-tree, which the
+/// dead-code lint flags. The enum is part of the cross-platform surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum BlockDeviceTransport {
     Nvme,
     Sata,
@@ -114,6 +121,7 @@ pub enum BlockDeviceTransport {
 impl BlockDeviceTransport {
     /// Lowercase short label suitable for inline doctor-row prose.
     #[must_use]
+    #[allow(dead_code)]
     pub fn label(self) -> &'static str {
         match self {
             BlockDeviceTransport::Nvme => "nvme",

--- a/crates/aegis-cli/src/detect/mod.rs
+++ b/crates/aegis-cli/src/detect/mod.rs
@@ -41,6 +41,92 @@ pub fn list_removable_drives() -> Vec<Drive> {
     Vec::new()
 }
 
+/// Cross-platform full block-device inventory used by `doctor` (#560).
+/// Linux returns `Some(devices)`; macOS and Windows return `None` so the
+/// doctor row falls back to a Skip with a platform note rather than
+/// silently emitting "0 disks detected".
+///
+/// `clippy::unnecessary_wraps` is silenced here because the `Option`
+/// disappears on Linux under the cfg gate — clippy only sees the active
+/// branch and assumes `None` is unreachable. The cross-platform contract
+/// is what matters; allowing the lint preserves the API shape.
+#[must_use]
+#[allow(clippy::unnecessary_wraps)]
+pub fn list_block_devices() -> Option<Vec<BlockDevice>> {
+    #[cfg(target_os = "linux")]
+    {
+        Some(linux::list_block_devices())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// A persistent block device the operator might flash, image, or use as
+/// an install target. Surfaces in `aegis-boot doctor` output as one row
+/// per device. Includes both removable (USB sticks, SD cards) and fixed
+/// (`NVMe`, SATA SSDs) media — `removable` distinguishes them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockDevice {
+    /// Block device path (e.g. `/dev/nvme0n1`, `/dev/sda`).
+    pub dev: PathBuf,
+    /// Human-readable model string from sysfs `device/model`.
+    pub model: String,
+    /// Capacity in bytes (zero if sysfs `size` is missing).
+    pub size_bytes: u64,
+    /// Kernel-reported removable flag (`/sys/block/<dev>/removable == 1`).
+    pub removable: bool,
+    /// Bus / transport classification — informational, not load-bearing.
+    pub transport: BlockDeviceTransport,
+}
+
+impl BlockDevice {
+    /// Human-readable capacity (mirrors `Drive::size_human`).
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn size_human(&self) -> String {
+        let gb = self.size_bytes as f64 / 1_073_741_824.0;
+        if gb >= 1.0 {
+            format!("{gb:.1} GB")
+        } else {
+            let mb = self.size_bytes as f64 / 1_048_576.0;
+            format!("{mb:.0} MB")
+        }
+    }
+}
+
+/// Bus classification for a [`BlockDevice`]. Derived from the device-name
+/// prefix or — for SCSI/SATA `sd*` devices — the resolved
+/// `device/subsystem` symlink target. `Unknown` when neither yields a
+/// definitive answer; the doctor row still surfaces the device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockDeviceTransport {
+    Nvme,
+    Sata,
+    Scsi,
+    Usb,
+    Virtio,
+    Mmc,
+    Unknown,
+}
+
+impl BlockDeviceTransport {
+    /// Lowercase short label suitable for inline doctor-row prose.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            BlockDeviceTransport::Nvme => "nvme",
+            BlockDeviceTransport::Sata => "sata",
+            BlockDeviceTransport::Scsi => "scsi",
+            BlockDeviceTransport::Usb => "usb",
+            BlockDeviceTransport::Virtio => "virtio",
+            BlockDeviceTransport::Mmc => "mmc",
+            BlockDeviceTransport::Unknown => "unknown-bus",
+        }
+    }
+}
+
 /// A detected removable drive. Identical across platforms.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Drive {

--- a/crates/aegis-cli/src/doctor.rs
+++ b/crates/aegis-cli/src/doctor.rs
@@ -286,6 +286,7 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
     check_boot_mode(&mut report);
     check_tpm(&mut report);
     check_removable_drives(&mut report);
+    check_block_devices(&mut report);
     if !json_mode {
         println!();
         println!("Stick checks:");
@@ -1066,6 +1067,59 @@ fn read_tpm_from(sysfs_root: &str) -> TpmState {
         return TpmState::Present { version };
     }
     TpmState::SysfsEmpty
+}
+
+/// Surface the host's full block-device inventory (#560). Lists every
+/// persistent disk an operator might care about — fixed (`NVMe`, SATA,
+/// virtio) and removable (USB, SD/MMC) — with size, model, and bus.
+///
+/// Emits one summary row plus one row per device. Always non-fatal: this
+/// is informational context for `aegis-boot bug-report` and operators
+/// triaging "which stick is which" before flashing. macOS/Windows
+/// currently Skip — see `detect::list_block_devices` for the cross-
+/// platform plan in #123.
+fn check_block_devices(report: &mut Report) {
+    let summary_name = "block devices".to_string();
+    let Some(devices) = detect::list_block_devices() else {
+        report.add(
+            Verdict::Skip,
+            summary_name,
+            "block-device inventory not yet implemented on this platform (#123)",
+        );
+        return;
+    };
+
+    if devices.is_empty() {
+        report.add(
+            Verdict::Skip,
+            summary_name,
+            "no persistent block devices detected (loop/ram/optical excluded)",
+        );
+        return;
+    }
+
+    let removable = devices.iter().filter(|d| d.removable).count();
+    let fixed = devices.len() - removable;
+    report.add(
+        Verdict::Pass,
+        summary_name,
+        format!(
+            "{} detected ({fixed} fixed, {removable} removable)",
+            devices.len()
+        ),
+    );
+
+    for d in &devices {
+        let removable_label = if d.removable { ", removable" } else { "" };
+        let detail = format!(
+            "{} ({}, {}{removable_label}) — {}",
+            d.dev.display(),
+            d.size_human(),
+            d.transport.label(),
+            d.model
+        );
+        report.add(Verdict::Pass, format!("disk: {}", d.dev.display()), detail);
+    }
 }
 
 fn check_removable_drives(report: &mut Report) {
@@ -1993,5 +2047,58 @@ mod tests {
         assert_eq!(r.rows.len(), 1);
         assert!(matches!(r.rows[0].0, Verdict::Pass));
         assert!(r.rows[0].2.to_lowercase().contains("efi"));
+    }
+
+    // ---- block-device inventory (#560) -----------------------------------
+
+    #[test]
+    fn check_block_devices_always_emits_at_least_summary_row() {
+        // Whatever the local environment, the first row is the summary
+        // ("block devices"). On Linux it is Pass + count. On macOS/Windows
+        // it is Skip with a platform note.
+        let mut r = Report::new().with_json_mode(true);
+        check_block_devices(&mut r);
+        assert!(!r.rows.is_empty(), "must emit at least the summary row");
+        assert_eq!(r.rows[0].1, "block devices");
+        assert!(
+            matches!(r.rows[0].0, Verdict::Pass | Verdict::Skip),
+            "summary verdict must be Pass or Skip, got {:?}",
+            r.rows[0].0
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn check_block_devices_per_disk_rows_carry_size_and_bus_labels() {
+        // On a Linux host the summary is followed by one row per device
+        // whose detail string carries the size and a bus label. Bus may
+        // be `unknown-bus` on hosts where /sys/.../subsystem isn't a
+        // resolved symlink (e.g. some CI containers), so the assertion
+        // is structural — every row's detail contains "GB" or "MB" plus
+        // a parenthesized bus label.
+        let mut r = Report::new().with_json_mode(true);
+        check_block_devices(&mut r);
+        // Skip the summary row, walk per-disk rows.
+        for (verdict, name, detail) in r.rows.iter().skip(1) {
+            assert!(name.starts_with("disk: /dev/"), "row name shape: {name}");
+            assert!(
+                matches!(verdict, Verdict::Pass),
+                "per-disk verdict: {verdict:?}"
+            );
+            assert!(
+                detail.contains("GB") || detail.contains("MB"),
+                "detail must include size unit, got: {detail}"
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn check_block_devices_skips_on_non_linux() {
+        let mut r = Report::new().with_json_mode(true);
+        check_block_devices(&mut r);
+        assert_eq!(r.rows.len(), 1);
+        assert!(matches!(r.rows[0].0, Verdict::Skip));
+        assert!(r.rows[0].2.contains("#123"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `check_block_devices()` to `aegis-boot doctor` so operators get a complete picture of every persistent disk on the host — fixed (NVMe, SATA, virtio) and removable (USB, SD/MMC) — with size, model, bus, and removable bit.

The existing `check_removable_drives` row only surfaced removable USB sticks. With M1D, an operator triaging "which device is which?" before a flash, or filing a bug report, sees the full inventory in one place.

Emits one summary row plus one row per disk:

```
[✓ PASS] block devices                     2 detected (1 fixed, 1 removable)
[✓ PASS] disk: /dev/nvme0n1                /dev/nvme0n1 (931.5 GB, nvme) — Sabrent Rocket Q4
[✓ PASS] disk: /dev/sdb                    /dev/sdb (29.8 GB, scsi, removable) — Cruzer
```

## Implementation choices

- `detect::list_block_devices() -> Option<Vec<BlockDevice>>` — `Some` on Linux, `None` on macOS/Windows, so the doctor row falls back to a Skip with a platform note rather than misreporting "0 disks detected" on platforms where the inventory isn't implemented yet (#123).
- Linux scan is **sysfs-pure** — same pattern as `detect::linux::list_removable_drives`. No subprocess shell-out to `lsblk`. This keeps the binary deterministic and avoids adding a util-linux dependency.
- Whitelist of persistent prefixes (`sd*`, `nvme*`, `vd*`, `xvd*`, `mmcblk*`); blocks pseudo + optical (`loop*`, `ram*`, `dm-*`, `sr*`, `zram*`).
- Transport classification is name-prefix based for `nvme*`/`vd*`/`mmcblk*`. For `sd*` it resolves the `device/subsystem` symlink target (USB / SCSI / ATA). Falls back to `Unknown` on hosts where the symlink isn't present (some CI containers).
- **No JSON schema bump.** The disks surface as additional entries in the existing `rows[]` array — additive, no `schema_version: 1 → 2` cascade through bug-report.

## Test plan

- [x] `cargo +1.88.0 test -p aegis-bootctl --bin aegis-boot` — 736 tests pass (7 new: 4 in `detect::linux::tests`, 3 in `doctor::tests`)
- [x] `cargo +1.88.0 clippy -p aegis-bootctl --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run --bin aegis-boot -- doctor` shows summary row + one row per detected disk on this workstation (verified: NVMe 931.5 GB Sabrent + USB 29.8 GB Cruzer)

Refs: epic #556 milestone M1D.