### PR TITLE
feat(rescue-tui): cmdline editor Home/End/Ctrl+A/Ctrl+E (closes #544)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -22,7 +22,7 @@ use std::thread;
 use std::time::Duration;
 
 use crossterm::cursor::MoveTo;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
     Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -391,6 +391,26 @@ where
             }
         }
 
+        // Ctrl+A / Ctrl+E in the cmdline editor are readline-style
+        // line-start / line-end jumps. Intercept BEFORE the main match so
+        // the catch-all KeyCode::Char(c) → cmdline_insert(c) doesn't
+        // swallow them as literal 'a' / 'e'. (#544)
+        if matches!(state.screen, Screen::EditCmdline { .. })
+            && key.modifiers.contains(KeyModifiers::CONTROL)
+        {
+            match key.code {
+                KeyCode::Char('a') => {
+                    state.cmdline_cursor_home();
+                    continue;
+                }
+                KeyCode::Char('e') => {
+                    state.cmdline_cursor_end();
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
         match (&state.screen, key.code) {
             // Tab toggles focus between the list pane and the info pane
             // on the List screen only. Shift+Tab is treated the same
@@ -498,6 +518,8 @@ where
             (Screen::EditCmdline { .. }, KeyCode::Esc) => state.cancel_cmdline_edit(),
             (Screen::EditCmdline { .. }, KeyCode::Left) => state.cmdline_cursor_left(),
             (Screen::EditCmdline { .. }, KeyCode::Right) => state.cmdline_cursor_right(),
+            (Screen::EditCmdline { .. }, KeyCode::Home) => state.cmdline_cursor_home(),
+            (Screen::EditCmdline { .. }, KeyCode::End) => state.cmdline_cursor_end(),
             (Screen::EditCmdline { .. }, KeyCode::Backspace) => state.cmdline_backspace(),
             (Screen::EditCmdline { .. }, KeyCode::Char(c)) => state.cmdline_insert(c),
 

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -677,6 +677,22 @@ impl AppState {
         *cursor = new_cursor;
     }
 
+    /// Jump cursor to the start of the line (Home / Ctrl+A). #544.
+    pub fn cmdline_cursor_home(&mut self) {
+        let Screen::EditCmdline { cursor, .. } = &mut self.screen else {
+            return;
+        };
+        *cursor = 0;
+    }
+
+    /// Jump cursor to the end of the line (End / Ctrl+E). #544.
+    pub fn cmdline_cursor_end(&mut self) {
+        let Screen::EditCmdline { buffer, cursor, .. } = &mut self.screen else {
+            return;
+        };
+        *cursor = buffer.len();
+    }
+
     /// Jump to the first visible row (vim `g`). (#85). The visible
     /// view always has at least one row (the rescue-shell entry
     /// since #90), so the `has_view` check is trivially true — kept
@@ -1802,6 +1818,60 @@ mod tests {
         // cursor=9 after backspaces → left→left moves to 7 (before 's');
         // inserting 'X' there gives "boot=ca" + "X" + "sp".
         assert_eq!(buffer, "boot=caXsp");
+    }
+
+    #[test]
+    fn cmdline_cursor_home_jumps_to_start() {
+        // #544: Home / Ctrl+A should move the cursor to byte 0 regardless
+        // of where it is when the key is pressed.
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        // Default buffer is "boot=casper", cursor at end (11).
+        s.cmdline_cursor_home();
+        let Screen::EditCmdline { cursor, .. } = &s.screen else {
+            panic!("expected EditCmdline")
+        };
+        assert_eq!(*cursor, 0);
+        // Inserting 'X' at home should land at index 0.
+        s.cmdline_insert('X');
+        let Screen::EditCmdline { buffer, cursor, .. } = &s.screen else {
+            panic!()
+        };
+        assert_eq!(buffer, "Xboot=casper");
+        assert_eq!(*cursor, 1);
+    }
+
+    #[test]
+    fn cmdline_cursor_end_jumps_to_buffer_len() {
+        // #544: End / Ctrl+E should move the cursor to buffer.len()
+        // regardless of where it is when the key is pressed.
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.confirm_selection();
+        s.enter_cmdline_editor();
+        // Move to the start, then jump to end.
+        s.cmdline_cursor_home();
+        s.cmdline_cursor_end();
+        let Screen::EditCmdline { buffer, cursor, .. } = &s.screen else {
+            panic!()
+        };
+        assert_eq!(*cursor, buffer.len());
+        // Append should land after the existing buffer.
+        s.cmdline_insert('!');
+        let Screen::EditCmdline { buffer, .. } = &s.screen else {
+            panic!()
+        };
+        assert_eq!(buffer, "boot=casper!");
+    }
+
+    #[test]
+    fn cmdline_cursor_home_and_end_are_idempotent_on_empty_screen() {
+        // Defensive: home / end called when not in cmdline editor must
+        // not panic (the early-return guard in state.rs covers this).
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        // Still on List screen — neither key should mutate state or panic.
+        s.cmdline_cursor_home();
+        s.cmdline_cursor_end();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds readline-style line-start / line-end navigation to the kernel cmdline editor in rescue-tui.

| Key | Action |
| --- | --- |
| Home, Ctrl+A | cursor → byte 0 |
| End, Ctrl+E | cursor → buffer.len() |

Closes the UX review T3A finding (#544): long cmdlines on narrow terminals were tedious to edit with arrow keys alone.

## Implementation note

\`Ctrl+A\` and \`Ctrl+E\` are intercepted **before** the main screen-match because the catch-all \`KeyCode::Char(c)\` arm would otherwise insert literal 'a'/'e' characters. The early-continue pattern is the minimum-invasive approach that doesn't reshape the match.

\`Home\` and \`End\` (no modifier) wire normally in the EditCmdline branch alongside Left / Right.

## Test plan

- [x] \`cargo +1.88.0 test -p rescue-tui --lib\` — 181 tests pass (3 new in \`state::tests\`)
- [x] \`cargo +1.88.0 clippy -p rescue-tui --tests -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean