### PR TITLE
feat(rescue-tui): Shift+↑/Shift+↓ scrolls info pane without losing list focus (closes #545)

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -411,6 +411,28 @@ where
             }
         }
 
+        // Shift+↑ / Shift+↓ on the List screen scrolls the info pane while
+        // keeping list-pane focus, mirroring tig/gitui/lazygit. Without
+        // this chord the operator has to Tab away from the list, scroll,
+        // then Tab back — losing their selection cursor. Intercept BEFORE
+        // the main match so the unmodified KeyCode::Up/Down arms route to
+        // the focused pane (existing behavior). (#545)
+        if matches!(state.screen, Screen::List { .. })
+            && key.modifiers.contains(KeyModifiers::SHIFT)
+        {
+            match key.code {
+                KeyCode::Up => {
+                    state.move_info_scroll(-1);
+                    continue;
+                }
+                KeyCode::Down => {
+                    state.move_info_scroll(1);
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
         match (&state.screen, key.code) {
             // Tab toggles focus between the list pane and the info pane
             // on the List screen only. Shift+Tab is treated the same

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -1984,6 +1984,24 @@ mod tests {
     }
 
     #[test]
+    fn move_info_scroll_does_not_change_pane_focus() {
+        // #545: Shift+↑ / Shift+↓ on List should scroll info pane WITHOUT
+        // moving focus off the list. The keybinding (in main.rs) calls
+        // `move_info_scroll` directly; this test pins the contract that
+        // the function does NOT mutate `pane`. If a future refactor adds
+        // pane-toggle side effects here, this test catches the regression
+        // and forces the keybinding to be reconsidered.
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        let pane_before = s.pane;
+        s.move_info_scroll(3);
+        s.move_info_scroll(-1);
+        assert_eq!(
+            s.pane, pane_before,
+            "info-scroll must not mutate pane focus (Shift+arrow contract)"
+        );
+    }
+
+    #[test]
     fn move_selection_resets_info_scroll() {
         // Per-ISO scroll state would confuse operators; resetting on
         // selection change matches gitui's pattern.


### PR DESCRIPTION
## Summary

Closes the UX review T3B finding: on the List screen, scrolling the info pane today requires Tab-ing away from the list, which loses the selection cursor. This PR adds the tig/gitui/lazygit convention:

| Key | Action |
| --- | --- |
| `↑` / `↓` (no modifier) | move whichever pane has focus (existing) |
| `Shift+↑` / `Shift+↓` | scroll **info pane** while keeping list focus (new) |

## Implementation

`main.rs` intercepts `Shift+Up` / `Shift+Down` BEFORE the main screen-match, same pattern as the #544 `Ctrl+A` / `Ctrl+E` intercept. Plain arrows continue to route to the focused pane — no behavior change for muscle memory.

`state::move_info_scroll` already implements the underlying mutation; this PR adds a regression test pinning that calling it does NOT change `pane` focus, so any future refactor that breaks the "stay on list" promise will fail the test.

## Test plan

- [x] `cargo +1.88.0 test -p rescue-tui --lib` — 182 tests pass (1 new in `state::tests`)
- [x] `cargo +1.88.0 clippy -p rescue-tui --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs: UX review epic #537, T3B finding.
