### PR TITLE
feat: --out / --out-dir / --cache-base interchangeable across subcommands (closes #541)

### DIFF
--- a/crates/aegis-cli/src/bundle_fetch.rs
+++ b/crates/aegis-cli/src/bundle_fetch.rs
@@ -304,15 +304,23 @@ fn parse_args(args: &[String]) -> Result<Args, u8> {
     while let Some(a) = iter.next() {
         match a.as_str() {
             "-h" | "--help" => out.help_requested = true,
-            "--cache-base" => {
+            // #541: --out / --out-dir / --cache-base are interchangeable
+            // across the four output-writing subcommands.
+            "--cache-base" | "--out" | "--out-dir" => {
                 let v = iter.next().ok_or_else(|| {
-                    eprintln!("aegis-boot fetch-trust-chain: --cache-base requires an argument");
+                    eprintln!("aegis-boot fetch-trust-chain: {a} requires an argument");
                     2u8
                 })?;
                 out.cache_base = Some(PathBuf::from(v));
             }
             s if s.starts_with("--cache-base=") => {
                 out.cache_base = Some(PathBuf::from(&s["--cache-base=".len()..]));
+            }
+            s if s.starts_with("--out=") => {
+                out.cache_base = Some(PathBuf::from(&s["--out=".len()..]));
+            }
+            s if s.starts_with("--out-dir=") => {
+                out.cache_base = Some(PathBuf::from(&s["--out-dir=".len()..]));
             }
             s if s.starts_with('-') => {
                 eprintln!("aegis-boot fetch-trust-chain: unknown flag {s:?}");
@@ -478,6 +486,59 @@ mod tests {
         ];
         let out = parse_args(&args).unwrap();
         assert_eq!(out.cache_base.as_deref(), Some(Path::new("/tmp/cache")));
+    }
+
+    // ---- #541: --out / --out-dir aliases for fetch-trust-chain --cache-base
+
+    #[test]
+    fn parse_args_accepts_out_alias_split_form() {
+        let args = vec![
+            "--out".to_string(),
+            "/tmp/aegis-bf".to_string(),
+            "https://example.invalid/".to_string(),
+        ];
+        let out = parse_args(&args).unwrap();
+        assert_eq!(out.cache_base.as_deref(), Some(Path::new("/tmp/aegis-bf")));
+    }
+
+    #[test]
+    fn parse_args_accepts_out_dir_alias_split_form() {
+        let args = vec![
+            "--out-dir".to_string(),
+            "/tmp/aegis-bf-od".to_string(),
+            "https://example.invalid/".to_string(),
+        ];
+        let out = parse_args(&args).unwrap();
+        assert_eq!(
+            out.cache_base.as_deref(),
+            Some(Path::new("/tmp/aegis-bf-od"))
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_out_alias_eq_form() {
+        let args = vec![
+            "--out=/tmp/aegis-bf-eq".to_string(),
+            "https://example.invalid/".to_string(),
+        ];
+        let out = parse_args(&args).unwrap();
+        assert_eq!(
+            out.cache_base.as_deref(),
+            Some(Path::new("/tmp/aegis-bf-eq"))
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_out_dir_alias_eq_form() {
+        let args = vec![
+            "--out-dir=/tmp/aegis-bf-od-eq".to_string(),
+            "https://example.invalid/".to_string(),
+        ];
+        let out = parse_args(&args).unwrap();
+        assert_eq!(
+            out.cache_base.as_deref(),
+            Some(Path::new("/tmp/aegis-bf-od-eq"))
+        );
     }
 
     #[test]

--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -222,9 +222,13 @@ fn parse_flags(args: &[String]) -> Result<Option<FetchFlags>, u8> {
                 print_help();
                 return Ok(None);
             }
-            "--out" => {
+            // #541: --out / --out-dir / --cache-base are interchangeable
+            // aliases across fetch, flash, fetch-image, and fetch-trust-chain.
+            // Operator muscle memory from `curl -o`, `cp --target-directory`,
+            // `tar -C` doesn't agree on a single name, so we accept all three.
+            "--out" | "--out-dir" | "--cache-base" => {
                 let Some(v) = iter.next() else {
-                    eprintln!("aegis-boot fetch: --out requires a directory argument");
+                    eprintln!("aegis-boot fetch: {a} requires a directory argument");
                     return Err(2);
                 };
                 out_dir = Some(PathBuf::from(v));
@@ -235,6 +239,12 @@ fn parse_flags(args: &[String]) -> Result<Option<FetchFlags>, u8> {
             "--progress" => no_progress = Some(false),
             arg if arg.starts_with("--out=") => {
                 out_dir = Some(PathBuf::from(arg.trim_start_matches("--out=")));
+            }
+            arg if arg.starts_with("--out-dir=") => {
+                out_dir = Some(PathBuf::from(arg.trim_start_matches("--out-dir=")));
+            }
+            arg if arg.starts_with("--cache-base=") => {
+                out_dir = Some(PathBuf::from(arg.trim_start_matches("--cache-base=")));
             }
             arg if arg.starts_with("--") => {
                 eprintln!("aegis-boot fetch: unknown option '{arg}'");
@@ -552,6 +562,84 @@ mod tests {
         .expect("parse ok")
         .expect("not --help");
         assert_eq!(parsed.no_progress, Some(false));
+    }
+
+    // ---- #541: --out / --out-dir / --cache-base aliases -------------------
+
+    #[test]
+    fn parse_flags_accepts_out_flag_split_form() {
+        let p = parse_flags(&[
+            "--out".to_string(),
+            "/tmp/aegis".to_string(),
+            "ubuntu-24.04-live-server".to_string(),
+        ])
+        .expect("parse ok")
+        .expect("not --help");
+        assert_eq!(
+            p.out_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/aegis"))
+        );
+    }
+
+    #[test]
+    fn parse_flags_accepts_out_dir_alias_split_form() {
+        // #541: --out-dir is a fetch alias for --out so muscle memory from
+        // `aegis-boot flash --out-dir` doesn't get a usage error here.
+        let p = parse_flags(&[
+            "--out-dir".to_string(),
+            "/tmp/aegis-od".to_string(),
+            "ubuntu-24.04-live-server".to_string(),
+        ])
+        .expect("parse ok")
+        .expect("not --help");
+        assert_eq!(
+            p.out_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/aegis-od"))
+        );
+    }
+
+    #[test]
+    fn parse_flags_accepts_cache_base_alias_split_form() {
+        // #541: --cache-base alias from `aegis-boot fetch-trust-chain`.
+        let p = parse_flags(&[
+            "--cache-base".to_string(),
+            "/tmp/aegis-cb".to_string(),
+            "ubuntu-24.04-live-server".to_string(),
+        ])
+        .expect("parse ok")
+        .expect("not --help");
+        assert_eq!(
+            p.out_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/aegis-cb"))
+        );
+    }
+
+    #[test]
+    fn parse_flags_accepts_out_dir_alias_equals_form() {
+        let p = parse_flags(&[
+            "--out-dir=/tmp/aegis-eq".to_string(),
+            "ubuntu-24.04-live-server".to_string(),
+        ])
+        .expect("parse ok")
+        .expect("not --help");
+        assert_eq!(
+            p.out_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/aegis-eq"))
+        );
+    }
+
+    #[test]
+    fn parse_flags_accepts_cache_base_alias_equals_form() {
+        let p = parse_flags(&[
+            "--cache-base=/tmp/aegis-eq2".to_string(),
+            "ubuntu-24.04-live-server".to_string(),
+        ])
+        .expect("parse ok")
+        .expect("not --help");
+        assert_eq!(
+            p.out_dir.as_deref(),
+            Some(std::path::Path::new("/tmp/aegis-eq2"))
+        );
     }
 
     #[test]

--- a/crates/aegis-cli/src/fetch_image.rs
+++ b/crates/aegis-cli/src/fetch_image.rs
@@ -438,16 +438,27 @@ fn parse_args(args: &[String]) -> Result<ParsedArgs, u8> {
             arg if arg.starts_with("--url=") => {
                 p.url = Some(arg["--url=".len()..].to_string());
             }
-            "--out" => {
+            // #541: --out / --out-dir / --cache-base are interchangeable
+            // across the four output-writing subcommands. fetch-image's
+            // canonical name is --out (its argument is a single output
+            // file path, not a directory, but the alias still works as
+            // operators expect).
+            "--out" | "--out-dir" | "--cache-base" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    eprintln!("aegis-boot fetch-image: --out requires a path");
+                    eprintln!("aegis-boot fetch-image: {a} requires a path");
                     return Err(2);
                 };
                 p.out = Some(PathBuf::from(v));
             }
             arg if arg.starts_with("--out=") => {
                 p.out = Some(PathBuf::from(&arg["--out=".len()..]));
+            }
+            arg if arg.starts_with("--out-dir=") => {
+                p.out = Some(PathBuf::from(&arg["--out-dir=".len()..]));
+            }
+            arg if arg.starts_with("--cache-base=") => {
+                p.out = Some(PathBuf::from(&arg["--cache-base=".len()..]));
             }
             "--sha256" => {
                 i += 1;
@@ -713,6 +724,36 @@ mod tests {
         let p = parse_args(&args).unwrap();
         assert_eq!(p.url.as_deref(), Some("https://example.com/img"));
         assert!(p.expected_sha256.is_some());
+    }
+
+    // ---- #541: --out-dir / --cache-base aliases for fetch-image --out -----
+
+    #[test]
+    fn parse_args_accepts_out_dir_alias_split_form() {
+        let args = vec!["--out-dir".to_string(), "/tmp/aegis-fi".to_string()];
+        let p = parse_args(&args).unwrap();
+        assert_eq!(p.out, Some(PathBuf::from("/tmp/aegis-fi")));
+    }
+
+    #[test]
+    fn parse_args_accepts_cache_base_alias_split_form() {
+        let args = vec!["--cache-base".to_string(), "/tmp/aegis-fi-cb".to_string()];
+        let p = parse_args(&args).unwrap();
+        assert_eq!(p.out, Some(PathBuf::from("/tmp/aegis-fi-cb")));
+    }
+
+    #[test]
+    fn parse_args_accepts_out_dir_alias_eq_form() {
+        let args = vec!["--out-dir=/tmp/aegis-fi-eq".to_string()];
+        let p = parse_args(&args).unwrap();
+        assert_eq!(p.out, Some(PathBuf::from("/tmp/aegis-fi-eq")));
+    }
+
+    #[test]
+    fn parse_args_accepts_cache_base_alias_eq_form() {
+        let args = vec!["--cache-base=/tmp/aegis-fi-cb-eq".to_string()];
+        let p = parse_args(&args).unwrap();
+        assert_eq!(p.out, Some(PathBuf::from("/tmp/aegis-fi-cb-eq")));
     }
 
     #[test]

--- a/crates/aegis-cli/src/flash.rs
+++ b/crates/aegis-cli/src/flash.rs
@@ -75,16 +75,27 @@ fn parse_args(args: &[String]) -> Result<ParsedArgs<'_>, u8> {
             "--no-progress" => p.no_progress = true,
             "--no-expand" => p.no_expand = true,
             "--direct-install" => p.direct_install = true,
-            "--out-dir" => {
+            // #541: --out / --out-dir / --cache-base are interchangeable
+            // across the four output-writing subcommands. Operators with
+            // muscle memory from `curl -o`, `cp --target-directory`, or
+            // `tar -C` get the obvious-on-first-guess behavior.
+            flag @ ("--out-dir" | "--out" | "--cache-base") => {
+                let flag_owned = flag.to_string();
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    eprintln!("aegis-boot flash: --out-dir requires a path argument");
+                    eprintln!("aegis-boot flash: {flag_owned} requires a path argument");
                     return Err(2);
                 };
                 p.out_dir = Some(PathBuf::from(v));
             }
             arg if arg.starts_with("--out-dir=") => {
                 p.out_dir = Some(PathBuf::from(&arg["--out-dir=".len()..]));
+            }
+            arg if arg.starts_with("--out=") => {
+                p.out_dir = Some(PathBuf::from(&arg["--out=".len()..]));
+            }
+            arg if arg.starts_with("--cache-base=") => {
+                p.out_dir = Some(PathBuf::from(&arg["--cache-base=".len()..]));
             }
             "--image" => {
                 i += 1;
@@ -2703,6 +2714,42 @@ mod tests {
         let argv = vec![String::from("--out-dir=/tmp/x")];
         let p = parse_args(&argv).unwrap();
         assert_eq!(p.out_dir, Some(PathBuf::from("/tmp/x")));
+    }
+
+    // ---- #541: --out / --cache-base aliases for flash --out-dir -----------
+
+    #[test]
+    fn parse_args_accepts_out_alias_split_form() {
+        // #541: muscle memory from `aegis-boot fetch --out` should work
+        // here too without re-reading the help.
+        let argv = vec![String::from("--out"), String::from("/tmp/aegis-flash")];
+        let p = parse_args(&argv).unwrap();
+        assert_eq!(p.out_dir, Some(PathBuf::from("/tmp/aegis-flash")));
+    }
+
+    #[test]
+    fn parse_args_accepts_cache_base_alias_split_form() {
+        // #541: muscle memory from `aegis-boot fetch-trust-chain --cache-base`.
+        let argv = vec![
+            String::from("--cache-base"),
+            String::from("/tmp/aegis-flash-cb"),
+        ];
+        let p = parse_args(&argv).unwrap();
+        assert_eq!(p.out_dir, Some(PathBuf::from("/tmp/aegis-flash-cb")));
+    }
+
+    #[test]
+    fn parse_args_accepts_out_alias_eq_form() {
+        let argv = vec![String::from("--out=/tmp/aegis-flash-eq")];
+        let p = parse_args(&argv).unwrap();
+        assert_eq!(p.out_dir, Some(PathBuf::from("/tmp/aegis-flash-eq")));
+    }
+
+    #[test]
+    fn parse_args_accepts_cache_base_alias_eq_form() {
+        let argv = vec![String::from("--cache-base=/tmp/aegis-flash-cb2")];
+        let p = parse_args(&argv).unwrap();
+        assert_eq!(p.out_dir, Some(PathBuf::from("/tmp/aegis-flash-cb2")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the UX review T2A finding (#541): three different flag names for "write output to this directory" across four subcommands meant first-time operators got `unknown flag` errors on the obvious-from-muscle-memory invocation.

After this PR, all four output-writing subcommands accept `--out`, `--out-dir`, `--cache-base` as exact aliases (split form AND equals form):

| Subcommand | Canonical (in --help) | Now also accepts |
| --- | --- | --- |
| `fetch` | `--out` | `--out-dir`, `--cache-base` |
| `flash` | `--out-dir` | `--out`, `--cache-base` |
| `fetch-image` | `--out` | `--out-dir`, `--cache-base` |
| `fetch-trust-chain` | `--cache-base` | `--out`, `--out-dir` |

Existing scripts that pin the canonical name continue to work unchanged.

## Why aliasing not deprecation

The issue suggested either aliasing or "pick one canonical and deprecate the other two." I went with aliasing because the semantic shape differs slightly per subcommand:

- `fetch --out` → directory (multiple files land there)
- `fetch-image --out` → single file path
- `flash --out-dir` → directory (image lands there)
- `fetch-trust-chain --cache-base` → cache root

Picking one canonical (e.g. `--out-dir`) would force `fetch-image`'s file-path argument under a misleading name. Aliasing preserves each subcommand's per-help canonical while removing the muscle-memory trap.

## Test plan

- [x] `cargo +1.88.0 test -p aegis-bootctl --bin aegis-boot` — 757 tests pass (17 new alias tests across 4 parsers)
- [x] `cargo +1.88.0 clippy -p aegis-bootctl --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs: UX review epic #537, T2A finding.
