### PR TITLE
feat(init): per-file progress header on profile fetches (closes #547)

### DIFF
--- a/crates/aegis-cli/src/init.rs
+++ b/crates/aegis-cli/src/init.rs
@@ -173,8 +173,9 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::from(code);
     }
 
-    for slug in profile.slugs {
-        if let Err(code) = fetch_and_add_step(slug, parsed.skip_gpg) {
+    let total = profile.slugs.len();
+    for (idx, slug) in profile.slugs.iter().enumerate() {
+        if let Err(code) = fetch_and_add_step(slug, parsed.skip_gpg, idx + 1, total) {
             return ExitCode::from(code);
         }
     }
@@ -232,9 +233,18 @@ fn flash_step(device: Option<&str>, assume_yes: bool, direct_install: bool) -> R
     })
 }
 
-fn fetch_and_add_step(slug: &str, skip_gpg: bool) -> Result<(), u8> {
+fn fetch_and_add_step(slug: &str, skip_gpg: bool, idx: usize, total: usize) -> Result<(), u8> {
     println!();
-    println!("--- {slug} ---");
+    // #547: per-file progress header. Operators on slow WiFi watching
+    // panic-room (~5 GB across multiple ISOs) couldn't tell whether
+    // the process was hung or just downloading the third ISO. The
+    // "fetch N/M: <slug> (<size>)" line answers "where am I in the
+    // batch and how big is the file" before curl's progress bar
+    // takes over the next ~minutes.
+    let size_hint = find_entry(slug)
+        .map(|e| format!(" (~{} MiB)", e.size_mib))
+        .unwrap_or_default();
+    println!("--- fetch {idx}/{total}: {slug}{size_hint} ---");
 
     let mut fetch_args: Vec<String> = Vec::new();
     if skip_gpg {


### PR DESCRIPTION
## Summary

Closes UX review T4A: `aegis-boot init --profile panic-room` downloads ~5 GB across multiple ISOs. Operators on slow WiFi couldn't tell whether the process was hung or just on the third file.

```
Before:                       After:
--- ubuntu-... ---            --- fetch 2/3: ubuntu-... (~1700 MiB) ---
```

The `N/M` position answers "how far am I in the batch?" and the size hint sets a download-time expectation before curl's `--progress-bar` takes over the next several minutes. The curl bar itself was already auto-enabled when stdout is a TTY (via `IsTerminal::is_terminal`); this PR just adds the surrounding header context.

## Implementation

- `fetch_and_add_step` gains `(idx, total)` params
- Loop in `init::run()` supplies them via `.enumerate()`
- `size_mib` comes from existing `catalog::Entry` — no new field
- `.unwrap_or_default()` falls back to empty size hint if slug isn't in catalog (defensive)

## Test plan

- [x] `cargo +1.88.0 test -p aegis-bootctl --bin aegis-boot init::` — 20 init tests pass
- [x] `cargo +1.88.0 clippy -p aegis-bootctl --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs: UX review epic #537, T4A finding.
