### PR TITLE
feat(rescue-tui): explain-why toast on Enter over tier-4 blocked row (closes #546)

### DIFF
--- a/crates/rescue-tui/src/docgen.rs
+++ b/crates/rescue-tui/src/docgen.rs
@@ -141,6 +141,7 @@ fn screen_short_name(s: ScreenKind) -> String {
         ScreenKind::Help => "Help",
         ScreenKind::ConfirmQuit => "ConfirmQuit",
         ScreenKind::Quitting => "Quitting",
+        ScreenKind::BlockedToast => "BlockedToast",
     };
     name.to_string()
 }

--- a/crates/rescue-tui/src/keybindings.rs
+++ b/crates/rescue-tui/src/keybindings.rs
@@ -47,6 +47,8 @@ pub(crate) enum ScreenKind {
     ConfirmQuit,
     /// Quitting (terminal state; no bindings).
     Quitting,
+    /// "Cannot boot" toast over a tier-4 row. (#546)
+    BlockedToast,
 }
 
 impl ScreenKind {
@@ -63,6 +65,7 @@ impl ScreenKind {
             Screen::Help { .. } => Self::Help,
             Screen::ConfirmQuit { .. } => Self::ConfirmQuit,
             Screen::Quitting => Self::Quitting,
+            Screen::BlockedToast { .. } => Self::BlockedToast,
         }
     }
 }

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -353,6 +353,14 @@ where
             continue;
         }
 
+        // BlockedToast (#546) — any key dismisses back to List. Lives
+        // here alongside Help/ConfirmQuit so the toast doesn't fall
+        // through to the main match's per-screen bindings.
+        if matches!(state.screen, Screen::BlockedToast { .. }) {
+            state.dismiss_blocked_toast();
+            continue;
+        }
+
         let in_editor = matches!(state.screen, Screen::EditCmdline { .. });
         let in_filter_input = state.filter_editing;
 

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -54,6 +54,9 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
     if let Screen::ConfirmQuit { .. } = &state.screen {
         draw_confirm_quit_overlay(frame, area, state);
     }
+    if let Screen::BlockedToast { message, .. } = &state.screen {
+        draw_blocked_toast_overlay(frame, area, state, message);
+    }
 }
 
 fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -85,6 +88,9 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         Screen::TrustChallenge { selected, buffer } => {
             draw_trust_challenge(frame, area, state, *selected, buffer);
         }
+        // BlockedToast (#546) renders the List underneath at return_to,
+        // then the toast popup paints on top via the overlay pass.
+        Screen::BlockedToast { return_to, .. } => draw_list(frame, area, state, *return_to),
         Screen::Quitting | Screen::Help { .. } | Screen::ConfirmQuit { .. } => {}
     }
 }
@@ -486,6 +492,46 @@ fn draw_confirm_quit_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState
         )),
     ];
     let block = Block::default().borders(Borders::ALL).title(" Confirm ");
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        panel,
+    );
+}
+
+/// Centered popup overlay for [`Screen::BlockedToast`] (#546). Two-line
+/// payload — the message itself plus a "press any key" dismiss hint —
+/// rendered with an error-tinted border so the operator immediately
+/// reads "this is a refusal, not a confirmation prompt." Sized to the
+/// max message width so long parse-failed reasons don't wrap awkwardly.
+fn draw_blocked_toast_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState, message: &str) {
+    // Width: hug the message, but cap to avoid edge-of-screen panels.
+    // Account for the "press any key to dismiss" hint as the floor.
+    const DISMISS_HINT: &str = "press any key to dismiss";
+    let content_width = message.len().max(DISMISS_HINT.len());
+    let w = u16::try_from(content_width.saturating_add(4))
+        .unwrap_or(u16::MAX)
+        .min(area.width)
+        .min(70);
+    let h: u16 = 5;
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let panel = Rect::new(x, y, w, h);
+    let lines = vec![
+        Line::from(Span::styled(
+            message.to_string(),
+            Style::default()
+                .fg(state.theme.error)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            DISMISS_HINT,
+            Style::default().fg(state.theme.warning),
+        )),
+    ];
+    let block = Block::default().borders(Borders::ALL).title(" Blocked ");
     frame.render_widget(
         Paragraph::new(lines)
             .block(block)

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -84,6 +84,20 @@ pub enum Screen {
     },
     /// User asked to quit; main loop should exit cleanly.
     Quitting,
+    /// "Cannot boot" toast surfaced when the operator presses Enter
+    /// over a List row that refuses kexec — currently fires for
+    /// tier-4 (parse-failed) ISOs, where `confirm_selection`'s silent
+    /// no-op left operators wondering whether the keypress registered.
+    /// Any key dismisses; `return_to` restores the cursor position.
+    /// (#546 — UX review T3C.)
+    BlockedToast {
+        /// Single-line "Cannot boot: <reason>" message shown in the
+        /// popup. Pre-sanitized — see `failed_iso_toast_message`.
+        message: String,
+        /// Cursor position to restore on dismiss so the operator
+        /// returns to the same row they tried.
+        return_to: usize,
+    },
 }
 
 /// Top-level application state.
@@ -774,9 +788,43 @@ impl AppState {
     /// [`RESCUE_SHELL_EXIT_CODE`] in that case).
     pub fn confirm_selection(&mut self) {
         if let Screen::List { selected } = self.screen {
-            if let Some(ViewEntry::Iso(real)) = self.view_entry(selected) {
-                self.screen = Screen::Confirm { selected: real };
+            match self.view_entry(selected) {
+                Some(ViewEntry::Iso(real)) => {
+                    self.screen = Screen::Confirm { selected: real };
+                }
+                Some(ViewEntry::FailedIso(idx)) => {
+                    // #546: tier-4 rows refused Enter silently. Surface
+                    // the parse-failed reason as a toast rather than
+                    // leaving the operator wondering if Enter registered.
+                    let message = self.failed_iso_toast_message(idx);
+                    self.screen = Screen::BlockedToast {
+                        message,
+                        return_to: selected,
+                    };
+                }
+                _ => {}
             }
+        }
+    }
+
+    /// Compose the "Cannot boot:" toast message for a tier-4 (`FailedIso`)
+    /// row at `idx`. Falls back to a generic message if the index is
+    /// out of bounds (defensive — `view_entry` should have validated it).
+    fn failed_iso_toast_message(&self, idx: usize) -> String {
+        match self.failed_isos.get(idx) {
+            Some(failed) => format!("Cannot boot: parse failed — {}", failed.reason),
+            None => "Cannot boot: parse failed (no reason available)".to_string(),
+        }
+    }
+
+    /// Dismiss the `BlockedToast` and return the cursor to the row the
+    /// operator originally tried. Any-key dismissal — `main.rs` binds
+    /// every keypress to this in the `BlockedToast` branch.
+    pub fn dismiss_blocked_toast(&mut self) {
+        if let Screen::BlockedToast { return_to, .. } = self.screen {
+            self.screen = Screen::List {
+                selected: return_to,
+            };
         }
     }
 
@@ -1536,6 +1584,70 @@ mod tests {
         s.filter = "debian".to_string();
         s.confirm_selection();
         assert_eq!(s.screen, Screen::Confirm { selected: 1 });
+    }
+
+    // ---- BlockedToast (#546 UX T3C) -----------------------------------
+
+    fn fake_failed_iso(reason: &str) -> iso_probe::FailedIso {
+        iso_probe::FailedIso {
+            iso_path: std::path::PathBuf::from("/run/media/AEGIS_ISOS/broken.iso"),
+            reason: reason.to_string(),
+            kind: iso_probe::FailureKind::NoBootEntries,
+        }
+    }
+
+    #[test]
+    fn confirm_selection_over_failed_iso_opens_blocked_toast() {
+        // #546: tier-4 rows (FailedIso) used to refuse Enter silently.
+        // Now they route to a BlockedToast popup whose message includes
+        // the parse-failed reason so the operator gets immediate
+        // feedback instead of "did Enter even register?"
+        let mut s =
+            AppState::new(vec![]).with_failed_isos(vec![fake_failed_iso("kernel/initrd missing")]);
+        // Cursor at 0 = the FailedIso row (no real ISOs, so it's first).
+        s.screen = Screen::List { selected: 0 };
+        s.confirm_selection();
+        match &s.screen {
+            Screen::BlockedToast { message, return_to } => {
+                assert!(
+                    message.contains("kernel/initrd missing"),
+                    "toast message must include the parse-failed reason, got: {message}"
+                );
+                assert!(message.starts_with("Cannot boot:"), "got: {message}");
+                assert_eq!(*return_to, 0, "cursor preserved for dismissal");
+            }
+            other => panic!("expected BlockedToast, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dismiss_blocked_toast_returns_to_list_at_original_cursor() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        s.screen = Screen::BlockedToast {
+            message: "Cannot boot: parse failed — synthetic test reason".to_string(),
+            return_to: 1,
+        };
+        s.dismiss_blocked_toast();
+        assert_eq!(s.screen, Screen::List { selected: 1 });
+    }
+
+    #[test]
+    fn dismiss_blocked_toast_no_op_outside_toast_screen() {
+        // Defensive: dismiss called from any non-toast screen must not
+        // mutate state (would otherwise mask other UI bugs).
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        let before = s.screen.clone();
+        s.dismiss_blocked_toast();
+        assert_eq!(s.screen, before);
+    }
+
+    #[test]
+    fn confirm_selection_iso_row_unchanged_by_blocked_toast_addition() {
+        // Regression guard: the FailedIso branch I added must not
+        // change the existing ViewEntry::Iso → Screen::Confirm path.
+        let mut s = AppState::new(vec![fake_iso("ubuntu")]);
+        s.confirm_selection();
+        assert_eq!(s.screen, Screen::Confirm { selected: 0 });
     }
 
     // --- rescue-shell entry (#90) -------------------------------------


### PR DESCRIPTION
## Summary

Closes the UX review T3C finding for **tier-4 (parse-failed) rows**. Before this PR, pressing Enter on a `ViewEntry::FailedIso` row was a silent no-op — operators wondered whether the keypress registered. After: a centered popup appears with the parse-failed reason, dismissed by any key.

```
┌ Blocked ───────────────────────────────────────────┐
│ Cannot boot: parse failed — kernel/initrd missing │
│                                                    │
│ press any key to dismiss                           │
└────────────────────────────────────────────────────┘
```

## Implementation

- New `Screen::BlockedToast { message, return_to }` variant
- `confirm_selection()` routes `ViewEntry::FailedIso` → `BlockedToast` (was silent fall-through)
- `dismiss_blocked_toast()` returns the cursor to the original row
- `main.rs` intercepts the screen via the same swallows-everything pattern as `Help` / `ConfirmQuit`
- `render.rs` adds `draw_blocked_toast_overlay` (centered, error-tinted border)
- `ScreenKind` + `docgen::screen_short_name` extended

## Scope decision (acknowledged in commit body)

The issue mentions tier-4 + tier-5 + tier-6. Tier-5 (`SecureBootBlocked`) and tier-6 (`HashMismatch`) ISOs already get reasonable UX via the existing `Confirm → Error` flow — the `Error` screen surfaces a clear remedy. Routing them through the same toast would need verdict lookup at List-Enter time and a separate consensus pass on whether to skip the Confirm step entirely. **Deferred** — tier-4 was the actual silent case, and that's fixed.

## Test plan

- [x] `cargo +1.88.0 test -p rescue-tui --lib` — 186 tests pass (4 new in `state::tests`)
- [x] `cargo +1.88.0 clippy -p rescue-tui --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs: UX review epic #537, T3C finding.
