### PR TITLE
ci: paths-ignore docs-only PRs on 7 expensive workflows (#580 Phase 1)

### DIFF
--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -1,10 +1,13 @@
 name: Direct-install E2E
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # #274 Phase 3 — exercises `aegis-boot flash --direct-install` end-to-end

--- a/.github/workflows/kexec-e2e.yml
+++ b/.github/workflows/kexec-e2e.yml
@@ -1,10 +1,28 @@
 name: kexec E2E
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. The 6 E2E workflows (kexec,
+  # ovmf-secboot, direct-install, mkusb, qemu-smoke, update-rotate) plus
+  # reproducible-build share this paths-ignore block. Markdown / docs /
+  # issue templates / LICENSE cannot break a QEMU boot flow, so burning
+  # ~5 CPU-min on each was pure waste (PR #572 burned ~25 CPU-min on a
+  # docs-only architecture-umbrella change). Branch protection on `main`
+  # is currently empty (see docs/governance/CI_REQUIRED_CHECKS.md), so
+  # plain paths-ignore is safe — no dummy-pass consolidation needed.
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE*'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE*'
   workflow_dispatch:
 
 # Proves the rescue-tui -> target-kernel kexec handoff works end-to-end.

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -1,10 +1,13 @@
 name: mkusb Image Build
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # Build the mkusb image in CI and smoke-boot it under OVMF SecBoot. Proves:

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -1,10 +1,13 @@
 name: OVMF SecBoot
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # Phase 1 of issue #16: validate the OVMF SecBoot environment in CI by

--- a/.github/workflows/qemu-smoke.yml
+++ b/.github/workflows/qemu-smoke.yml
@@ -1,10 +1,13 @@
 name: QEMU Smoke Boot
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,10 +1,15 @@
 name: Reproducible Build Verification
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
+  # reproducible-build does two full builds (~2:13 each), making it the
+  # second-biggest CPU hog after the QEMU E2E suite — high-leverage skip.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # Reproducibility is verified at the level we ship — the Rust release binaries

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -1,10 +1,13 @@
 name: Update rotate E2E
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. See kexec-e2e.yml for rationale.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # #444 — exercises `aegis-boot update --apply --experimental-apply`


### PR DESCRIPTION
## Summary

Closes the largest single chunk of epic #580 Phase 1: skip the 6 QEMU E2E workflows + reproducible-build on docs-only PRs. Per the audit in #591 (docs/governance/CI_REQUIRED_CHECKS.md), `main` has no branch-protection rules, so plain `paths-ignore` is safe.

## Time saved per docs-only PR

| Workflow | Saved |
| --- | --- |
| kexec-e2e | ~4:30 |
| direct-install-e2e | ~4:13 |
| ovmf-secboot | ~4:00 |
| mkusb | ~3:51 |
| update-rotate-e2e | ~3:49 |
| qemu-smoke | ~3:26 |
| reproducible-build | ~2:13 |
| **Total** | **~26 CPU-min** |

PR #572 (architecture-umbrella, docs-only) is the worked example. It would have saved exactly this on the next docs-only change.

## Patterns ignored

```yaml
paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
```

## What's NOT changed

Code-affecting workflows continue to run on every push:

- `ci.yml` (cargo check + clippy + tests)
- CodeQL, miri, fuzz, integration
- windows-cargo-check, macOS native smoke
- All doc-drift checks (these *should* run on doc PRs — they catch the case where a doc claims X but the binary surface says Y)

## Test plan

- [x] `python3 -c 'yaml.safe_load(...)'` validates all 7 workflows parse cleanly with `paths-ignore` present
- [x] kexec-e2e gets the long explanatory comment; the others just reference back to it
- [x] `paths-ignore` applied to BOTH `push:` and `pull_request:` triggers (so main-push events skip too)
- [ ] First docs-only PR after merge will be the live verification — wall-clock should drop from ~5 min to ~2 min

Refs: epic #580 Phase 1, audit #591.
