### PR TITLE
fix(kexec-loader): retry close(2) on EINTR + log non-EINTR failures (#598)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ version = "0.17.0"
 dependencies = [
  "libc",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/kexec-loader/Cargo.toml
+++ b/crates/kexec-loader/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["os::linux-apis", "api-bindings"]
 [dependencies]
 thiserror.workspace = true
 libc.workspace = true
+tracing.workspace = true
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # intentionally empty — crate is Linux-only at runtime. Non-Linux builds

--- a/crates/kexec-loader/src/lib.rs
+++ b/crates/kexec-loader/src/lib.rs
@@ -167,13 +167,37 @@ impl OwnedFd {
 #[cfg(target_os = "linux")]
 impl Drop for OwnedFd {
     fn drop(&mut self) {
+        // POSIX: close(2) may be interrupted by a signal and return EINTR,
+        // in which case it should be retried. Other errors (EIO flushing a
+        // buffered device, ENOSPC, etc.) are exceedingly rare on the
+        // O_RDONLY fds opened by this crate but worth a tracing line so a
+        // post-mortem can find them. #598.
+        //
         // SAFETY: fd was obtained from `open(2)` in `open_path` and is not
         // shared. Closing an already-closed or never-opened fd would be UB,
         // but construction paths guarantee `self.0 >= 0` and single-owner.
-        #[allow(unsafe_code)]
-        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
-        unsafe {
-            libc::close(self.0);
+        // The retry loop only re-issues `close` on EINTR — the kernel's
+        // own contract is that the fd is *already* released when EINTR is
+        // returned on Linux, but POSIX leaves the state implementation-
+        // defined; retrying matches the broadly portable advice and is
+        // harmless here because we hold the only reference.
+        loop {
+            #[allow(unsafe_code)]
+            // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
+            let rc = unsafe { libc::close(self.0) };
+            if rc == 0 {
+                return;
+            }
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            tracing::warn!(
+                fd = self.0,
+                error = %err,
+                "kexec-loader: close() on owned fd failed"
+            );
+            return;
         }
     }
 }


### PR DESCRIPTION
## Summary

- POSIX requires `close(2)` to be retried on `EINTR`. The previous `Drop for OwnedFd` discarded the return value, so a signal-interrupted close could leak the fd on stricter implementations and any genuine close failure (`EIO`, `ENOSPC`) was invisible to post-mortem analysis.
- Drop now loops on `EINTR` and emits a `tracing::warn!` on other errors. The fds owned here are short-lived `O_RDONLY` refs to kernel/initrd images, so the change is observability-first; SAFETY comment is updated to document the retry contract.
- Adds `tracing` to kexec-loader's deps via `tracing.workspace = true` so the warn line lands in the same sink rescue-tui already configures.

Closes #598.

## Test plan

- [x] `cargo test -p kexec-loader --lib` — 6 tests pass.
- [x] `cargo clippy -p kexec-loader --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p kexec-loader` clean.
- [x] `cargo build -p kexec-loader` succeeds with the new dep.

No new test — the existing path-open tests already exercise the construct → drop path; injecting `EINTR` into `libc::close` would require a libc mock or seccomp-bpf, neither warranted by this change. The Drop is purely observational (still always closes the fd on the success path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)