### PR TITLE
feat(kexec-loader): typed errno variants for EBUSY / EFBIG / EACCES / ENOMEM (#599)

### DIFF
--- a/crates/kexec-loader/src/lib.rs
+++ b/crates/kexec-loader/src/lib.rs
@@ -79,6 +79,38 @@ pub enum KexecError {
     #[error("kernel image format not recognized (kexec_file_load returned ENOEXEC)")]
     UnsupportedImage,
 
+    /// Another kexec image is already loaded; the kernel refuses to load a
+    /// second one until the first is released. Maps to `EBUSY`. User remedy:
+    /// `kexec -u` (unload), or reboot.
+    #[error(
+        "another kexec image is already loaded (EBUSY); run `kexec -u` to unload, or reboot first"
+    )]
+    AlreadyLoaded,
+
+    /// Image (kernel or initrd) exceeds the kernel's `kexec_file_load`
+    /// size limit. Maps to `EFBIG`. User remedy: pick a smaller kernel
+    /// variant (e.g. non-debug, non-bigmem) or extend `crashkernel=` if
+    /// that's the bound being hit.
+    #[error("kernel image is too large for kexec_file_load (EFBIG); try a smaller kernel variant")]
+    ImageTooLarge,
+
+    /// Path-level permission denied opening the kernel or initrd. Distinct
+    /// from [`KexecError::LockdownRefused`] — that's the kernel refusing
+    /// the syscall under lockdown; this is regular file-permission failure
+    /// before the syscall is even issued. Maps to `EACCES`.
+    #[error(
+        "permission denied opening kernel or initrd file (EACCES); check the operator has read access"
+    )]
+    PermissionDenied,
+
+    /// Kernel could not allocate enough memory to stage the new image.
+    /// Maps to `ENOMEM`. User remedy: free memory or reboot to a fresh
+    /// state. The rescue initramfs shouldn't normally have memory
+    /// pressure, so this typically points at a bzImage that decompresses
+    /// far larger than its packed size suggests.
+    #[error("not enough memory to stage the kexec image (ENOMEM); free memory or reboot")]
+    OutOfMemory,
+
     /// Underlying I/O or file-descriptor failure.
     #[error("io error: {0}")]
     Io(#[from] io::Error),
@@ -208,6 +240,10 @@ pub fn classify_errno(errno: i32) -> KexecError {
         libc::EKEYREJECTED => KexecError::SignatureRejected,
         libc::EPERM => KexecError::LockdownRefused,
         libc::ENOEXEC => KexecError::UnsupportedImage,
+        libc::EBUSY => KexecError::AlreadyLoaded,
+        libc::EFBIG => KexecError::ImageTooLarge,
+        libc::EACCES => KexecError::PermissionDenied,
+        libc::ENOMEM => KexecError::OutOfMemory,
         other => KexecError::Io(io::Error::from_raw_os_error(other)),
     }
 }
@@ -247,6 +283,58 @@ mod tests {
             panic!("expected Io variant");
         };
         assert_eq!(io_err.raw_os_error(), Some(libc::ENOENT));
+    }
+
+    #[test]
+    fn classify_already_loaded() {
+        assert!(matches!(
+            classify_errno(libc::EBUSY),
+            KexecError::AlreadyLoaded
+        ));
+    }
+
+    #[test]
+    fn classify_image_too_large() {
+        assert!(matches!(
+            classify_errno(libc::EFBIG),
+            KexecError::ImageTooLarge
+        ));
+    }
+
+    #[test]
+    fn classify_permission_denied() {
+        assert!(matches!(
+            classify_errno(libc::EACCES),
+            KexecError::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn classify_out_of_memory() {
+        assert!(matches!(
+            classify_errno(libc::ENOMEM),
+            KexecError::OutOfMemory
+        ));
+    }
+
+    /// Each typed variant must carry an actionable hint in its Display.
+    /// rescue-tui's error frame shows the message verbatim, so empty or
+    /// generic strings are a regression on operator UX. #599.
+    #[test]
+    fn each_typed_variant_has_actionable_message() {
+        for (errno, needle) in [
+            (libc::EBUSY, "kexec -u"),
+            (libc::EFBIG, "smaller"),
+            (libc::EACCES, "permission"),
+            (libc::ENOMEM, "memory"),
+        ] {
+            let err = classify_errno(errno);
+            let msg = err.to_string();
+            assert!(
+                msg.to_lowercase().contains(needle),
+                "errno {errno}: message {msg:?} should mention {needle:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -1229,6 +1229,38 @@ pub fn error_diagnostic_with_iso(
             "Kernel image format not recognized".to_string(),
             Some("The ISO's kernel is not a valid bzImage; this ISO is not supported.".to_string()),
         ),
+        KexecError::AlreadyLoaded => (
+            "Another kexec image is already loaded".to_string(),
+            Some(
+                "Another kexec image is staged in this kernel. Run `kexec -u` to unload, \
+                 or reboot the rescue stick fresh before retrying."
+                    .to_string(),
+            ),
+        ),
+        KexecError::ImageTooLarge => (
+            "Kernel image too large for kexec".to_string(),
+            Some(
+                "The ISO's kernel exceeds the kexec_file_load size limit. Try a smaller \
+                 kernel variant (e.g. non-debug, non-bigmem build) on the same ISO."
+                    .to_string(),
+            ),
+        ),
+        KexecError::PermissionDenied => (
+            "Permission denied opening kernel or initrd".to_string(),
+            Some(
+                "The operator could not read the kernel or initrd file. Check the ISO is \
+                 mounted and the rescue process has read access."
+                    .to_string(),
+            ),
+        ),
+        KexecError::OutOfMemory => (
+            "Not enough memory to stage the kexec image".to_string(),
+            Some(
+                "The kernel could not allocate enough memory to load this image. Reboot \
+                 to a fresh rescue state and try again."
+                    .to_string(),
+            ),
+        ),
         KexecError::Io(io) => (
             format!("System error: {io}"),
             io.raw_os_error()


### PR DESCRIPTION
## Summary

- `classify_errno` previously mapped only three errnos (`EKEYREJECTED`, `EPERM`, `ENOEXEC`) and funnelled the rest into `Io(io::Error)`. This PR adds typed variants for four more `kexec_file_load(2)` failure modes, each with an operator-actionable hint baked into the Display string:

  | errno   | variant            | hint                                |
  |---------|--------------------|-------------------------------------|
  | EBUSY   | `AlreadyLoaded`    | run `kexec -u` or reboot first      |
  | EFBIG   | `ImageTooLarge`    | try a smaller kernel variant        |
  | EACCES  | `PermissionDenied` | check operator has read access      |
  | ENOMEM  | `OutOfMemory`      | free memory or reboot               |

- `error_diagnostic_with_iso` in rescue-tui is updated to match exhaustively against the new variants and elevates the prose into the toast remedy hint.

Closes #599.

## Test plan

- [x] `cargo test -p kexec-loader --lib` — 11 tests pass (5 new: one per errno + one meta-test asserting each typed variant carries an actionable hint).
- [x] `cargo test -p rescue-tui --lib state::` — 71 state tests still pass.
- [x] `cargo clippy -p kexec-loader -p rescue-tui --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p kexec-loader -p rescue-tui` clean.
- [x] `cargo build -p kexec-loader -p rescue-tui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)