### PR TITLE
refactor(aegis-fitness): consolidate 9 checks behind fn-pointer registry (#601)

### DIFF
--- a/crates/aegis-fitness/src/main.rs
+++ b/crates/aegis-fitness/src/main.rs
@@ -10,6 +10,7 @@
 //! Output formats:
 //!   * default — colorless human table + score footer
 //!   * `--json` — machine-readable for CI gating
+//!   * `--list-checks` — just print the registry (id + weight) and exit
 //!
 //! Exit codes:
 //!   * 0 — score >= threshold (default 90)
@@ -50,6 +51,77 @@ struct Report {
     checks: Vec<CheckResult>,
 }
 
+/// Registry entry for a fitness check.
+///
+/// Each check is a stateless `(name, weight, run)` triple. Adding a new
+/// check is a one-line append to [`CHECKS`] plus a small `fn(&Path) ->
+/// (Status, String)`. #601 chose this fn-pointer table over the
+/// `trait Check { ... }` + unit-struct shape suggested in the issue
+/// because the checks carry no per-check state — the data table is the
+/// simpler form, doesn't need dyn dispatch, and keeps the inventory
+/// grep-friendly in one place.
+struct Check {
+    /// Human-readable label shown in the audit table and emitted to JSON.
+    /// Treat as stable: a name change is a CLI break for any tool that
+    /// greps the report.
+    name: &'static str,
+    /// Score weight; the sum across all checks is the /100 denominator.
+    weight: u32,
+    /// Execute the check against the repo root. Returns the verdict +
+    /// a one-line detail message rendered into the audit table.
+    run: fn(&Path) -> (Status, String),
+}
+
+/// Single source of truth for the fitness audit inventory. New checks
+/// are added here; the registry order is also the report row order.
+const CHECKS: &[Check] = &[
+    Check {
+        name: "Cargo.lock committed",
+        weight: 10,
+        run: check_cargo_lock,
+    },
+    Check {
+        name: "Workspace crates present",
+        weight: 15,
+        run: check_required_crates,
+    },
+    Check {
+        name: "No tracked secrets at root",
+        weight: 10,
+        run: check_no_secrets,
+    },
+    Check {
+        name: "initramfs.cpio.gz built",
+        weight: 15,
+        run: check_initramfs_artifact,
+    },
+    Check {
+        name: "initramfs size <= 20 MiB",
+        weight: 10,
+        run: check_initramfs_size_budget,
+    },
+    Check {
+        name: "initramfs sha256 sidecar",
+        weight: 5,
+        run: check_initramfs_checksum,
+    },
+    Check {
+        name: "Required scripts present",
+        weight: 15,
+        run: check_scripts_present,
+    },
+    Check {
+        name: "CHANGELOG.md present",
+        weight: 10,
+        run: check_changelog_current,
+    },
+    Check {
+        name: "Operator docs present",
+        weight: 10,
+        run: check_docs_present,
+    },
+];
+
 fn main() -> ExitCode {
     // Standard CLI dispatch. argv[0] is dropped (`.skip(1)`); remaining
     // args are flag names the user already controls. No security
@@ -57,6 +129,7 @@ fn main() -> ExitCode {
     // nosemgrep: rust.lang.security.args.args
     let args: Vec<String> = env::args().skip(1).collect();
     let json_mode = args.iter().any(|a| a == "--json");
+    let list_mode = args.iter().any(|a| a == "--list-checks");
     let threshold = args
         .iter()
         .position(|a| a == "--threshold")
@@ -65,6 +138,11 @@ fn main() -> ExitCode {
         .unwrap_or(DEFAULT_THRESHOLD);
     if args.iter().any(|a| a == "-h" || a == "--help") {
         print_help();
+        return ExitCode::SUCCESS;
+    }
+
+    if list_mode {
+        print_check_inventory();
         return ExitCode::SUCCESS;
     }
 
@@ -104,12 +182,27 @@ fn print_help() {
     println!("aegis-fitness — repo / build / artifact health audit");
     println!();
     println!("USAGE:");
-    println!("  aegis-fitness [--json] [--threshold N]");
+    println!("  aegis-fitness [--json] [--threshold N] [--list-checks]");
     println!();
     println!("OPTIONS:");
     println!("  --json             machine-readable output");
     println!("  --threshold N      pass threshold (default {DEFAULT_THRESHOLD})");
+    println!("  --list-checks      print the check registry and exit (no scoring)");
     println!("  -h, --help         this message");
+}
+
+/// Print the static check inventory (name + weight) without scoring.
+/// Useful for CI dashboards or `aegis-fitness --list-checks | wc -l`
+/// drift assertions in tooling.
+fn print_check_inventory() {
+    println!("aegis-fitness — check inventory ({} checks)", CHECKS.len());
+    println!("{}", "─".repeat(60));
+    let total: u32 = CHECKS.iter().map(|c| c.weight).sum();
+    for c in CHECKS {
+        println!("  ({:>2}pt) {}", c.weight, c.name);
+    }
+    println!("{}", "─".repeat(60));
+    println!("  total weight: {total}");
 }
 
 fn find_repo_root() -> Option<PathBuf> {
@@ -124,40 +217,43 @@ fn find_repo_root() -> Option<PathBuf> {
     }
 }
 
+/// Walk the static [`CHECKS`] registry and assemble a [`CheckResult`]
+/// for each. The output order matches the registry order so the audit
+/// table is deterministic across runs.
 fn run_checks(root: &Path) -> Vec<CheckResult> {
-    vec![
-        check_cargo_lock(root),
-        check_required_crates(root),
-        check_no_secrets(root),
-        check_initramfs_artifact(root),
-        check_initramfs_size_budget(root),
-        check_initramfs_checksum(root),
-        check_scripts_present(root),
-        check_changelog_current(root),
-        check_docs_present(root),
-    ]
+    CHECKS
+        .iter()
+        .map(|c| {
+            let (status, detail) = (c.run)(root);
+            CheckResult {
+                name: c.name,
+                status,
+                weight: c.weight,
+                detail,
+            }
+        })
+        .collect()
 }
 
-fn check_cargo_lock(root: &Path) -> CheckResult {
+// ---- check implementations --------------------------------------------------
+//
+// Each `check_*` returns `(Status, String)`. The `name` and `weight` live in
+// the `CHECKS` registry above so they can't drift between sites and so a
+// `--list-checks` view is trivial.
+
+fn check_cargo_lock(root: &Path) -> (Status, String) {
     let path = root.join("Cargo.lock");
     if path.is_file() {
-        CheckResult {
-            name: "Cargo.lock committed",
-            status: Status::Pass,
-            weight: 10,
-            detail: "present at workspace root".to_string(),
-        }
+        (Status::Pass, "present at workspace root".to_string())
     } else {
-        CheckResult {
-            name: "Cargo.lock committed",
-            status: Status::Fail,
-            weight: 10,
-            detail: "missing — required for reproducible builds".to_string(),
-        }
+        (
+            Status::Fail,
+            "missing — required for reproducible builds".to_string(),
+        )
     }
 }
 
-fn check_required_crates(root: &Path) -> CheckResult {
+fn check_required_crates(root: &Path) -> (Status, String) {
     let required = [
         "iso-parser",
         "iso-probe",
@@ -171,23 +267,16 @@ fn check_required_crates(root: &Path) -> CheckResult {
         .copied()
         .collect();
     if missing.is_empty() {
-        CheckResult {
-            name: "Workspace crates present",
-            status: Status::Pass,
-            weight: 15,
-            detail: format!("all {} expected crates present", required.len()),
-        }
+        (
+            Status::Pass,
+            format!("all {} expected crates present", required.len()),
+        )
     } else {
-        CheckResult {
-            name: "Workspace crates present",
-            status: Status::Fail,
-            weight: 15,
-            detail: format!("missing: {}", missing.join(", ")),
-        }
+        (Status::Fail, format!("missing: {}", missing.join(", ")))
     }
 }
 
-fn check_no_secrets(root: &Path) -> CheckResult {
+fn check_no_secrets(root: &Path) -> (Status, String) {
     let bad = [".env", ".env.local", "secrets.toml", "id_rsa"];
     let found: Vec<&str> = bad
         .iter()
@@ -195,90 +284,57 @@ fn check_no_secrets(root: &Path) -> CheckResult {
         .copied()
         .collect();
     if found.is_empty() {
-        CheckResult {
-            name: "No tracked secrets at root",
-            status: Status::Pass,
-            weight: 10,
-            detail: "no .env / id_rsa / secrets.toml present".to_string(),
-        }
+        (
+            Status::Pass,
+            "no .env / id_rsa / secrets.toml present".to_string(),
+        )
     } else {
-        CheckResult {
-            name: "No tracked secrets at root",
-            status: Status::Fail,
-            weight: 10,
-            detail: format!("present: {}", found.join(", ")),
-        }
+        (Status::Fail, format!("present: {}", found.join(", ")))
     }
 }
 
-fn check_initramfs_artifact(root: &Path) -> CheckResult {
+fn check_initramfs_artifact(root: &Path) -> (Status, String) {
     let path = root.join("out").join("initramfs.cpio.gz");
     if path.is_file() {
-        CheckResult {
-            name: "initramfs.cpio.gz built",
-            status: Status::Pass,
-            weight: 15,
-            detail: format!("found at {}", path.display()),
-        }
+        (Status::Pass, format!("found at {}", path.display()))
     } else {
-        CheckResult {
-            name: "initramfs.cpio.gz built",
-            status: Status::Warn,
-            weight: 15,
-            detail: "out/initramfs.cpio.gz absent — run scripts/build-initramfs.sh".to_string(),
-        }
+        (
+            Status::Warn,
+            "out/initramfs.cpio.gz absent — run scripts/build-initramfs.sh".to_string(),
+        )
     }
 }
 
-fn check_initramfs_size_budget(root: &Path) -> CheckResult {
+fn check_initramfs_size_budget(root: &Path) -> (Status, String) {
     const BUDGET: u64 = 20 * 1024 * 1024;
     let path = root.join("out").join("initramfs.cpio.gz");
     let Ok(meta) = std::fs::metadata(&path) else {
-        return CheckResult {
-            name: "initramfs size <= 20 MiB",
-            status: Status::Warn,
-            weight: 10,
-            detail: "no artifact to measure (run build-initramfs.sh first)".to_string(),
-        };
+        return (
+            Status::Warn,
+            "no artifact to measure (run build-initramfs.sh first)".to_string(),
+        );
     };
     let size = meta.len();
     if size <= BUDGET {
-        CheckResult {
-            name: "initramfs size <= 20 MiB",
-            status: Status::Pass,
-            weight: 10,
-            detail: format!("{size} bytes / 20 MiB budget"),
-        }
+        (Status::Pass, format!("{size} bytes / 20 MiB budget"))
     } else {
-        CheckResult {
-            name: "initramfs size <= 20 MiB",
-            status: Status::Fail,
-            weight: 10,
-            detail: format!("{size} bytes exceeds 20 MiB budget"),
-        }
+        (Status::Fail, format!("{size} bytes exceeds 20 MiB budget"))
     }
 }
 
-fn check_initramfs_checksum(root: &Path) -> CheckResult {
+fn check_initramfs_checksum(root: &Path) -> (Status, String) {
     let path = root.join("out").join("initramfs.cpio.gz.sha256");
     if path.is_file() {
-        CheckResult {
-            name: "initramfs sha256 sidecar",
-            status: Status::Pass,
-            weight: 5,
-            detail: "sha256 sidecar present".to_string(),
-        }
+        (Status::Pass, "sha256 sidecar present".to_string())
     } else {
-        CheckResult {
-            name: "initramfs sha256 sidecar",
-            status: Status::Warn,
-            weight: 5,
-            detail: "no sha256 sidecar (build-initramfs.sh writes it)".to_string(),
-        }
+        (
+            Status::Warn,
+            "no sha256 sidecar (build-initramfs.sh writes it)".to_string(),
+        )
     }
 }
 
-fn check_scripts_present(root: &Path) -> CheckResult {
+fn check_scripts_present(root: &Path) -> (Status, String) {
     let required = [
         "build-initramfs.sh",
         "mkusb.sh",
@@ -293,50 +349,31 @@ fn check_scripts_present(root: &Path) -> CheckResult {
         .copied()
         .collect();
     if missing.is_empty() {
-        CheckResult {
-            name: "Required scripts present",
-            status: Status::Pass,
-            weight: 15,
-            detail: format!("all {} scripts present", required.len()),
-        }
+        (
+            Status::Pass,
+            format!("all {} scripts present", required.len()),
+        )
     } else {
-        CheckResult {
-            name: "Required scripts present",
-            status: Status::Fail,
-            weight: 15,
-            detail: format!("missing: {}", missing.join(", ")),
-        }
+        (Status::Fail, format!("missing: {}", missing.join(", ")))
     }
 }
 
-fn check_changelog_current(root: &Path) -> CheckResult {
+fn check_changelog_current(root: &Path) -> (Status, String) {
     let path = root.join("CHANGELOG.md");
     let Ok(content) = std::fs::read_to_string(&path) else {
-        return CheckResult {
-            name: "CHANGELOG.md present",
-            status: Status::Fail,
-            weight: 10,
-            detail: "missing".to_string(),
-        };
+        return (Status::Fail, "missing".to_string());
     };
     if content.contains("## ") {
-        CheckResult {
-            name: "CHANGELOG.md present",
-            status: Status::Pass,
-            weight: 10,
-            detail: format!("{} bytes, has version sections", content.len()),
-        }
+        (
+            Status::Pass,
+            format!("{} bytes, has version sections", content.len()),
+        )
     } else {
-        CheckResult {
-            name: "CHANGELOG.md present",
-            status: Status::Warn,
-            weight: 10,
-            detail: "no version sections found".to_string(),
-        }
+        (Status::Warn, "no version sections found".to_string())
     }
 }
 
-fn check_docs_present(root: &Path) -> CheckResult {
+fn check_docs_present(root: &Path) -> (Status, String) {
     let required = ["README.md", "docs/USB_LAYOUT.md", "docs/LOCAL_TESTING.md"];
     let missing: Vec<&str> = required
         .iter()
@@ -344,19 +381,9 @@ fn check_docs_present(root: &Path) -> CheckResult {
         .copied()
         .collect();
     if missing.is_empty() {
-        CheckResult {
-            name: "Operator docs present",
-            status: Status::Pass,
-            weight: 10,
-            detail: format!("all {} docs present", required.len()),
-        }
+        (Status::Pass, format!("all {} docs present", required.len()))
     } else {
-        CheckResult {
-            name: "Operator docs present",
-            status: Status::Warn,
-            weight: 10,
-            detail: format!("missing: {}", missing.join(", ")),
-        }
+        (Status::Warn, format!("missing: {}", missing.join(", ")))
     }
 }
 
@@ -439,5 +466,45 @@ mod tests {
     #[test]
     fn score_empty_is_zero() {
         assert_eq!(compute_score(&[]), 0);
+    }
+
+    /// #601: the registry is the single source of truth for the audit
+    /// inventory. Lock down its size + total weight so reordering or
+    /// silent additions during refactors get caught at test time.
+    /// Update both numbers in lockstep when intentionally adding a check.
+    #[test]
+    fn registry_inventory_locked() {
+        assert_eq!(
+            CHECKS.len(),
+            9,
+            "CHECKS registry size changed; bump this test deliberately"
+        );
+        let total: u32 = CHECKS.iter().map(|c| c.weight).sum();
+        assert_eq!(
+            total, 100,
+            "CHECKS weights must sum to 100 (the /100 denominator)"
+        );
+    }
+
+    /// #601: catch a refactor that accidentally renames a check (which
+    /// would break any tooling grepping the report) by asserting the
+    /// names against the historical list.
+    #[test]
+    fn registry_names_are_stable() {
+        let names: Vec<&str> = CHECKS.iter().map(|c| c.name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "Cargo.lock committed",
+                "Workspace crates present",
+                "No tracked secrets at root",
+                "initramfs.cpio.gz built",
+                "initramfs size <= 20 MiB",
+                "initramfs sha256 sidecar",
+                "Required scripts present",
+                "CHANGELOG.md present",
+                "Operator docs present",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The 9 `check_*` fns each constructed a `CheckResult { name, status, weight, detail }` inline, repeating metadata across 9 sites. Adding a check meant editing both the body AND the `run_checks` collector.
- Replace with a `Check { name, weight, run: fn(&Path) -> (Status, String) }` registry plus a single `CHECKS: &[Check]` static. The 9 existing checks become tight `(Status, String)`-returning bodies; `run_checks` walks the registry.

## Why fn-pointer table over the issue's `trait Check`

The issue suggested a `trait Check { fn run() -> CheckResult }` shape with unit structs. The fn-pointer table is simpler:

- No dyn dispatch, no `&'static dyn` static-array gymnastics
- Checks have no per-check state — the trait's polymorphism buys nothing
- The inventory stays grep-friendly: one `CHECKS:` static is the single source of truth
- Adding a check is one append + one fn (vs one struct + one impl block + one register)

## Output stability

Output is **byte-identical for a clean repo**: registry order matches the old `vec![...]` order, every `(name, weight, detail)` triple is preserved verbatim. Smoke-tested locally — `aegis-fitness --json` produces the same payload structure on a clean checkout.

## Side bonuses (free with this shape)

- New `--list-checks` flag prints the inventory + total weight.
- `registry_inventory_locked` test pins `CHECKS.len() == 9` and `Σweight == 100`.
- `registry_names_are_stable` test catches accidental rename refactors that would break tools grepping the report.

Closes #601.

## Test plan

- [x] `cargo test -p aegis-fitness` — 7 tests pass (5 original + 2 new registry guards).
- [x] `cargo clippy -p aegis-fitness --all-targets --no-deps -- -D warnings` clean.
- [x] `cargo fmt -p aegis-fitness` clean.
- [x] Smoke: `cargo run -p aegis-fitness -- --json` returns score=100 on clean main.
- [x] Smoke: `cargo run -p aegis-fitness -- --list-checks` lists 9 checks summing to 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)