### PR TITLE
feat(rescue-tui): additive Source/Media verdict accessors (#558)

### DIFF
--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -1348,6 +1348,45 @@ fn draw_confirm(frame: &mut Frame<'_>, area: Rect, state: &AppState, selected: u
             Span::raw("   "),
             signature_span(&iso.signature_verification, &state.theme),
         ]),
+        // #558 per-axis breakdown. The combined `Verdict:` line at the
+        // top of the Confirm screen down-shifts to the worse-of-two; the
+        // breakdown here lets operators see which axis the verdict came
+        // from. Source = origin trust (sidecar + minisig); Media = bytes
+        // match recorded hash. See verdict.rs for the mapping table.
+        {
+            let src = crate::verdict::TrustVerdict::source_verdict(iso);
+            Line::from(vec![
+                Span::styled("Source:   ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    src.label(),
+                    Style::default()
+                        .fg(src.color(&state.theme))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    "(origin trust — sidecar + minisig)",
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+            ])
+        },
+        {
+            let med = crate::verdict::TrustVerdict::media_verdict(iso);
+            Line::from(vec![
+                Span::styled("Media:    ", Style::default().add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    med.label(),
+                    Style::default()
+                        .fg(med.color(&state.theme))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    "(bytes-on-stick vs recorded hash)",
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+            ])
+        },
         Line::from(""),
         // Per-screen action hint kept inline to make BLOCKED state
         // unmissable; full keybind list is in the persistent footer.

--- a/crates/rescue-tui/src/verdict.rs
+++ b/crates/rescue-tui/src/verdict.rs
@@ -243,6 +243,173 @@ impl TrustVerdict {
             reason: failed.reason.clone(),
         }
     }
+
+    /// Origin-trust axis (#558). "Did this ISO come from a trustworthy
+    /// place?" Computed from the ISO's signature + hash sidecar signals.
+    /// Independent of [`Self::media_verdict`]; the combined
+    /// [`Self::from_discovered`] continues to be the boot-gating verdict.
+    pub(crate) fn source_verdict(iso: &DiscoveredIso) -> SourceVerdict {
+        SourceVerdict::from_iso(iso)
+    }
+
+    /// Storage-integrity axis (#558). "Do the on-stick ISO bytes match
+    /// the most-recent recorded hash (sidecar or verify-now)?" The
+    /// verify-now flow (#548) is the operator-driven path that turns
+    /// `Unverified` into `Verified` (or surfaces `Mismatch` as a tamper
+    /// signal).
+    pub(crate) fn media_verdict(iso: &DiscoveredIso) -> MediaVerdict {
+        MediaVerdict::from_iso(iso)
+    }
+}
+
+/// Origin-trust axis. Captures the question "is the ISO's claimed
+/// content vouched for by something we recognize?" Independent of
+/// whether the on-stick bytes match — that's [`MediaVerdict`].
+///
+/// Mapping from `iso-probe` signals (see [`SourceVerdict::from_iso`]):
+///
+/// | iso-probe state                                                  | SourceVerdict     |
+/// | ---------------------------------------------------------------- | ----------------- |
+/// | `SignatureVerification::Verified` (key in `AEGIS_TRUSTED_KEYS`)  | `Verified`        |
+/// | `HashVerification::Verified` (sidecar matches; no signature)     | `Verified`        |
+/// | `SignatureVerification::Forged`                                  | `Tampered`        |
+/// | `SignatureVerification::KeyNotTrusted`                           | `KeyNotTrusted`   |
+/// | nothing else passes                                              | `Bare`            |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceVerdict {
+    /// A trusted attestation (signature or sidecar) vouches for the
+    /// claimed ISO content.
+    Verified,
+    /// A signature parses but the signing key is not in
+    /// `AEGIS_TRUSTED_KEYS`. The bytes may be intact, but no party we
+    /// recognize attests them.
+    KeyNotTrusted,
+    /// A signature parses against a recognized key BUT the signed
+    /// digest does not match what's on disk. Strong tamper signal at
+    /// the source layer (the publisher's claim disagrees with reality).
+    Tampered,
+    /// No verification material at all (no `.sha256`, no `.minisig`).
+    Bare,
+}
+
+impl SourceVerdict {
+    /// Compute from [`DiscoveredIso`] signals. Order of precedence
+    /// matters: a forged signature wins over a signature-verified
+    /// branch (defense in depth — the more-suspicious result surfaces).
+    pub(crate) fn from_iso(iso: &DiscoveredIso) -> Self {
+        use HashVerification as H;
+        use SignatureVerification as S;
+        // Tamper signals first.
+        if matches!(iso.signature_verification, S::Forged { .. }) {
+            return Self::Tampered;
+        }
+        // Trust signals next.
+        if matches!(iso.signature_verification, S::Verified { .. })
+            || matches!(iso.hash_verification, H::Verified { .. })
+        {
+            return Self::Verified;
+        }
+        // Untrusted-but-parseable signature.
+        if matches!(iso.signature_verification, S::KeyNotTrusted { .. }) {
+            return Self::KeyNotTrusted;
+        }
+        // No verification material present (or hash mismatch with no
+        // sig — the bytes-vs-recorded divergence is reported on the
+        // Media axis, not Source).
+        Self::Bare
+    }
+
+    /// One-word ASCII label for monochrome / serial / braille displays.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Verified => "VERIFIED",
+            Self::KeyNotTrusted => "UNTRUSTED KEY",
+            Self::Tampered => "TAMPERED",
+            Self::Bare => "UNVERIFIED",
+        }
+    }
+
+    /// Color from the active theme. 16-color-safe.
+    pub(crate) fn color(self, theme: &Theme) -> Color {
+        match self {
+            Self::Verified => theme.success,
+            Self::KeyNotTrusted => theme.warning,
+            Self::Tampered => theme.error,
+            Self::Bare => Color::Gray,
+        }
+    }
+}
+
+/// Storage-integrity axis. Captures the question "do the on-stick ISO
+/// bytes match the most-recent recorded hash?"
+///
+/// "Recorded hash" can come from two places:
+/// 1. The sibling `.sha256` / minisig sidecar checked at discovery time.
+/// 2. The verify-now (#548) operator flow, which recomputes the hash
+///    at boot time and updates [`DiscoveredIso::hash_verification`] in
+///    place.
+///
+/// Mapping from `iso-probe` signals (see [`MediaVerdict::from_iso`]):
+///
+/// | iso-probe state                                | `MediaVerdict`   |
+/// | ---------------------------------------------- | --------------- |
+/// | `SignatureVerification::Verified`              | `Verified`      |
+/// | `SignatureVerification::Forged`                | `Mismatch`      |
+/// | `HashVerification::Verified`                   | `Verified`      |
+/// | `HashVerification::Mismatch`                   | `Mismatch`      |
+/// | otherwise                                      | `Unverified`    |
+///
+/// `Verified` requires either a passing signature (which transitively
+/// vouches for the bytes) or a matching sidecar sha. `Mismatch` is the
+/// tamper-detection signal at the storage layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MediaVerdict {
+    /// On-stick bytes match the recorded hash (sidecar or verify-now).
+    Verified,
+    /// On-stick bytes differ from the recorded hash. Strong tamper
+    /// signal at the storage layer.
+    Mismatch,
+    /// No recorded hash to compare against, or the bytes haven't been
+    /// re-hashed since discovery. The verify-now flow (#548) is the
+    /// operator-driven path that resolves this state.
+    Unverified,
+}
+
+impl MediaVerdict {
+    pub(crate) fn from_iso(iso: &DiscoveredIso) -> Self {
+        use HashVerification as H;
+        use SignatureVerification as S;
+        // Signature checks are computed against bytes — a passing
+        // signature implies the bytes match the signer's claim, which
+        // is exactly the Media-axis property.
+        if matches!(iso.signature_verification, S::Verified { .. }) {
+            return Self::Verified;
+        }
+        if matches!(iso.signature_verification, S::Forged { .. }) {
+            return Self::Mismatch;
+        }
+        match &iso.hash_verification {
+            H::Verified { .. } => Self::Verified,
+            H::Mismatch { .. } => Self::Mismatch,
+            _ => Self::Unverified,
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Verified => "VERIFIED",
+            Self::Mismatch => "MISMATCH",
+            Self::Unverified => "UNVERIFIED",
+        }
+    }
+
+    pub(crate) fn color(self, theme: &Theme) -> Color {
+        match self {
+            Self::Verified => theme.success,
+            Self::Mismatch => theme.error,
+            Self::Unverified => Color::Gray,
+        }
+    }
 }
 
 /// Truncate a long hex digest to the first 12 chars with an ellipsis —
@@ -512,6 +679,352 @@ mod tests {
         );
         let v = TrustVerdict::from_discovered(&iso, SecureBootStatus::Enforcing);
         assert!(matches!(v, TrustVerdict::HashMismatch { .. }));
+    }
+
+    // ---- #558 Source/Media verdict split (additive) -------------------
+
+    /// #558 migration property: every ISO fixture produces the SAME
+    /// 6-tier `TrustVerdict::from_discovered()` result before and after
+    /// the split. The new accessors are additive — they don't change
+    /// boot-gating or the canonical tier label.
+    ///
+    /// Pinned by exhaustive matrix below. If a future refactor breaks
+    /// this, every consumer of the combined verdict is also broken;
+    /// the panic message names the offending fixture so triage is one
+    /// step instead of three.
+    #[test]
+    fn from_discovered_combined_unchanged_after_split() {
+        let cases: &[(_, _, Vec<_>, _, SecureBootStatus, &str)] = &[
+            (
+                HashVerification::NotPresent,
+                SignatureVerification::Verified {
+                    key_id: "x".to_string(),
+                    sig_path: PathBuf::from("/x.minisig"),
+                },
+                vec![],
+                Distribution::Debian,
+                SecureBootStatus::Enforcing,
+                "OperatorAttested",
+            ),
+            (
+                HashVerification::Verified {
+                    digest: "h".to_string(),
+                    source: "/x.sha256".to_string(),
+                },
+                SignatureVerification::NotPresent,
+                vec![],
+                Distribution::Arch,
+                SecureBootStatus::Disabled,
+                "OperatorAttested",
+            ),
+            (
+                HashVerification::NotPresent,
+                SignatureVerification::KeyNotTrusted {
+                    key_id: "x".to_string(),
+                },
+                vec![],
+                Distribution::Debian,
+                SecureBootStatus::Enforcing,
+                "KeyNotTrusted",
+            ),
+            (
+                HashVerification::NotPresent,
+                SignatureVerification::NotPresent,
+                vec![],
+                Distribution::Debian,
+                SecureBootStatus::Enforcing,
+                "BareUnverified",
+            ),
+            (
+                HashVerification::Mismatch {
+                    expected: "a".repeat(64),
+                    actual: "b".repeat(64),
+                    source: "/x.sha256".to_string(),
+                },
+                SignatureVerification::NotPresent,
+                vec![],
+                Distribution::Debian,
+                SecureBootStatus::Enforcing,
+                "HashMismatch",
+            ),
+            (
+                HashVerification::NotPresent,
+                SignatureVerification::Forged {
+                    sig_path: PathBuf::from("/x.minisig"),
+                },
+                vec![],
+                Distribution::Debian,
+                SecureBootStatus::Enforcing,
+                "HashMismatch",
+            ),
+            (
+                HashVerification::NotPresent,
+                SignatureVerification::NotPresent,
+                vec![Quirk::NotKexecBootable],
+                Distribution::Windows,
+                SecureBootStatus::Enforcing,
+                "SecureBootBlocked",
+            ),
+        ];
+        for (hash, sig, quirks, distro, sb, expected_tier) in cases {
+            let iso = iso_with(hash.clone(), sig.clone(), quirks.clone(), *distro);
+            let v = TrustVerdict::from_discovered(&iso, *sb);
+            let actual_tier = match v {
+                TrustVerdict::OperatorAttested => "OperatorAttested",
+                TrustVerdict::BareUnverified => "BareUnverified",
+                TrustVerdict::KeyNotTrusted => "KeyNotTrusted",
+                TrustVerdict::ParseFailed { .. } => "ParseFailed",
+                TrustVerdict::SecureBootBlocked { .. } => "SecureBootBlocked",
+                TrustVerdict::HashMismatch { .. } => "HashMismatch",
+            };
+            assert_eq!(
+                actual_tier, *expected_tier,
+                "tier drift on fixture: hash={hash:?} sig={sig:?} quirks={quirks:?} sb={sb:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_verdict_verified_on_signature_or_hash() {
+        let iso_sig = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Verified {
+                key_id: "k".to_string(),
+                sig_path: PathBuf::from("/x.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&iso_sig),
+            SourceVerdict::Verified
+        );
+        let iso_hash = iso_with(
+            HashVerification::Verified {
+                digest: "h".to_string(),
+                source: "/x.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Arch,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&iso_hash),
+            SourceVerdict::Verified
+        );
+    }
+
+    #[test]
+    fn source_verdict_tampered_when_signature_forged() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Forged {
+                sig_path: PathBuf::from("/x.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&iso),
+            SourceVerdict::Tampered,
+            "forged sig is a tamper signal at the source layer"
+        );
+    }
+
+    #[test]
+    fn source_verdict_key_not_trusted_propagates() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::KeyNotTrusted {
+                key_id: "k".to_string(),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&iso),
+            SourceVerdict::KeyNotTrusted
+        );
+    }
+
+    #[test]
+    fn source_verdict_bare_when_no_material() {
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(TrustVerdict::source_verdict(&iso), SourceVerdict::Bare);
+    }
+
+    #[test]
+    fn source_verdict_bare_when_hash_mismatch_alone() {
+        // Hash mismatch with no signature: the bytes-vs-recorded
+        // divergence is a Media-axis problem, NOT a Source-axis one.
+        // The sidecar isn't itself authenticated; we don't know whether
+        // the recorded value or the actual bytes are the canonical one.
+        let iso = iso_with(
+            HashVerification::Mismatch {
+                expected: "a".repeat(64),
+                actual: "b".repeat(64),
+                source: "/x.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(TrustVerdict::source_verdict(&iso), SourceVerdict::Bare);
+    }
+
+    #[test]
+    fn media_verdict_verified_on_signature_or_hash() {
+        let iso_sig = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Verified {
+                key_id: "k".to_string(),
+                sig_path: PathBuf::from("/x.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&iso_sig),
+            MediaVerdict::Verified,
+            "passing sig transitively vouches for bytes"
+        );
+        let iso_hash = iso_with(
+            HashVerification::Verified {
+                digest: "h".to_string(),
+                source: "/x.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Arch,
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&iso_hash),
+            MediaVerdict::Verified
+        );
+    }
+
+    #[test]
+    fn media_verdict_mismatch_on_forged_sig_or_hash_mismatch() {
+        let iso_forged = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Forged {
+                sig_path: PathBuf::from("/x.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&iso_forged),
+            MediaVerdict::Mismatch,
+            "forged sig means bytes diverged from signer's claim"
+        );
+        let iso_mismatch = iso_with(
+            HashVerification::Mismatch {
+                expected: "a".repeat(64),
+                actual: "b".repeat(64),
+                source: "/x.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&iso_mismatch),
+            MediaVerdict::Mismatch
+        );
+    }
+
+    #[test]
+    fn media_verdict_unverified_when_no_recorded_hash() {
+        // No sidecar, no sig, nothing to compare bytes against.
+        let iso = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(TrustVerdict::media_verdict(&iso), MediaVerdict::Unverified);
+    }
+
+    /// Orthogonality demo: green source + red media = "publisher signed
+    /// these bytes but on-stick bytes diverge" (= forged sig). Distinct
+    /// from the inverse combinations the existing tier model collapses.
+    #[test]
+    fn source_and_media_axes_are_orthogonal() {
+        // Tampered + Mismatch — sig says X but bytes hash to Y.
+        let forged = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::Forged {
+                sig_path: PathBuf::from("/x.minisig"),
+            },
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&forged),
+            SourceVerdict::Tampered
+        );
+        assert_eq!(TrustVerdict::media_verdict(&forged), MediaVerdict::Mismatch);
+
+        // Bare + Mismatch — sidecar disagrees with bytes; no sig to authenticate.
+        let bare_mismatch = iso_with(
+            HashVerification::Mismatch {
+                expected: "a".repeat(64),
+                actual: "b".repeat(64),
+                source: "/x.sha256".to_string(),
+            },
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&bare_mismatch),
+            SourceVerdict::Bare
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&bare_mismatch),
+            MediaVerdict::Mismatch
+        );
+
+        // Bare + Unverified — no sidecar, no sig, no claim either way.
+        let pure_bare = iso_with(
+            HashVerification::NotPresent,
+            SignatureVerification::NotPresent,
+            vec![],
+            Distribution::Debian,
+        );
+        assert_eq!(
+            TrustVerdict::source_verdict(&pure_bare),
+            SourceVerdict::Bare
+        );
+        assert_eq!(
+            TrustVerdict::media_verdict(&pure_bare),
+            MediaVerdict::Unverified
+        );
+    }
+
+    #[test]
+    fn source_and_media_labels_non_empty_for_every_variant() {
+        for s in [
+            SourceVerdict::Verified,
+            SourceVerdict::KeyNotTrusted,
+            SourceVerdict::Tampered,
+            SourceVerdict::Bare,
+        ] {
+            assert!(!s.label().is_empty());
+        }
+        for m in [
+            MediaVerdict::Verified,
+            MediaVerdict::Mismatch,
+            MediaVerdict::Unverified,
+        ] {
+            assert!(!m.label().is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds two orthogonal verdict axes alongside the existing 6-tier `TrustVerdict`:

- **`SourceVerdict`** — origin trust. "Did this ISO come from a trustworthy place?" Computed from sidecar + minisig. Variants: `Verified | KeyNotTrusted | Tampered | Bare`.
- **`MediaVerdict`** — storage integrity. "Do the on-stick ISO bytes match the most-recent recorded hash?" Computed from sig + hash signals. Variants: `Verified | Mismatch | Unverified`.

Closes #558. Per [maintainer alignment](https://github.com/aegis-boot/aegis-boot/issues/558#issuecomment-4320354628): **additive** (interpretation A — per-ISO axis split), combined `Verdict:` line + info-pane breakdown, no kexec-gate behavior change.

## Why additive (and why per-ISO interpretation A)

The issue mentioned two underlying data sources (`Attestation.image_sha256` for source vs `Manifest.esp_files[].sha256` for media), but those are stick-infrastructure-level concepts. Your alignment answer (combined Verdict line on the per-ISO Confirm screen, info-pane breakdown) is per-ISO. So the right model is:

- **Source** = sidecar/minisig-level signals (the *origin* — does a recognized party vouch for this ISO?)
- **Media** = bytes-vs-recorded-hash (the *storage* layer — was anything tampered after recording?)

Both compute from existing iso-probe `DiscoveredIso` data — no new plumbing, no new fields. Verify-now (#548) already updates `iso.hash_verification` in place, which means the `MediaVerdict` automatically reflects post-verify-now state.

Additive avoids match-arm churn across the ~30+ existing `TrustVerdict` consumer sites in render.rs / state.rs / main.rs.

## UX

The Confirm-screen info pane gains two new rows:

```
Source:   VERIFIED         (origin trust — sidecar + minisig)
Media:    VERIFIED         (bytes-on-stick vs recorded hash)
```

Each labeled in the appropriate theme color (success/warning/error/gray). The combined `Verdict:` line at the top of the pane is **unchanged** — still down-shifts to the worse-of-two tier from the existing 6-tier model.

## Orthogonality matters

Some combinations the existing tier model collapses but operators care about:

| Source       | Media       | Today (`TrustVerdict`)  | New axes surface why                            |
| ------------ | ----------- | ----------------------- | ----------------------------------------------- |
| `Tampered`   | `Mismatch`  | `HashMismatch` (tier 6) | Forged sig — publisher's claim vs bytes diverged |
| `Bare`       | `Mismatch`  | `HashMismatch` (tier 6) | Sidecar disagrees with bytes; no auth on sidecar |
| `Verified`   | `Verified`  | `OperatorAttested`      | Full trust — both axes pass                      |
| `Bare`       | `Unverified`| `BareUnverified`        | Nothing to attest                                |

The mitigation differs per axis: source problems mean re-download; media problems mean re-flash or run verify-now.

## Migration property pinned

`from_discovered_combined_unchanged_after_split` walks 7 fixtures (verified-sig, verified-hash, key-not-trusted, bare, hash-mismatch, forged-sig, windows-blocked) and asserts the existing 6-tier output is unchanged. Future refactor that breaks this also breaks every tier-consumer; the panic message names the offending fixture.

## Boot gate

**Unchanged.** Per maintainer alignment: "no gate change. The existing block-on-mismatch is the secure default; operator-friendly recovery via verify-now (#548) already exists." Verify-now recomputes the on-stick hash; if it matches the recorded value, `iso.hash_verification` updates and `MediaVerdict` flips to `Verified`. No new "force boot through hash mismatch" path.

## Test plan

- [x] `cargo test -p rescue-tui --lib` — 200 tests pass (+12 new):
  - 1 migration test (combined verdict unchanged across 7 fixtures)
  - 5 Source-axis tests
  - 4 Media-axis tests
  - 1 orthogonality demo
  - 1 label-non-empty smoke test
- [x] `cargo clippy -p rescue-tui --all-targets --no-deps -- -D warnings` clean for touched lines.
- [x] `cargo fmt -p rescue-tui` clean.
- [x] `cargo build -p rescue-tui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)