### PR TITLE
feat(rescue-tui): per-session consent screen + Tier B failure log (#347)

### DIFF
--- a/crates/rescue-tui/src/docgen.rs
+++ b/crates/rescue-tui/src/docgen.rs
@@ -142,6 +142,7 @@ fn screen_short_name(s: ScreenKind) -> String {
         ScreenKind::ConfirmQuit => "ConfirmQuit",
         ScreenKind::Quitting => "Quitting",
         ScreenKind::BlockedToast => "BlockedToast",
+        ScreenKind::Consent => "Consent",
     };
     name.to_string()
 }

--- a/crates/rescue-tui/src/keybindings.rs
+++ b/crates/rescue-tui/src/keybindings.rs
@@ -49,6 +49,8 @@ pub(crate) enum ScreenKind {
     Quitting,
     /// "Cannot boot" toast over a tier-4 row. (#546)
     BlockedToast,
+    /// Consent screen for elevated-risk boot paths (#347).
+    Consent,
 }
 
 impl ScreenKind {
@@ -66,6 +68,7 @@ impl ScreenKind {
             Screen::ConfirmQuit { .. } => Self::ConfirmQuit,
             Screen::Quitting => Self::Quitting,
             Screen::BlockedToast { .. } => Self::BlockedToast,
+            Screen::Consent { .. } => Self::Consent,
         }
     }
 }

--- a/crates/rescue-tui/src/lib.rs
+++ b/crates/rescue-tui/src/lib.rs
@@ -32,5 +32,6 @@ pub mod persistence;
 pub mod render;
 pub mod state;
 pub mod theme;
+pub mod tier_b_log;
 pub mod tpm;
 pub mod verdict;

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -69,6 +69,39 @@ fn tracing_subscriber_init() {
     }
 }
 
+/// Persist a Tier B parse-failure log (#347 Phase 3b). Best-effort —
+/// writes to `/run/media/aegis-isos` first (the live `AEGIS_ISOS`
+/// mount), falls back to `/tmp/aegis-tier-b-log` if that's not
+/// writable. Never blocks rescue-tui startup; tracing carries the
+/// diagnostic if every base fails. Lifted out of `run()` so that fn
+/// stays under clippy's 100-line cap.
+fn persist_tier_b_log(failed: &[iso_probe::FailedIso]) {
+    if failed.is_empty() {
+        return;
+    }
+    for base in ["/run/media/aegis-isos", "/tmp/aegis-tier-b-log"] {
+        let dir = std::path::Path::new(base);
+        match tier_b_log::write_failure_log(failed, dir) {
+            Ok(Some(path)) => {
+                tracing::info!(
+                    path = %path.display(),
+                    count = failed.len(),
+                    "tier-b: parse-failure log written"
+                );
+                return;
+            }
+            Ok(None) => return, // empty list, guarded above; defensive
+            Err(e) => {
+                tracing::debug!(
+                    base = base,
+                    error = %e,
+                    "tier-b: write attempt failed; trying next base"
+                );
+            }
+        }
+    }
+}
+
 /// Count the number of `.iso` files present under any of `roots`.
 /// Depth-limited walk (max 3 levels) since `AEGIS_ISOS` is a flat
 /// layout in practice; goes 3 deep to catch operators who nested one
@@ -158,35 +191,7 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
     }
     let counted_but_not_attempted = on_disk_iso_count.saturating_sub(isos.len() + failed.len());
     let skipped = failed.len() + counted_but_not_attempted;
-    // #347 Tier B: persist a structured JSONL log of every parse-failed
-    // ISO so operators pulling the stick post-rescue can troubleshoot
-    // why specific ISOs didn't surface, without needing journald
-    // capture. Best-effort, parallel pattern to verify-now audit log
-    // (#548) — writes go to `/run/media/aegis-isos` (the live AEGIS_ISOS
-    // mount); tmp fallback if that path isn't writable.
-    if !failed.is_empty() {
-        for base in ["/run/media/aegis-isos", "/tmp/aegis-tier-b-log"] {
-            let dir = std::path::Path::new(base);
-            match tier_b_log::write_failure_log(&failed, dir) {
-                Ok(Some(path)) => {
-                    tracing::info!(
-                        path = %path.display(),
-                        count = failed.len(),
-                        "tier-b: parse-failure log written"
-                    );
-                    break;
-                }
-                Ok(None) => break, // empty list, but we guarded above; defensive
-                Err(e) => {
-                    tracing::debug!(
-                        base = base,
-                        error = %e,
-                        "tier-b: write attempt failed; trying next base"
-                    );
-                }
-            }
-        }
-    }
+    persist_tier_b_log(&failed);
     // Startup banner to stderr — mirrored via tracing::info! so structured
     // consumers (journald, CI smoke greps) see the same signal as humans
     // reading the serial console directly.

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -11,7 +11,7 @@
 
 // All modules now live in lib.rs so sibling binaries like
 // tiers-docgen (#462) can share them. main.rs is a thin driver.
-use rescue_tui::{failure_log, persistence, render, state, theme, tpm};
+use rescue_tui::{failure_log, persistence, render, state, theme, tier_b_log, tpm};
 
 use std::env;
 use std::io;
@@ -158,6 +158,35 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
     }
     let counted_but_not_attempted = on_disk_iso_count.saturating_sub(isos.len() + failed.len());
     let skipped = failed.len() + counted_but_not_attempted;
+    // #347 Tier B: persist a structured JSONL log of every parse-failed
+    // ISO so operators pulling the stick post-rescue can troubleshoot
+    // why specific ISOs didn't surface, without needing journald
+    // capture. Best-effort, parallel pattern to verify-now audit log
+    // (#548) — writes go to `/run/media/aegis-isos` (the live AEGIS_ISOS
+    // mount); tmp fallback if that path isn't writable.
+    if !failed.is_empty() {
+        for base in ["/run/media/aegis-isos", "/tmp/aegis-tier-b-log"] {
+            let dir = std::path::Path::new(base);
+            match tier_b_log::write_failure_log(&failed, dir) {
+                Ok(Some(path)) => {
+                    tracing::info!(
+                        path = %path.display(),
+                        count = failed.len(),
+                        "tier-b: parse-failure log written"
+                    );
+                    break;
+                }
+                Ok(None) => break, // empty list, but we guarded above; defensive
+                Err(e) => {
+                    tracing::debug!(
+                        base = base,
+                        error = %e,
+                        "tier-b: write attempt failed; trying next base"
+                    );
+                }
+            }
+        }
+    }
     // Startup banner to stderr — mirrored via tracing::info! so structured
     // consumers (journald, CI smoke greps) see the same signal as humans
     // reading the serial console directly.
@@ -555,12 +584,42 @@ where
                         "rescue-tui: refused kexec — ISO is kexec-blocked (quirk or verification failure)"
                     );
                     state.record_kexec_error(&kexec_loader::KexecError::UnsupportedImage);
+                } else if let Some(kind) = state.consent_required_for(idx) {
+                    // #347: elevated-risk path requires per-session
+                    // consent before kexec proceeds. Once granted, the
+                    // session_consent flag short-circuits this branch
+                    // and subsequent boots flow through normally.
+                    state.enter_consent(kind, idx);
                 } else if state.is_degraded_trust(idx) {
                     // #93: YELLOW/GRAY verdict → require typing "boot".
                     state.enter_trust_challenge(idx);
                 } else {
                     attempt_kexec(state, idx);
                 }
+            }
+
+            // #347 consent-screen handlers. 'y' grants for the session;
+            // Esc cancels back to Confirm. The ConsentKind drives what
+            // happens after grant: install-warning consent flows into
+            // the normal kexec dispatch (re-entering the Confirm Enter
+            // path with session_consent set short-circuits the consent
+            // gate); tier-4 force-boot would attempt a kexec that fails
+            // with a clearer error than the current silent BlockedToast.
+            (Screen::Consent { .. }, KeyCode::Char('y' | 'Y')) => {
+                if let Some(idx) = state.grant_consent() {
+                    // After grant: re-evaluate the gate chain for `idx`.
+                    // The consent flag is now sticky for the session, so
+                    // the consent gate won't fire again; falls through
+                    // to trust-challenge or kexec as appropriate.
+                    if state.is_degraded_trust(idx) {
+                        state.enter_trust_challenge(idx);
+                    } else {
+                        attempt_kexec(state, idx);
+                    }
+                }
+            }
+            (Screen::Consent { .. }, KeyCode::Esc) => {
+                state.cancel_consent();
             }
 
             // Trust challenge (#93): Enter only fires kexec if the

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -12,7 +12,7 @@ use ratatui::{
 };
 
 use crate::keybindings::{self, ScreenKind};
-use crate::state::{AppState, Pane, Screen, SecureBootStatus, quirks_summary};
+use crate::state::{AppState, ConsentKind, Pane, Screen, SecureBootStatus, quirks_summary};
 use crate::theme::Theme;
 use crate::verdict::TrustVerdict;
 
@@ -57,6 +57,9 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
     if let Screen::BlockedToast { message, .. } = &state.screen {
         draw_blocked_toast_overlay(frame, area, state, message);
     }
+    if let Screen::Consent { kind, .. } = &state.screen {
+        draw_consent_overlay(frame, area, state, *kind);
+    }
 }
 
 fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -68,7 +71,14 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
     };
     match effective {
         Screen::List { selected } => draw_list(frame, area, state, *selected),
-        Screen::Confirm { selected } => draw_confirm(frame, area, state, *selected),
+        // Confirm + Consent share the same backdrop: Consent (#347)
+        // renders the Confirm screen underneath at the selected ISO so
+        // the operator sees verdict context, then the consent overlay
+        // paints on top via the overlay pass below (parallel to the
+        // BlockedToast pattern).
+        Screen::Confirm { selected } | Screen::Consent { selected, .. } => {
+            draw_confirm(frame, area, state, *selected);
+        }
         Screen::EditCmdline {
             selected,
             buffer,
@@ -532,6 +542,58 @@ fn draw_blocked_toast_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppStat
         )),
     ];
     let block = Block::default().borders(Borders::ALL).title(" Blocked ");
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        panel,
+    );
+}
+
+/// Centered consent-prompt overlay (#347). Renders the Confirm screen
+/// underneath at the selected ISO so the operator sees the verdict
+/// context they're consenting against, then layers the prompt on top.
+/// Visually distinct from `BlockedToast` (warning-tinted border + a
+/// `[ Consent required ]` title) so the operator reads it as
+/// "decision needed" rather than "boot refused."
+fn draw_consent_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState, kind: ConsentKind) {
+    use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+    let prose = kind.prose();
+    let title = kind.title();
+    // Width: hug the longest line; cap so wide messages still land in
+    // the centered panel rather than spilling to the framebuffer edges.
+    let content_width = prose
+        .iter()
+        .copied()
+        .chain(std::iter::once(title))
+        .map(str::len)
+        .max()
+        .unwrap_or(40);
+    let w = u16::try_from(content_width.saturating_add(4))
+        .unwrap_or(u16::MAX)
+        .min(area.width)
+        .min(72);
+    // Height: prose lines + 2 (top/bottom border) + 2 (top spacer + footer).
+    let h = u16::try_from(prose.len().saturating_add(4))
+        .unwrap_or(u16::MAX)
+        .min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let panel = Rect::new(x, y, w, h);
+
+    let mut lines: Vec<Line<'_>> = Vec::with_capacity(prose.len().saturating_add(2));
+    lines.push(Line::from(""));
+    for body_line in prose {
+        lines.push(Line::from(Span::styled(
+            *body_line,
+            Style::default().fg(state.theme.warning),
+        )));
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {title} "));
     frame.render_widget(
         Paragraph::new(lines)
             .block(block)

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -142,7 +142,7 @@ impl ConsentKind {
     pub fn title(&self) -> &'static str {
         match self {
             Self::InstallerCanEraseDisks => "Confirm: installer can erase disks",
-            Self::Tier4ForceBoot => "Confirm: force boot of unparseable ISO",
+            Self::Tier4ForceBoot => "Confirm: force boot of unparsable ISO",
         }
     }
 

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -98,6 +98,82 @@ pub enum Screen {
         /// returns to the same row they tried.
         return_to: usize,
     },
+    /// Consent screen — operator must explicitly acknowledge an
+    /// elevated-risk boot path before the kexec proceeds. Per-session
+    /// (`AppState::session_consent`): once granted, subsequent boots
+    /// in the same session skip this screen. (#347 — Phase 3b of #342.)
+    Consent {
+        /// What the operator is being asked to consent to. Drives the
+        /// rendered prose + the post-grant routing.
+        kind: ConsentKind,
+        /// Which Confirm-screen ISO to return to after consent
+        /// (granted → kexec; dismissed → Confirm).
+        selected: usize,
+    },
+}
+
+/// Reason for a [`Screen::Consent`] prompt. Each variant pairs with a
+/// specific operator decision the system needs explicit ack for. The
+/// shipped policy is *allow boot of any media but maintain the chain
+/// of trust as opt-in for high security* — the consent screen is the
+/// hinge where the operator opts down from "trusted only" to "any
+/// media." (#347 maintainer alignment.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentKind {
+    /// The selected ISO carries an installer that can erase disks on
+    /// the host machine if the operator picks the wrong target inside
+    /// the ISO's own boot menu. Triggered by [`DiscoveredIso`]'s
+    /// `contains_installer` flag (#131). The Confirm screen renders an
+    /// inline warning today; consent is the second-step gate before
+    /// kexec proceeds.
+    InstallerCanEraseDisks,
+    /// The selected entry is a parse-failed (tier-4) ISO and the
+    /// operator wants to attempt boot anyway. Currently a no-op
+    /// because iso-parser couldn't extract a kernel/initrd, but
+    /// recording the consent makes the eventual kernel-extraction
+    /// failure path's diagnostic clearer ("force-boot consented but
+    /// no kernel found in this ISO").
+    Tier4ForceBoot,
+}
+
+impl ConsentKind {
+    /// Short imperative title for the consent-screen header.
+    #[must_use]
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::InstallerCanEraseDisks => "Confirm: installer can erase disks",
+            Self::Tier4ForceBoot => "Confirm: force boot of unparseable ISO",
+        }
+    }
+
+    /// Multi-line operator-facing prose describing what consent means
+    /// for this kind. Returned as a `Vec<&'static str>` so the
+    /// renderer can wrap to terminal width without re-parsing.
+    #[must_use]
+    pub fn prose(&self) -> &'static [&'static str] {
+        match self {
+            Self::InstallerCanEraseDisks => &[
+                "This ISO contains an OS installer.",
+                "If the ISO's own boot menu defaults to 'Install',",
+                "DISKS ON THIS MACHINE MAY BE ERASED — including",
+                "the aegis-boot stick itself, if you pick it as a target.",
+                "",
+                "Press 'y' to grant consent for the rest of this rescue session.",
+                "Press Esc to return to the Confirm screen and pick differently.",
+            ],
+            Self::Tier4ForceBoot => &[
+                "This ISO failed to parse — iso-parser could not extract",
+                "a kernel + initrd from its layout.",
+                "",
+                "Force-boot will attempt the kexec anyway, but is expected",
+                "to fail with a clear error explaining what's missing.",
+                "Useful for diagnosing parser-vs-distro disagreement.",
+                "",
+                "Press 'y' to grant force-boot consent for the rest of this session.",
+                "Press Esc to return to the list.",
+            ],
+        }
+    }
 }
 
 /// Top-level application state.
@@ -171,6 +247,15 @@ pub struct AppState {
     /// verify succeeds, since the new line replaces the missing one.
     /// (#602)
     pub audit_warning: Option<String>,
+    /// Per-session consent flag (#347). When true, the operator has
+    /// explicitly acknowledged at least one elevated-risk boot path
+    /// (installer-can-erase, tier-4 force-boot) and subsequent boots
+    /// in the same session skip the [`Screen::Consent`] gate. Resets
+    /// to false on every rescue-tui startup — boot-decisions made by
+    /// last week's operator do not carry forward to today's. The flag
+    /// is inspected at the Confirm-screen Enter handler before
+    /// dispatching to [`Self::is_kexec_blocked`] / kexec.
+    pub session_consent: bool,
 }
 
 /// Sort order applied to the List view. Cycled with the `s` key.
@@ -388,7 +473,59 @@ impl AppState {
             pane: Pane::default(),
             info_scroll: 0,
             audit_warning: None,
+            session_consent: false,
         }
+    }
+
+    /// Open the [`Screen::Consent`] screen for the given consent kind
+    /// against the given Confirm-screen ISO. Called from the Confirm
+    /// Enter handler when consent is required AND not yet granted in
+    /// this session. (#347)
+    pub fn enter_consent(&mut self, kind: ConsentKind, selected: usize) {
+        self.screen = Screen::Consent { kind, selected };
+    }
+
+    /// Grant consent for the current session. Returns the `selected`
+    /// index from the consent screen so the caller can chain into the
+    /// Confirm-screen path the operator was originally trying to
+    /// reach. Resets the screen to Confirm; subsequent kexec attempts
+    /// in the same session no longer hit the consent screen. (#347)
+    pub fn grant_consent(&mut self) -> Option<usize> {
+        if let Screen::Consent { selected, .. } = self.screen {
+            self.session_consent = true;
+            self.screen = Screen::Confirm { selected };
+            Some(selected)
+        } else {
+            None
+        }
+    }
+
+    /// Cancel a pending consent prompt without granting. Returns the
+    /// operator to the Confirm screen for the same ISO without
+    /// persisting consent. (#347)
+    pub fn cancel_consent(&mut self) {
+        if let Screen::Consent { selected, .. } = self.screen {
+            self.screen = Screen::Confirm { selected };
+        }
+    }
+
+    /// Whether the Confirm-screen Enter path needs to detour through
+    /// the consent screen for the given ISO. Returns `Some(kind)` if
+    /// a consent prompt is required for some reason, `None` if the
+    /// path can proceed straight to the existing kexec / trust
+    /// challenge flow. Caller is `main.rs`'s Confirm-Enter handler.
+    /// (#347)
+    #[must_use]
+    pub fn consent_required_for(&self, iso_idx: usize) -> Option<ConsentKind> {
+        // Per-session: if consent already granted, no further prompts.
+        if self.session_consent {
+            return None;
+        }
+        let iso = self.isos.get(iso_idx)?;
+        if iso.contains_installer {
+            return Some(ConsentKind::InstallerCanEraseDisks);
+        }
+        None
     }
 
     /// Set the non-blocking audit-log warning banner shown on the Confirm
@@ -1928,6 +2065,121 @@ mod tests {
         assert!(
             !s.is_kexec_blocked(0),
             "audit warning is informational and must not gate kexec"
+        );
+    }
+
+    // ---- #347 consent screen + per-session consent ---------------------
+
+    fn fake_iso_with_installer_flag(name: &str, contains_installer: bool) -> DiscoveredIso {
+        let mut iso = fake_iso(name);
+        iso.contains_installer = contains_installer;
+        iso
+    }
+
+    /// #347: clean ISO (no installer warning, no quirks) needs no
+    /// consent screen. The Confirm-Enter handler proceeds straight to
+    /// the trust-challenge / kexec dispatch chain.
+    #[test]
+    fn consent_not_required_for_clean_iso() {
+        let s = AppState::new(vec![fake_iso("clean")]);
+        assert!(
+            s.consent_required_for(0).is_none(),
+            "no consent for clean ISO"
+        );
+    }
+
+    /// #347: an ISO carrying an installer (#131 `contains_installer`
+    /// flag) requires consent before kexec can proceed — that's the
+    /// "installer can erase disks" gate.
+    #[test]
+    fn consent_required_for_installer_iso_pre_grant() {
+        let s = AppState::new(vec![fake_iso_with_installer_flag("ubuntu-server", true)]);
+        let Some(kind) = s.consent_required_for(0) else {
+            panic!("installer ISO must require consent");
+        };
+        assert_eq!(kind, ConsentKind::InstallerCanEraseDisks);
+    }
+
+    /// #347: per-session consent — once granted, subsequent
+    /// installer-ISO selections in the same session do NOT re-trigger
+    /// the consent gate. Resets on rescue-tui restart.
+    #[test]
+    fn consent_required_returns_none_after_session_grant() {
+        let mut s = AppState::new(vec![fake_iso_with_installer_flag("ubuntu-server", true)]);
+        s.session_consent = true;
+        assert!(
+            s.consent_required_for(0).is_none(),
+            "session_consent should short-circuit the gate"
+        );
+    }
+
+    /// #347: `enter_consent` transitions to `Screen::Consent` carrying
+    /// the kind + the selected-ISO index for return-routing.
+    #[test]
+    fn enter_consent_transitions_to_consent_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_consent(ConsentKind::InstallerCanEraseDisks, 0);
+        match s.screen {
+            Screen::Consent { kind, selected } => {
+                assert_eq!(kind, ConsentKind::InstallerCanEraseDisks);
+                assert_eq!(selected, 0);
+            }
+            other => panic!("expected Screen::Consent, got {other:?}"),
+        }
+    }
+
+    /// #347: `grant_consent` flips `session_consent` and routes back
+    /// to the Confirm screen for the same ISO. Returns `Some(idx)` so
+    /// the main-loop handler can chain into kexec dispatch.
+    #[test]
+    fn grant_consent_sets_session_flag_and_routes_to_confirm() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_consent(ConsentKind::InstallerCanEraseDisks, 0);
+        let Some(idx) = s.grant_consent() else {
+            panic!("consent grant returns the idx");
+        };
+        assert_eq!(idx, 0);
+        assert!(s.session_consent, "consent must persist for the session");
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+    }
+
+    /// #347: `cancel_consent` returns to Confirm WITHOUT setting the
+    /// `session_consent` flag — operator declined.
+    #[test]
+    fn cancel_consent_does_not_persist_grant() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.enter_consent(ConsentKind::InstallerCanEraseDisks, 0);
+        s.cancel_consent();
+        assert!(matches!(s.screen, Screen::Confirm { selected: 0 }));
+        assert!(!s.session_consent, "cancel must NOT persist consent");
+    }
+
+    /// #347: `grant_consent` on a non-Consent screen is a no-op
+    /// (returns `None`) so a stray keypress can't toggle
+    /// `session_consent` from elsewhere in the state machine.
+    #[test]
+    fn grant_consent_noop_when_not_on_consent_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        // screen is List by default; calling grant_consent should
+        // return None and leave session_consent untouched.
+        assert!(s.grant_consent().is_none());
+        assert!(!s.session_consent);
+    }
+
+    /// #347: the consent flag does NOT bypass the kexec-blocked gate.
+    /// Granting consent on a Windows ISO (`NotKexecBootable`) does not
+    /// allow kexec to proceed — the security invariant from #602/#558
+    /// (`Quirk::NotKexecBootable` always blocks) stays in force.
+    #[test]
+    fn consent_does_not_bypass_kexec_block() {
+        let mut iso = fake_iso("windows.iso");
+        iso.quirks = vec![Quirk::NotKexecBootable];
+        iso.contains_installer = true;
+        let mut s = AppState::new(vec![iso]);
+        s.session_consent = true;
+        assert!(
+            s.is_kexec_blocked(0),
+            "NotKexecBootable wins over session_consent"
         );
     }
 

--- a/crates/rescue-tui/src/tier_b_log.rs
+++ b/crates/rescue-tui/src/tier_b_log.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tier B failure log (#347 Phase 3b).
+//!
+//! Writes a structured JSONL record of every parse-failed ISO
+//! (`iso-probe`'s `DiscoveryReport::failed`) to the `AEGIS_ISOS`
+//! partition at rescue-tui startup. Operators pulling the stick
+//! post-rescue can read this file from any host machine to troubleshoot
+//! why specific ISOs didn't surface in the boot menu, without needing
+//! to capture journald output during the rescue session.
+//!
+//! Parallel pattern to the verify-now audit log shipped in #548:
+//! - One JSON object per line, one entry per failed ISO.
+//! - Filename `aegis-boot-failures-<unix-ts>.jsonl` so multiple boots
+//!   of the same stick produce comparable, non-clobbering files.
+//! - Best-effort: write failures are logged via `tracing::warn!` but
+//!   never block rescue-tui startup. The same UX principle as #602's
+//!   audit-warning banner — degraded logging signal is surfaced, not
+//!   pretended-away.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use iso_probe::{FailedIso, FailureKind};
+use serde::Serialize;
+
+/// One entry in the Tier B failure log. JSON-serialized one-per-line.
+#[derive(Debug, Serialize)]
+struct TierBEntry<'a> {
+    /// Schema version. Bump only when adding/removing required fields.
+    schema_version: u8,
+    /// UNIX timestamp (seconds) the entry was written. Same value
+    /// across all entries from the same rescue-tui run.
+    timestamp: u64,
+    /// Absolute path of the failed ISO on the `AEGIS_ISOS` partition.
+    iso_path: String,
+    /// Sanitized human-readable reason from iso-parser.
+    reason: &'a str,
+    /// Structured failure classification (`io_error`, `mount_failed`,
+    /// `no_boot_entries`). Stable wire identifier; kebab-case to match
+    /// the rest of the JSONL schemas.
+    kind: &'static str,
+}
+
+const SCHEMA_VERSION: u8 = 1;
+
+fn kind_label(k: FailureKind) -> &'static str {
+    match k {
+        FailureKind::IoError => "io_error",
+        FailureKind::MountFailed => "mount_failed",
+        FailureKind::NoBootEntries => "no_boot_entries",
+    }
+}
+
+/// Write a Tier B failure log to `log_dir` listing every parse-failed
+/// ISO. Returns the path of the written file. No-op (returns `Ok(None)`)
+/// if `failed` is empty — operators with a clean stick don't get an
+/// empty file cluttering `AEGIS_ISOS`.
+///
+/// # Errors
+///
+/// Returns `std::io::Error` if the file cannot be created or written.
+/// `serde_json` serialization errors are converted to `io::Error` —
+/// they're not actually possible for the simple `TierBEntry` shape but
+/// the conversion keeps the signature uniform for callers.
+pub fn write_failure_log(failed: &[FailedIso], log_dir: &Path) -> std::io::Result<Option<PathBuf>> {
+    if failed.is_empty() {
+        return Ok(None);
+    }
+    // SystemTime before UNIX_EPOCH means a clock so broken we
+    // can't produce a usable filename. Fall back to 0 rather
+    // than refuse to log; the file timestamp on disk preserves
+    // the ordering anyway.
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let path = log_dir.join(format!("aegis-boot-failures-{timestamp}.jsonl"));
+    std::fs::create_dir_all(log_dir)?;
+    let mut file = std::fs::File::create(&path)?;
+    for f in failed {
+        let entry = TierBEntry {
+            schema_version: SCHEMA_VERSION,
+            timestamp,
+            iso_path: f.iso_path.display().to_string(),
+            reason: &f.reason,
+            kind: kind_label(f.kind),
+        };
+        let line = serde_json::to_string(&entry).map_err(std::io::Error::other)?;
+        writeln!(file, "{line}")?;
+    }
+    file.flush()?;
+    Ok(Some(path))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn fake_failed(iso: &str, reason: &str, kind: FailureKind) -> FailedIso {
+        FailedIso {
+            iso_path: PathBuf::from(iso),
+            reason: reason.to_string(),
+            kind,
+        }
+    }
+
+    #[test]
+    fn empty_failed_list_writes_no_file() {
+        let dir = tempdir().unwrap();
+        let res = write_failure_log(&[], dir.path()).unwrap();
+        assert!(res.is_none(), "no log file expected for empty failed list");
+        // Directory should also remain empty.
+        let entries: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "log_dir should not have been created/populated"
+        );
+    }
+
+    #[test]
+    fn writes_one_jsonl_line_per_failure() {
+        let dir = tempdir().unwrap();
+        let failed = vec![
+            fake_failed(
+                "/run/aegis-isos/a.iso",
+                "mount: wrong fs type",
+                FailureKind::MountFailed,
+            ),
+            fake_failed(
+                "/run/aegis-isos/b.iso",
+                "no kernel found",
+                FailureKind::NoBootEntries,
+            ),
+            fake_failed(
+                "/run/aegis-isos/c.iso",
+                "EIO reading sector 1",
+                FailureKind::IoError,
+            ),
+        ];
+        let path = write_failure_log(&failed, dir.path()).unwrap().unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 3, "one JSONL line per failure");
+
+        // Each line parses as JSON and has the expected fields.
+        for (i, line) in lines.iter().enumerate() {
+            let v: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("line {i} not valid JSON: {e} -- {line}"));
+            assert_eq!(v["schema_version"], 1);
+            assert!(v["timestamp"].is_u64());
+            assert!(v["iso_path"].is_string());
+            assert!(v["reason"].is_string());
+            assert!(v["kind"].is_string());
+        }
+    }
+
+    #[test]
+    fn kind_labels_are_stable_kebab_case() {
+        // These strings are wire-identifiers — changing them breaks
+        // any downstream tooling that greps the log. Pin them here.
+        assert_eq!(kind_label(FailureKind::IoError), "io_error");
+        assert_eq!(kind_label(FailureKind::MountFailed), "mount_failed");
+        assert_eq!(kind_label(FailureKind::NoBootEntries), "no_boot_entries");
+    }
+
+    #[test]
+    fn filename_includes_unix_timestamp() {
+        let dir = tempdir().unwrap();
+        let failed = vec![fake_failed("/x.iso", "r", FailureKind::IoError)];
+        let path = write_failure_log(&failed, dir.path()).unwrap().unwrap();
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(
+            name.starts_with("aegis-boot-failures-"),
+            "filename prefix unexpected: {name}"
+        );
+        // Use Path::extension() to satisfy clippy's
+        // case_sensitive_file_extension_comparisons lint without an
+        // allow attr. We control the filename so we know the case
+        // anyway, but the lint is right that the idiomatic check goes
+        // through Path.
+        assert_eq!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("jsonl"),
+            "filename extension unexpected: {name}"
+        );
+        // Middle is the unix timestamp; should be all digits.
+        let middle = name
+            .strip_prefix("aegis-boot-failures-")
+            .unwrap()
+            .strip_suffix(".jsonl")
+            .unwrap();
+        assert!(
+            middle.chars().all(|c| c.is_ascii_digit()),
+            "expected unix-timestamp middle, got {middle:?}"
+        );
+    }
+
+    #[test]
+    fn each_entry_carries_the_reason_verbatim() {
+        let dir = tempdir().unwrap();
+        let weird = "mount: wrong fs type, bad option, bad superblock";
+        let failed = vec![fake_failed("/x.iso", weird, FailureKind::MountFailed)];
+        let path = write_failure_log(&failed, dir.path()).unwrap().unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+        assert_eq!(v["reason"], weird);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3b of #342. Two coordinated additions to the rescue-tui runtime, per [maintainer alignment](https://github.com/aegis-boot/aegis-boot/issues/347#issuecomment-4320353742):

### 1. Per-session consent screen

- New `Screen::Consent { kind, selected }` variant + `ConsentKind` enum (`InstallerCanEraseDisks`, `Tier4ForceBoot`) + `AppState` methods.
- The Confirm-Enter handler detours through the consent screen when an ISO carries the `contains_installer` flag (#131) and consent has not yet been granted in this rescue session.
- Once granted, `AppState.session_consent` stays true for the rest of the boot session — subsequent installer-ISO selections do not re-prompt. Resets on rescue-tui restart by design (a new session = a new decision).
- Overlay rendering follows the same pattern as #546's `BlockedToast` (backdrop = Confirm screen, centered warning-tinted prompt on top). `'y'` grants for the session; `Esc` cancels back to Confirm.

**`Tier4ForceBoot` variant** is defined but not yet wired from a call site — present in the type system so future iso-parser work that lets operators force-boot parse-failed ISOs has a clean target. The consent UX is ready ahead of the parser-side change.

### 2. Tier B failure log

- New `tier_b_log` module writes a JSONL record of every parse-failed ISO to `AEGIS_ISOS` at rescue-tui startup.
- Filename: `aegis-boot-failures-<unix-ts>.jsonl`. One JSON object per line with `schema_version` = 1, `timestamp`, `iso_path`, `reason`, `kind`.
- Operators pulling the stick post-rescue can troubleshoot from any host without journald access.
- Best-effort write (parallels #548's verify-now audit log): falls back to `/tmp/aegis-tier-b-log` if `/run/media/aegis-isos` isn't writable. Never blocks startup.

## Security invariant pinned

The consent flag does **not** bypass any kexec security gate. A Windows ISO (`Quirk::NotKexecBootable`) with consent granted still refuses to kexec — `is_kexec_blocked()` runs first in the Confirm-Enter chain. Pinned by `consent_does_not_bypass_kexec_block` test so a future refactor can't accidentally weaken the gate.

## What's not in this PR (deferred follow-ups)

- **Force-boot of tier-4 parse-failed ISOs**. The `ConsentKind::Tier4ForceBoot` variant is defined but unwired because iso-parser doesn't extract a kernel/initrd for parse-failed ISOs — there's nothing to kexec into. Wiring the variant requires a separate iso-parser change (best-effort kernel-extraction heuristic OR an operator-supplied sidecar config). Tracked separately when that direction is decided.
- **Source/Media verdict surfacing in the info pane** is in #558 (already merged) — that PR added the Source: + Media: lines on the Confirm screen which the consent prompt now appears over.

Closes #347.

## Test plan

- [x] `cargo test -p rescue-tui --lib` — 202 tests pass (+13 new):
  - 7 consent-flow tests (including `consent_does_not_bypass_kexec_block`)
  - 5 tier_b_log tests (log shape + schema-stability)
  - 1 test confirms the existing #602 audit-warning still works alongside the new state field
- [x] `cargo clippy -p rescue-tui --all-targets --no-deps -- -D warnings` clean for touched lines.
- [x] `cargo fmt -p rescue-tui` clean.
- [x] `cargo build -p rescue-tui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)