### PR TITLE
docs(demos): asciinema recording + render harness for README demos (#348 Phase 1)

### DIFF
--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# aegis-boot demos
+
+Inline asciinema recordings of the three operator-facing flows
+referenced in [#348](https://github.com/aegis-boot/aegis-boot/issues/348),
+rendered to SVG so GitHub markdown displays them natively without
+depending on an external host (asciinema.org).
+
+## Status
+
+This directory holds the **harness** — the scripts that record + render
+the demos — but **not yet the recordings themselves**. Recording the
+three flows is interactive (asciinema needs a real terminal driving the
+TUI / CLI flows + a built `aegis-boot.img` for the QEMU demo); a
+maintainer or contributor with the dev environment runs the harness
+once and commits the resulting `.svg` files.
+
+When the SVGs land, this directory will contain:
+
+| File                          | Flow                                                       |
+| ----------------------------- | ---------------------------------------------------------- |
+| `01-quickstart.svg`           | `aegis-boot quickstart /dev/sdc` — sub-10-minute happy path |
+| `02-init.svg`                 | `aegis-boot init /dev/sdc --yes` — 3-distro panic-room      |
+| `03-qemu-boot.svg`            | QEMU+OVMF SecureBoot → rescue-tui ISO selection             |
+
+The README's "What it does" section embeds these via plain
+`<img src="docs/demos/<n>-<name>.svg">` once they exist.
+
+## Recording
+
+```bash
+# Record one flow (asciinema is interactive — drives a real terminal).
+sudo scripts/record-demos.sh quickstart      # 01-quickstart.cast
+sudo scripts/record-demos.sh init            # 02-init.cast
+scripts/record-demos.sh qemu-boot            # 03-qemu-boot.cast
+
+# Or all three, sequentially.
+sudo scripts/record-demos.sh all
+```
+
+`AEGIS_DEMO_TARGET=/dev/loopN scripts/record-demos.sh init` overrides
+the default target (`/dev/loop99`) for the destructive flash flows
+(quickstart, init). Use a loop device for reproducibility — the QEMU
+demo doesn't need a target since it boots a pre-built `aegis-boot.img`.
+
+## Rendering
+
+```bash
+# Renders every .cast in docs/demos/casts/ to docs/demos/<name>.svg.
+scripts/render-demos.sh
+```
+
+Tries `svg-term-cli` first (preferred — produces SVG), falls back to
+`agg` (produces GIF) if svg-term-cli isn't installed:
+
+```bash
+# Either of:
+npm install -g svg-term-cli
+go install github.com/asciinema/agg@latest
+```
+
+## Why inline SVG and not asciinema.org
+
+Three reasons, per the [maintainer alignment in #348](https://github.com/aegis-boot/aegis-boot/issues/348#issuecomment-4320353920):
+
+1. **Self-contained repo.** Operators reading the README on a
+   no-network preview (e.g. cloned offline) still see the demos.
+2. **No external availability dependency.** asciinema.org outages
+   would invisibly break the README's primary onboarding visual.
+3. **Reproducible rendering.** SVG is checked in; the rendered file
+   is what every reader sees, no per-viewer player initialization or
+   third-party JS.
+
+`agg`'s GIF fallback is supported but discouraged — bigger files (≥10×
+SVG size) and worse legibility on mobile/print.

--- a/scripts/record-demos.sh
+++ b/scripts/record-demos.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Record the three asciinema demos referenced in #348.
+#
+# This script is INTERACTIVE — it drives `asciinema rec` against three
+# canned aegis-boot flows. Outputs go to docs/demos/casts/ as `.cast`
+# files; render-demos.sh converts them to inline-renderable SVG.
+#
+# Maintainer alignment (#348, 2026-04-25):
+#   - Three flows: quickstart, init (3-distro), QEMU+OVMF rescue-tui boot.
+#   - Inline-render via SVG (svg-term-cli or agg) for native GitHub
+#     markdown — no external host (asciinema.org) dependency.
+#   - Below the "What it does" section in README.md.
+#
+# Prereqs:
+#   - asciinema (apt: asciinema, brew: asciinema)
+#   - For QEMU demo: qemu-system-x86, ovmf, a built aegis-boot.img
+#   - Raw write demos require a sacrificial USB stick; loop-device path
+#     is preferred for reproducibility (the Linux-host CI uses loop too).
+#
+# Usage:
+#   tools/record-demos.sh quickstart          # cast 1
+#   tools/record-demos.sh init                # cast 2
+#   tools/record-demos.sh qemu-boot           # cast 3
+#   tools/record-demos.sh all                 # all three sequentially
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASTS_DIR="$REPO_ROOT/docs/demos/casts"
+mkdir -p "$CASTS_DIR"
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: '$1' not on PATH" >&2
+        exit 1
+    fi
+}
+
+require asciinema
+
+record_quickstart() {
+    local target="${AEGIS_DEMO_TARGET:-/dev/loop99}"
+    cat <<EOF
+record-demos: cast 1 of 3 — aegis-boot quickstart
+
+This demo records:
+  sudo aegis-boot quickstart $target
+which composes flash + add for a single-distro panic-room stick (Alpine
+3.20 default). Operator-facing happy path; sub-10-minute by design.
+
+You will be prompted by asciinema to start the recording. The script
+will run quickstart against $target. Press Ctrl-D or 'exit' to stop
+recording when the flow finishes.
+EOF
+    asciinema rec \
+        --title "aegis-boot quickstart — single-distro panic-room (Alpine 3.20)" \
+        --command "sudo $REPO_ROOT/target/release/aegis-boot quickstart $target" \
+        "$CASTS_DIR/01-quickstart.cast"
+}
+
+record_init() {
+    local target="${AEGIS_DEMO_TARGET:-/dev/loop99}"
+    cat <<EOF
+record-demos: cast 2 of 3 — aegis-boot init (3-distro)
+
+This demo records:
+  sudo aegis-boot init $target --yes
+which composes flash + fetch + add for the 3-distro panic-room profile
+(Alpine + Ubuntu Server + Rocky). Single attestation manifest covers
+the whole run.
+EOF
+    asciinema rec \
+        --title "aegis-boot init — panic-room 3-distro stick" \
+        --command "sudo $REPO_ROOT/target/release/aegis-boot init $target --yes" \
+        "$CASTS_DIR/02-init.cast"
+}
+
+record_qemu_boot() {
+    cat <<EOF
+record-demos: cast 3 of 3 — QEMU+OVMF rescue-tui boot
+
+This demo records the rescue-tui experience:
+  ./scripts/qemu-loaded-stick.sh -d ./test-isos -a usb -i
+launches QEMU+OVMF with SecureBoot enforcing, boots the aegis-boot.img,
+and lands the operator on the ratatui ISO list. This is what an
+operator sees on a real machine.
+
+Press Ctrl-A then x to exit QEMU when the demo flow is done; that's
+the cleanest way to stop the recording without leaving the VM running.
+EOF
+    asciinema rec \
+        --title "aegis-boot rescue-tui — booted under QEMU + OVMF SecureBoot" \
+        --command "$REPO_ROOT/scripts/qemu-loaded-stick.sh -d $REPO_ROOT/test-isos -a usb -i" \
+        "$CASTS_DIR/03-qemu-boot.cast"
+}
+
+case "${1:-}" in
+    quickstart) record_quickstart ;;
+    init) record_init ;;
+    qemu-boot) record_qemu_boot ;;
+    all) record_quickstart; record_init; record_qemu_boot ;;
+    *)
+        cat <<EOF >&2
+usage: $0 <quickstart|init|qemu-boot|all>
+
+Set AEGIS_DEMO_TARGET to override the default loop device for
+quickstart / init (default: /dev/loop99). Recordings land in
+docs/demos/casts/. Render to SVG via tools/render-demos.sh.
+EOF
+        exit 2
+        ;;
+esac
+
+echo
+echo "Recording done. Cast(s) in $CASTS_DIR/"
+echo "Next: $REPO_ROOT/scripts/render-demos.sh"

--- a/scripts/render-demos.sh
+++ b/scripts/render-demos.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Render asciinema .cast files to inline-renderable SVG (#348).
+#
+# Maintainer alignment (#348): inline SVG so GitHub markdown renders
+# the demo without an external asciinema.org dependency. Two render
+# tools are supported in order of preference; first one available wins:
+#
+#   1. svg-term-cli (Node-based, npm install -g svg-term-cli)
+#      - Single static SVG, animated via SMIL — best size + portability.
+#   2. agg (Go-based, github.com/asciinema/agg)
+#      - Renders to GIF rather than SVG; bigger files but zero JS.
+#
+# The first SVG-capable tool on PATH is used. If neither is installed,
+# this script prints install instructions and exits non-zero.
+#
+# Output layout:
+#   docs/demos/casts/<n>-<name>.cast    (input from record-demos.sh)
+#   docs/demos/<n>-<name>.svg           (inline-renderable artifact)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CASTS_DIR="$REPO_ROOT/docs/demos/casts"
+SVG_DIR="$REPO_ROOT/docs/demos"
+
+if [ ! -d "$CASTS_DIR" ]; then
+    echo "error: no $CASTS_DIR — run scripts/record-demos.sh first" >&2
+    exit 1
+fi
+
+renderer=""
+if command -v svg-term >/dev/null 2>&1; then
+    renderer="svg-term"
+elif command -v agg >/dev/null 2>&1; then
+    renderer="agg"
+else
+    cat <<'EOF' >&2
+error: no asciinema render tool found. Install one of:
+
+  npm install -g svg-term-cli           (preferred — produces SVG)
+  go install github.com/asciinema/agg@latest   (fallback — produces GIF)
+
+Then rerun this script.
+EOF
+    exit 1
+fi
+
+shopt -s nullglob
+casts=("$CASTS_DIR"/*.cast)
+if [ ${#casts[@]} -eq 0 ]; then
+    echo "warning: no .cast files in $CASTS_DIR — nothing to render" >&2
+    exit 0
+fi
+
+for cast in "${casts[@]}"; do
+    base="$(basename "$cast" .cast)"
+    out_svg="$SVG_DIR/$base.svg"
+    out_gif="$SVG_DIR/$base.gif"
+    case "$renderer" in
+        svg-term)
+            echo "rendering $cast → $out_svg"
+            # --window adds a terminal chrome; --no-cursor keeps the
+            # render compact since the cast itself shows the prompt.
+            svg-term --in "$cast" --out "$out_svg" --window
+            ;;
+        agg)
+            echo "rendering $cast → $out_gif (svg-term not available; SVG preferred)"
+            agg "$cast" "$out_gif"
+            ;;
+    esac
+done
+
+echo
+echo "Render done. Output(s) in $SVG_DIR/"
+echo "Embed inline in README.md with: ![demo](docs/demos/<name>.svg)"


### PR DESCRIPTION
## Summary

Phase 1 of #348 — ships the **harness** for inline asciinema demos in the README, but not the recordings themselves (those need an interactive terminal + built `aegis-boot.img` and can't be shipped autonomously).

Per [maintainer alignment](https://github.com/aegis-boot/aegis-boot/issues/348#issuecomment-4320353920): three flows (quickstart, init 3-distro, QEMU+OVMF rescue-tui), inline-rendered as SVG, placed below the "What it does" section.

## What's in this PR

| File                        | Purpose |
| --------------------------- | ------- |
| `scripts/record-demos.sh`   | Interactive `asciinema rec` driver. `quickstart` / `init` / `qemu-boot` / `all` subcommands. Output → `docs/demos/casts/<n>-<name>.cast`. |
| `scripts/render-demos.sh`   | Renders `.cast` → inline-renderable SVG via `svg-term-cli` (preferred) or `agg` (GIF fallback). |
| `docs/demos/README.md`      | Operator-facing workflow: prereqs, recording, rendering, why inline SVG over asciinema.org. |

## What's deliberately NOT in this PR

The recordings themselves (`docs/demos/01-quickstart.svg`, `02-init.svg`, `03-qemu-boot.svg`) and the corresponding `<img>` tags in `README.md`'s "What it does" section. Two reasons:

1. **Interactive recording can't be autonomous.** asciinema needs a real terminal driving the TUI / CLI flows, plus a built `aegis-boot.img` for the QEMU demo. Faking those with synthesized casts would ship misleading content.
2. **Adding `<img>` tags before the SVGs exist would render as broken images** in README — worse than no-change.

## Follow-up by maintainer (or contributor with dev env)

Three steps, one tiny content PR:

```bash
sudo scripts/record-demos.sh all       # produces 3 .cast files
scripts/render-demos.sh                # produces 3 .svg files
# then commit the SVGs + add 3 <img> tags to README.md
```

`docs/demos/README.md` walks through this end-to-end.

## Why inline SVG over asciinema.org

(documented in `docs/demos/README.md`):

1. Self-contained repo — operators on a no-network preview still see the demos.
2. No external availability dependency.
3. Reproducible rendering — committed SVG is what every reader sees.

Closes #348 *Phase 1*. Issue stays open for the recording follow-up.

## Test plan

- [x] `bash -n scripts/record-demos.sh && bash -n scripts/render-demos.sh` — syntax clean.
- [x] Both scripts marked executable (mode 755) in git.
- [x] `docs/demos/README.md` renders cleanly in markdown preview (links + tables verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)