### PR TITLE
ci: e2e-suite.yml — shared-artifact pattern + qemu-smoke canary (#580 Phase 2a)

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -1,0 +1,184 @@
+name: E2E suite (shared-build)
+
+# #580 Phase 2 — shared-artifact pattern. The standalone E2E workflows
+# (kexec-e2e, ovmf-secboot, direct-install-e2e, mkusb, qemu-smoke,
+# update-rotate-e2e) each rebuild rescue-tui + initramfs.cpio.gz from
+# scratch. This workflow produces those artifacts ONCE in a `build-shared`
+# job and feeds them to consumer jobs via `needs:` + actions/download-artifact.
+#
+# Phase 2a (this commit): canary qemu-smoke job. Existing
+# .github/workflows/qemu-smoke.yml is intentionally LEFT IN PLACE so both
+# pipelines run per PR for ~5 PRs of observation. Once the new path is
+# proven (CPU-min savings real, no flake-rate regression), Phase 2b
+# retires qemu-smoke.yml in a single follow-up PR.
+#
+# Phases 2b–2f migrate one E2E at a time, complexity-ascending:
+# kexec-e2e → mkusb → direct-install-e2e → update-rotate-e2e → ovmf-secboot.
+#
+# RISK NOTE (Architect's condition on consensus_vote 2026-04-25):
+# `build-shared` is a single point of failure for downstream consumers
+# once migration completes. A flaky toolchain install would block the
+# entire E2E suite instead of one workflow. Mitigations:
+#   - retention-days: 1 (consumer-side artifact rot is bounded)
+#   - if `build-shared` fails, downstream jobs skip cleanly via `needs:`
+#   - the standalone workflows stay as a fallback during 2a-2f rollout
+#
+# CANARY EXIT CRITERIA (DevEx + Architect's conditions):
+# Retire the standalone qemu-smoke.yml after EITHER:
+#   - 5 consecutive merged PRs where both pipelines pass with parity, OR
+#   - explicit maintainer go-ahead based on observation.
+# Whichever lands first.
+
+on:
+  push:
+    branches: [main]
+    # Same paths-ignore as kexec-e2e.yml et al — docs-only PRs skip
+    # the whole suite (#580 Phase 1).
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE*'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'LICENSE*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Producer job. Builds the artifacts every consumer needs:
+  # rescue-tui release binary + deterministic initramfs.cpio.gz.
+  # Uses Swatinem/rust-cache to keep cargo registry + git caches
+  # warm across runs (~/.cargo only — NOT target/, to stay well
+  # under the 10 GB GHA cache quota with 6 future consumers).
+  build-shared:
+    name: Build shared artifacts (rescue-tui + initramfs)
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install initramfs build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends busybox-static cpio
+
+      - name: Install Rust toolchain (pinned)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain 1.88.0 --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: rust-cache (registry + git only — see comment)
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # cache-targets: false would skip target/ — but Swatinem
+          # already excludes it by default for non-binary crates.
+          # Including only the workspace members we actually build
+          # in this job keeps the cache tight.
+          workspaces: ". -> target"
+          # Distinguish the cache from per-workflow caches in other
+          # jobs so this job's first build doesn't poison their keys.
+          shared-key: e2e-shared-build
+
+      - name: Build rescue-tui (release)
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+        run: cargo build --release -p rescue-tui
+
+      - name: Build initramfs (out/initramfs.cpio.gz)
+        env:
+          SOURCE_DATE_EPOCH: "1700000000"
+        run: ./scripts/build-initramfs.sh
+
+      - name: Stage shared artifacts
+        run: |
+          # The producer assembles a flat layout for consumers:
+          #   shared/rescue-tui              (release binary)
+          #   shared/initramfs.cpio.gz       (deterministic image)
+          #   shared/initramfs.cpio.gz.sha256 (for integrity check)
+          # Consumers reposition into target/release/ and out/ so
+          # existing scripts/*.sh keep working unchanged.
+          mkdir -p shared
+          cp target/release/rescue-tui                shared/rescue-tui
+          cp out/initramfs.cpio.gz                    shared/initramfs.cpio.gz
+          cp out/initramfs.cpio.gz.sha256             shared/initramfs.cpio.gz.sha256
+          ls -lh shared/
+
+      - name: Upload shared artifacts
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+        with:
+          name: e2e-shared-build
+          path: shared/
+          # Consumers fire in the same workflow run; 1 day is more
+          # than enough headroom + avoids artifact-storage bloat.
+          retention-days: 1
+          if-no-files-found: error
+
+  # First consumer (canary). Mirror of qemu-smoke.yml but with the
+  # build steps replaced by an actions/download-artifact step. If this
+  # passes consistently for ~5 PRs, qemu-smoke.yml is retired in
+  # Phase 2b (single-PR `git rm`).
+  qemu-smoke-shared:
+    name: Boot initramfs under QEMU (shared-build canary)
+    needs: build-shared
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install QEMU + kernel runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 \
+            linux-image-generic \
+            busybox-static \
+            cpio
+          # linux-image-generic installs vmlinuz under /boot, typically
+          # 0644 on GHA runners. Verify readability up front. Same logic
+          # as the standalone qemu-smoke.yml.
+          ls -l /boot/vmlinuz-*-generic | tee /tmp/kernels.txt
+          KERNEL=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null | sort | tail -1)
+          if [ -z "$KERNEL" ] || [ ! -r "$KERNEL" ]; then
+            echo "No readable kernel; attempting chmod"
+            sudo chmod 0644 /boot/vmlinuz-*-generic || true
+            KERNEL=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null | sort | tail -1)
+          fi
+          echo "KERNEL=$KERNEL" >> "$GITHUB_ENV"
+
+      - name: Download shared artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: e2e-shared-build
+          path: shared/
+
+      - name: Reposition artifacts to expected paths
+        run: |
+          # The shared producer staged a flat layout; reposition into
+          # target/release/ + out/ so scripts/qemu-smoke.sh + the rest
+          # of the toolchain see the artifacts at the same paths the
+          # standalone workflows produce inline.
+          mkdir -p target/release out
+          mv shared/rescue-tui                  target/release/rescue-tui
+          mv shared/initramfs.cpio.gz           out/initramfs.cpio.gz
+          mv shared/initramfs.cpio.gz.sha256    out/initramfs.cpio.gz.sha256
+          chmod +x target/release/rescue-tui
+          ls -lh target/release/rescue-tui out/initramfs.cpio.gz
+
+      - name: QEMU smoke boot
+        env:
+          TIMEOUT_SECONDS: "90"
+        run: ./scripts/qemu-smoke.sh


### PR DESCRIPTION
## Summary

Introduces `.github/workflows/e2e-suite.yml` — a new top-level workflow that produces `rescue-tui` release binary + deterministic `initramfs.cpio.gz` **once** in a `build-shared` job, then feeds them to consumer jobs via `needs:` + `actions/download-artifact`.

**Phase 2a (this PR)**: canary `qemu-smoke-shared` job. The existing `.github/workflows/qemu-smoke.yml` is **intentionally left in place** so both pipelines run per PR for ~5 PRs of observation. Once parity is proven (CPU-min savings real, no flake-rate regression), Phase 2b retires `qemu-smoke.yml` in a single-PR `git rm` so revert is atomic.

Refs #580 (Phase 2a only — issue stays open for 2b–2f).

## Design (per 6-agent consensus_vote, higher_order, 5/6 approve)

| Decision | Why |
|---|---|
| Pattern A in phases (single-workflow `needs:`), not Pattern B (`workflow_run` chaining) | `workflow_run` lags PR check-status + has force-push race windows. Bottlerocket / Firecracker / kata-containers all avoid it. |
| Compose with Pattern D (`Swatinem/rust-cache@v2`) inside `build-shared` | Warms `~/.cargo/registry` across runs; default-excludes `target/` so it doesn't blow the 10 GB GHA cache quota with 6 future consumers. |
| Preserve `paths-ignore` | Contrarian rejector's load-bearing critique. New workflow carries identical block to the standalones it will eventually replace. |
| Canary exit criterion documented in workflow comment | "Retire `qemu-smoke.yml` after 5 PRs of green parity OR explicit maintainer go-ahead." Open-ended canary periods are how parallel pipelines drift. |
| Architect's SPOF note in workflow comment | Once migration completes, `build-shared` blocks all downstream E2Es if its toolchain install ever regresses. `retention-days: 1` + `if-no-files-found: error` keep blast radius bounded. |

## Per-PR savings projection

| Phase | Savings vs status quo |
|---|---|
| 2a (this PR) | **~0** — canary runs in parallel with standalone qemu-smoke; sequential `needs:` adds the savings back. |
| 2b (kexec-e2e migrated) | ~30s saved per PR |
| 2c (mkusb migrated) | ~60s saved per PR |
| 2d (direct-install migrated) | ~90s saved per PR |
| 2e (update-rotate migrated) | ~120s saved per PR |
| 2f (ovmf-secboot migrated) | ~150-180s saved per PR (ovmf has 2 jobs) |

Final state: ~2.5–3 CPU-min/PR saved, single-workflow gate replaces 6 standalone workflows, Phase 1 paths-ignore semantics preserved.

## Risk class & rollback

- **Risk class: LOW.** New file added; nothing else modified. `e2e-suite.yml` failing has zero blast radius — the standalone `qemu-smoke.yml` continues to be the authoritative gate during the canary period.
- **Rollback: `git revert`** of this PR removes one new file. Existing workflows unaffected.

## Action SHAs

All pinned per workspace convention. Already-present SHAs reused where possible:

- `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` — v5
- `actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4` — v5
- `actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0` — **v5** (new to this repo; verified via `gh api repos/actions/download-artifact/git/refs/tags/v5`)
- `Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32` — v2

## Test plan

- [x] YAML syntax: `python3 -c "import yaml; yaml.safe_load(...)"` clean.
- [ ] **CI run is the test.** This PR's own CI exercises both the new `e2e-suite.yml` (`build-shared` + `qemu-smoke-shared`) and the existing `qemu-smoke.yml`. Both should pass with comparable wall-clock.
- [ ] Compare `qemu-smoke-shared` vs `qemu-smoke` job runtimes in the GH Actions tab; record observation period in #580.

## Follow-ups (NOT in this PR)

- Phase 2b: retire standalone `qemu-smoke.yml` after canary observation period.
- Phases 2c–2f: migrate remaining 5 E2E workflows to `e2e-suite.yml` (one per PR, same canary pattern).
- Possibly worth filing later: cache the apt-installed `ovmf` package across the 5 SecBoot consumers (~5-10s × 5 = ~30s savings). Marginal — not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)