### PR TITLE
fix(ci): execute_install_scripts on cache-apt for kernel post-install hooks (#617 follow-up)

### DIFF
--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio util-linux diffutils
           version: '1.0'
+          # See mkusb.yml — kernel post-install hooks need to re-run on
+          # cache-restore so /boot/vmlinuz-* + /boot/initrd.img-* are
+          # present for mcopy. (#617 follow-up fix.)
+          execute_install_scripts: true
       - name: Make kernel/initrd readable for mcopy
         run: |
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio
           version: '1.0'
+          # #617 latent regression on cache-hit: kernel-package
+          # post-install hooks (which create /boot/vmlinuz-* and
+          # /boot/initrd.img-*) don't run on cache-restore by default.
+          # `execute_install_scripts: true` re-runs them after the
+          # cached .debs are restored — the documented fix per
+          # awalsh128/cache-apt-pkgs-action's README.
+          execute_install_scripts: true
       - name: Make kernel/initrd readable for mcopy
         run: |
           # Kernels mode 0600; we need them readable for mcopy.

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-generic mtools dosfstools exfatprogs gdisk busybox-static cpio
           version: '1.0'
+          # See mkusb.yml — kernel post-install hooks need to re-run on
+          # cache-restore so /boot/vmlinuz-*-generic +
+          # /boot/initrd.img-*-generic are present for mcopy.
+          # (#617 follow-up fix.)
+          execute_install_scripts: true
       - name: Make kernel/initrd readable for mcopy
         run: |
           # Kernels under /boot are typically 0600; SB E2E needs them readable.

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio util-linux
           version: '1.0'
+          # See mkusb.yml — kernel post-install hooks need to re-run on
+          # cache-restore so /boot/vmlinuz-* + /boot/initrd.img-* are
+          # present for mcopy. (#617 follow-up fix.)
+          execute_install_scripts: true
       - name: Make kernel/initrd readable for mcopy
         run: |
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true


### PR DESCRIPTION
## Summary

Hotfix for a latent regression introduced in PR #617 (cache-apt-pkgs migration). The bug only manifests on **cache-hit** runs, so #617's own CI didn't catch it — the cache was empty on that run. PR #619 (aegis-core PoC) was the first PR to see the populated cache and tripped over it on 4 E2E workflows.

## Root cause

`awalsh128/cache-apt-pkgs-action` skips post-install scripts on cache-restore by default. Kernel packages (`linux-image-virtual`, `linux-image-generic`) create `/boot/vmlinuz-*` and `/boot/initrd.img-*` via post-install hooks, NOT via files in the .deb. On cache-hit those hooks don't run; `mcopy` then fails with `no readable signed kernel found; set KERNEL_SRC=/path/to/vmlinuz`.

## Fix

Pass `execute_install_scripts: true` per the action's documented option for exactly this case. .deb files still come from the cache (preserves the savings); only post-install hooks re-run.

Touched 4 workflows (all 4 PR-time SecBoot E2Es affected):

| Workflow | Cache scope | Was broken? |
|---|---|---|
| `mkusb.yml` | full chain + linux-image-virtual | yes |
| `direct-install-e2e.yml` | full + util-linux + diffutils | yes |
| `update-rotate-e2e.yml` | full + util-linux | yes |
| `ovmf-secboot.yml` (full-chain job) | linux-image-generic | yes |
| `ovmf-secboot.yml` (foundation job) | qemu+ovmf only, no kernel | NOT affected |

## Why #617's CI didn't catch this

CI ran on `feat/615-cache-apt-pkgs-secboot-e2es` with an empty cache → action did a full `apt-get install` including post-install hooks → kernel files landed correctly. The cache populated **after** #617 merged. Subsequent PRs (the first being #619) saw the cache-hit path and hit the gap.

The canary-watcher routine for #580 would have caught this after 5+ PRs of observation, but that's specifically observing `qemu-smoke.yml` which doesn't need a kernel from `/boot/`. The kernel-needing E2Es weren't in the watcher's scope.

## Lesson for future cache changes

Cycle the cache on the introducing PR (push, run CI, push a no-op, run CI again) so cache-hit semantics are exercised before merge. Filing a follow-up to add this to CONTRIBUTING.md as a checklist item.

## Test plan

- [x] All 4 workflows YAML-parse clean.
- [x] `execute_install_scripts: true` placed under `with:` per the action's input schema (verified against awalsh128/cache-apt-pkgs-action README + action.yml at v1.6.0).
- [ ] **CI run is the test.** This PR's branch was created off `main` after #617 — the cache populated by #617 still hits on this PR. If the fix works, all 4 E2Es should pass; if it doesn't, the same `no readable signed kernel` error will surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)