### PR TITLE
Revert "ci: cache apt-installed signed-chain packages across 5 SecBoot E2Es (#617)"

### DIFF
--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -32,18 +32,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      # #615: cache the apt-installed signed boot chain + image tooling.
-      # Matches mkusb.yml's deps so the byte-parity diff has identical
-      # source files for both paths. Adds util-linux for losetup +
-      # diffutils for the parity diff (both already in ubuntu-22.04
-      # base, listed for clarity). First run ~5-15s; cached <2s.
       - name: Install signed boot chain + image tooling
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
-        with:
-          packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio util-linux diffutils
-          version: '1.0'
-      - name: Make kernel/initrd readable for mcopy
+        # Matches mkusb.yml's deps so the byte-parity diff has identical
+        # source files for both paths. Adds util-linux for losetup +
+        # diffutils for the parity diff (both already in ubuntu-22.04
+        # base, listed for clarity).
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools exfatprogs gdisk \
+            busybox-static cpio \
+            util-linux diffutils
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
           ls -l /boot/vmlinuz-* /boot/initrd.img-*
 

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -27,17 +27,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      # #615: cache the apt-installed signed boot chain + image tooling.
-      # First run populates the cache (~5-15s); subsequent runs hit it
-      # and complete in <2s. Cache key auto-derived from the packages
-      # list, so version drift invalidates correctly.
       - name: Install signed boot chain + image tooling
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
-        with:
-          packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio
-          version: '1.0'
-      - name: Make kernel/initrd readable for mcopy
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools exfatprogs gdisk \
+            busybox-static cpio
           # Kernels mode 0600; we need them readable for mcopy.
           # linux-image-virtual is a meta-package that pulls -generic on
           # modern Ubuntu; chmod all vmlinuz+initrd files conservatively.

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -25,16 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      # #615: cache the apt-installed QEMU + OVMF (foundation smoke
-      # only — minimal package set; full signed chain lives in the
-      # second job below).
       - name: Install QEMU + OVMF (with MS-enrolled vars)
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
-        with:
-          packages: qemu-system-x86 ovmf
-          version: '1.0'
-      - name: Verify OVMF SecBoot artifacts present
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf
           ls -l /usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
                 /usr/share/OVMF/OVMF_VARS_4M.ms.fd
 
@@ -52,17 +47,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      # #615: cache the apt-installed signed boot chain + tooling. Note
-      # this job uses linux-image-generic (vs -virtual elsewhere) — the
-      # full SB E2E needs the same kernel-image variant the rescue-tui
-      # eventually loads, not the lighter virtual one.
       - name: Install signed boot chain + tooling
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
-        with:
-          packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-generic mtools dosfstools exfatprogs gdisk busybox-static cpio
-          version: '1.0'
-      - name: Make kernel/initrd readable for mcopy
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-generic \
+            mtools dosfstools exfatprogs gdisk \
+            busybox-static cpio
           # Kernels under /boot are typically 0600; SB E2E needs them readable.
           sudo chmod 0644 /boot/vmlinuz-*-generic /boot/initrd.img-*-generic || true
 

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -33,17 +33,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      # #615: replace the manual apt install with awalsh128/cache-apt-pkgs.
-      # First run populates the cache (~5-15s); subsequent runs hit the
-      # cache and complete in <2s. Cache key auto-derived from the
-      # packages list, so any drift here invalidates correctly.
       - name: Install deps (QEMU + OVMF + signed boot chain + tooling)
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
-        with:
-          packages: qemu-system-x86 ovmf shim-signed grub-efi-amd64-signed linux-image-virtual mtools dosfstools exfatprogs gdisk busybox-static cpio util-linux
-          version: '1.0'
-      - name: Make kernel/initrd readable for mcopy
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools exfatprogs gdisk \
+            busybox-static cpio \
+            util-linux
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
 
       - name: Install Rust toolchain (pinned)


### PR DESCRIPTION
## Summary

Revert PR #617 (commit `78fd590a`). The cache-apt migration introduced a regression that surfaces only on cache-hit runs: kernel-package post-install hooks create `/boot/vmlinuz-*` and `/boot/initrd.img-*`, but `awalsh128/cache-apt-pkgs-action` doesn't include `/boot/` paths in its cache. On cache-hit, the kernel files never reappear in `/boot/`.

## Confirmed via attempted hotfix #620

- Cache hit confirmed in #620's mkusb run log (`Cache hit for: cache-apt-pkgs_3849f63e526b741788c7b7db84a378a7`)
- `execute_install_scripts: true` set per the action's README
- **Same `no readable signed kernel found` failure**

The action's `execute_install_scripts` flag re-runs post-install scripts, but the scripts have nothing to operate on — the .deb's tracked file list excludes `/boot/`, so the cache simply doesn't contain those files.

## Impact

- **4 PR-time SecBoot E2Es broken on cache-hit** (mkusb, direct-install, update-rotate, ovmf-secboot)
- **PR #619 (aegis-core PoC) blocked** — tripping on the same 4 E2Es
- The blast radius covers every PR until this lands

## Decision

Revert is the disciplined call:
- The original savings goal (~25-75s/PR) is not worth blocking critical E2E coverage
- A more careful approach is possible (split the cache: userspace-only via the action, kernel via plain `apt-get install`) — but that's a follow-up PR, not a blocker
- Reverting restores main to a known-good state in one click

## What this revert does

| File | Reverted to |
|---|---|
| `.github/workflows/ovmf-secboot.yml` | manual `apt-get install` (2 jobs) |
| `.github/workflows/direct-install-e2e.yml` | manual `apt-get install` |
| `.github/workflows/mkusb.yml` | manual `apt-get install` |
| `.github/workflows/update-rotate-e2e.yml` | manual `apt-get install` |

Each gives back the ~5-15s/run for fresh apt fetch, but kernel files reliably land in `/boot/`.

## Follow-up tracking

- **#615 reopened** — track the future, more-careful cache approach.
- **Lesson for the next attempt** (filed as a comment on #615): cache-introducing PRs MUST cycle the cache before merge. Push → CI run (cache miss) → no-op push → CI run again (cache hit). First run validates the populate path; second run validates the restore path. PR #617's CI only exercised the cache-miss path, which is why the cache-hit regression didn't surface until subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)