### PR TITLE
chore(ci): replace explicit `rustup toolchain install 1.95.0` with `rustup show`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust
+      - name: Install Rust toolchain (from rust-toolchain.toml) + cross targets
         run: |
-          rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
-          rustup override set 1.95.0
+          rustup show
           rustup target add x86_64-apple-darwin
           rustup target add x86_64-pc-windows-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -75,10 +74,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust
-        run: |
-          rustup toolchain install 1.95.0 --profile minimal --component rustfmt,clippy
-          rustup override set 1.95.0
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Format + lint rescue-tui
         run: |
@@ -105,11 +102,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal --component rustfmt,clippy
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Format + lint aegis-cli on native macOS
         run: |
@@ -159,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Run fitness audit (threshold 80)
         # Stage 8 of dev-test.sh — repo + scripts + docs hygiene.
@@ -188,7 +182,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --locked --version 0.5.7
       - name: Generate SBOM
@@ -275,7 +269,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p aegis-bootctl --bin constants-docgen --features docgen --locked -- --check
 
@@ -290,7 +284,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p aegis-bootctl --bin trust-anchors-docgen --features docgen --locked -- --check
 
@@ -308,7 +302,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Build aegis-boot binary
         run: cargo build -p aegis-bootctl --release --locked
@@ -328,7 +322,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p aegis-wire-formats --features schema --bin aegis-wire-formats-schema-docgen --locked -- --check
 
@@ -345,6 +339,6 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo run -p rescue-tui --bin tiers-docgen --locked -- --check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,8 +67,7 @@ jobs:
       # same tree the release binary is built from.
       - name: Install Rust
         if: matrix.language == 'rust'
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
-
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         if: matrix.language == 'rust'
 

--- a/.github/workflows/crates-publish-dryrun.yml
+++ b/.github/workflows/crates-publish-dryrun.yml
@@ -36,11 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust (pinned to workspace MSRV)
-        run: |
-          rustup toolchain install 1.95.0 --profile minimal
-          rustup override set 1.95.0
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: cargo publish --dry-run -p iso-parser
         # Zero unpublished path deps → registry resolution succeeds

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -70,10 +70,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust toolchain (pinned)
-        run: |
-          rustup toolchain install 1.95.0 --profile minimal --no-self-update
-          rustup default 1.95.0
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
           rustc --version
 
       - name: Mint short-lived crates.io token (OIDC)

--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -48,12 +48,8 @@ jobs:
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
           ls -l /boot/vmlinuz-* /boot/initrd.img-*
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build aegis-boot CLI + rescue-tui
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -72,12 +72,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends busybox-static cpio
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: rust-cache (registry + git only — see comment)
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:

--- a/.github/workflows/initramfs.yml
+++ b/.github/workflows/initramfs.yml
@@ -22,12 +22,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends busybox-static cpio
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui (release)
         run: cargo build --release -p rescue-tui
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,12 +23,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xorriso
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Check loop devices are available
         run: |
           # On GHA runners the loop driver is built into the kernel, so

--- a/.github/workflows/kexec-e2e.yml
+++ b/.github/workflows/kexec-e2e.yml
@@ -52,12 +52,8 @@ jobs:
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
           ls -l /boot/vmlinuz-* /boot/initrd.img-*
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui (release)
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Install Rust
-        run: rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0
+        run: rustup show
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       # Pinned version = what we tested locally (0.9.2). Bump via
       # Dependabot when upstream ships a new release. Install via

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -41,12 +41,8 @@ jobs:
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
           ls -l /boot/vmlinuz-* /boot/initrd.img-*
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -58,12 +58,8 @@ jobs:
           # Kernels under /boot are typically 0600; SB E2E needs them readable.
           sudo chmod 0644 /boot/vmlinuz-*-generic /boot/initrd.img-*-generic || true
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui (release)
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/qemu-smoke.yml
+++ b/.github/workflows/qemu-smoke.yml
@@ -40,12 +40,8 @@ jobs:
           fi
           echo "KERNEL=$KERNEL" >> "$GITHUB_ENV"
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui (release)
         run: cargo build --release -p rescue-tui
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,10 @@ jobs:
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
           ls -l /boot/vmlinuz-* /boot/initrd.img-*
 
-      - name: Install Rust toolchain (pinned) + musl target
+      - name: Install Rust toolchain (from rust-toolchain.toml) + musl target
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          "$HOME/.cargo/bin/rustup" target add x86_64-unknown-linux-musl
+          rustup show
+          rustup target add x86_64-unknown-linux-musl
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
@@ -373,15 +371,13 @@ jobs:
             echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install Rust toolchain (pinned)
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        # macos-14 runners are arm64-native, so aarch64-apple-darwin
+        # is installed by the rustup bootstrap above. No `rustup target
+        # add` needed — verify the host matches our release target.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          # macos-14 runners are arm64-native, so aarch64-apple-darwin
-          # is installed by the rustup bootstrap above. No `rustup target
-          # add` needed — verify the host matches our release target.
-          "$HOME/.cargo/bin/rustc" -vV | grep '^host: aarch64-apple-darwin$'
+          rustup show
+          rustc -vV | grep '^host: aarch64-apple-darwin$'
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3

--- a/.github/workflows/tui-screenshots.yml
+++ b/.github/workflows/tui-screenshots.yml
@@ -39,12 +39,8 @@ jobs:
             imagemagick python3
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build rescue-tui
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -44,12 +44,8 @@ jobs:
             util-linux
           sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
 
-      - name: Install Rust toolchain (pinned)
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain 1.95.0 --profile minimal
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        run: rustup show
       - name: Build aegis-bootctl + rescue-tui
         env:
           SOURCE_DATE_EPOCH: "1700000000"

--- a/.github/workflows/windows-cargo-check.yml
+++ b/.github/workflows/windows-cargo-check.yml
@@ -78,12 +78,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - name: Install Rust (MSRV pinned — matches Linux CI)
-        # Match the exact MSRV the rest of CI pins to so a Windows
-        # pass here means Linux will agree on the toolchain surface.
-        run: |
-          rustup toolchain install 1.95.0 --profile minimal --component clippy
-          rustup default 1.95.0
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        # Toolchain version + components come from rust-toolchain.toml
+        # so Windows agrees with Linux on the toolchain surface
+        # without duplicating the version pin here.
+        run: rustup show
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:


### PR DESCRIPTION
## Summary

After PR #637 added `rust-toolchain.toml` at the repo root, every explicit `rustup toolchain install 1.95.0 --profile minimal && rustup override set 1.95.0` line in CI is redundant. Modern rustup (1.27+, which all GHA runners ship) auto-installs the toml-pinned toolchain on the first cargo/rustup invocation in the repo dir.

## Changes

Replaces the install boilerplate across 17 workflow files with a single `rustup show`, which:

- Reads `rust-toolchain.toml`
- Auto-installs the pinned channel (1.95.0) + components (rustfmt, clippy)
- Sets the per-directory override automatically
- Prints version info for diagnostics

**Net:** 110 lines removed, 53 added (-57). Future Rust version bumps now edit ONE file (`rust-toolchain.toml`) instead of 16 workflows.

## Untouched (intentional)

- `ci.yml`'s `matrix.rust` row (matrix testing needs explicit toolchain control)
- `miri.yml` + `fuzz.yml` (use `nightly`, not 1.95)

## Special cases

For workflows that need extra targets/components on top of the toml's defaults:

- `release.yml` — `rustup show && rustup target add x86_64-unknown-linux-musl`
- `ci.yml` (Linux+macOS+Windows cross-check) — `rustup show && rustup target add x86_64-apple-darwin x86_64-pc-windows-gnu`

## Test plan

- [x] All workflow YAMLs parse cleanly (`python3 -c "import yaml; yaml.safe_load(open(f))"`)
- [ ] Full CI run validates `rustup show` works on each runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)