### PR TITLE
feat(catalog): per-distro URL resolvers + `--refresh` verb (#646 phase 1)

### DIFF
--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -81,6 +81,19 @@ pub struct Entry {
     pub sb: SbStatus,
     /// One-line reason an operator might want this image.
     pub purpose: &'static str,
+    /// Optional URL resolver that walks the project's directory
+    /// listing or follows a "latest" redirect to discover the current
+    /// ISO filename + sibling SHA / sig URLs (#646). Used by
+    /// `aegis-boot recommend --refresh` to detect when the static
+    /// fields here are out of date. The static fields stay
+    /// authoritative for fast-path use; the resolver is opt-in
+    /// freshness check.
+    pub resolver: Option<
+        fn() -> Result<
+            crate::catalog_resolvers::ResolvedUrls,
+            crate::catalog_resolvers::ResolverError,
+        >,
+    >,
 }
 
 /// The catalog itself. Keep entries alphabetically sorted by slug.
@@ -111,6 +124,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://repo.almalinux.org/almalinux/9/isos/x86_64/CHECKSUM",
         sb: SbStatus::Signed("Red Hat / AlmaLinux"),
         purpose: "Free RHEL-rebuild minimal installer. Cross-distro kexec quirk possible.",
+        resolver: None,
     },
     Entry {
         slug: "alpine-3.20-standard",
@@ -122,6 +136,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-standard-3.20.3-x86_64.iso.asc",
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Minimal recovery / forensic shell. Tiny footprint.",
+        resolver: None,
     },
     Entry {
         // DistroWatch top-12-month rank #4 (April 2026).
@@ -137,6 +152,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA512SUMS.sign",
         sb: SbStatus::Signed("Debian CA via shim"),
         purpose: "Minimal Debian network installer. DistroWatch top-5 popularity.",
+        resolver: Some(crate::catalog_resolvers::debian_netinst),
     },
     Entry {
         // DistroWatch top-12-month rank #9 (April 2026).
@@ -152,6 +168,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Workstation/x86_64/iso/Fedora-Workstation-43-1.6-x86_64-CHECKSUM",
         sb: SbStatus::Signed("Red Hat / Fedora"),
         purpose: "Fedora desktop live ISO. Cross-distro kexec quirk possible.",
+        resolver: None,
     },
     Entry {
         // Not on DistroWatch top-15 but the de-facto pentest distro
@@ -165,6 +182,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://cdimage.kali.org/kali-2026.1/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Kali / Debian shim chain"),
         purpose: "Pentesting + forensics installer. Debian-derived signed chain.",
+        resolver: None,
     },
     Entry {
         slug: "linuxmint-22-cinnamon",
@@ -176,6 +194,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22/sha256sum.txt.gpg",
         sb: SbStatus::Signed("Linux Mint"),
         purpose: "Friendly Ubuntu-derived desktop. Common operator install target.",
+        resolver: None,
     },
     Entry {
         // DistroWatch top-12-month rank #8 (April 2026). Manjaro
@@ -190,6 +209,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://download.manjaro.org/kde/26.0.4/manjaro-kde-26.0.4-260327-linux618.iso.sig",
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Arch-derived rolling release with KDE Plasma. Unsigned kernel.",
+        resolver: None,
     },
     Entry {
         // DistroWatch top-12-month rank #3 (April 2026).
@@ -202,6 +222,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://downloads.sourceforge.net/project/mx-linux/Final/Xfce/MX-25.1_Xfce_ahs_x64.iso.sig",
         sb: SbStatus::Signed("Debian shim chain (MX kernel)"),
         purpose: "Debian-based Xfce desktop with newer kernel. Top-3 popularity.",
+        resolver: None,
     },
     Entry {
         // DistroWatch top-12-month rank #12 (April 2026).
@@ -214,6 +235,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://download.opensuse.org/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-x86_64-Media.iso.sha256.asc",
         sb: SbStatus::Signed("SUSE CA"),
         purpose: "Enterprise-derived stable distribution. Full DVD installer.",
+        resolver: None,
     },
     Entry {
         // DistroWatch top-12-month rank #5 (April 2026). Build
@@ -228,6 +250,12 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://iso.pop-os.org/24.04/amd64/intel/9/SHA256SUMS.gpg",
         sb: SbStatus::Signed("System76 / Canonical CA"),
         purpose: "Ubuntu-derived desktop tuned for System76 hardware.",
+        // No resolver yet: iso.pop-os.org returns HTTP 403 on
+        // directory listings (nginx autoindex off). The published
+        // build number lives in the JSON payload at /api/v1 instead.
+        // Tracked under #646 as a follow-up resolver to add once the
+        // Debian one (this PR's MVP) ships.
+        resolver: None,
     },
     Entry {
         slug: "rocky-9-minimal",
@@ -241,6 +269,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/CHECKSUM",
         sb: SbStatus::Signed("Rocky Linux"),
         purpose: "Free RHEL-rebuild minimal installer. Cross-distro kexec quirk possible.",
+        resolver: None,
     },
     Entry {
         slug: "ubuntu-24.04-live-server",
@@ -252,6 +281,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS server installer. Validated under aegis-boot v0.12.0 #109.",
+        resolver: None,
     },
     Entry {
         slug: "ubuntu-24.04-desktop",
@@ -263,6 +293,7 @@ pub const CATALOG: &[Entry] = &[
         sig_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS desktop installer. >4 GB → requires ext4 data partition.",
+        resolver: None,
     },
 ];
 
@@ -286,6 +317,14 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    // --refresh (#646): walk every Entry that has a resolver attached
+    // and print a diff against the static URL. Doesn't mutate the
+    // catalog file — the operator (or a CI auto-PR) decides whether
+    // the resolver-discovered URL replaces the static fallback.
+    if args.first().map(String::as_str) == Some("--refresh") {
+        return run_refresh();
+    }
+
     // --json [slug]: structured full-catalog output (or single-entry
     // when a slug follows the flag). Complements --slugs-only (line-
     // per-slug) with the full field set — each entry's URLs, size,
@@ -307,6 +346,69 @@ pub fn run(args: &[String]) -> ExitCode {
         eprintln!("aegis-boot recommend: no catalog entry matching '{slug}'");
         eprintln!("run 'aegis-boot recommend' to see available slugs");
         ExitCode::from(1)
+    }
+}
+
+/// `aegis-boot recommend --refresh` — walk every Entry that has a
+/// resolver, call it, and print a diff against the static URL. Does
+/// NOT mutate the catalog file: the operator (or a CI auto-PR
+/// workflow per #646) decides whether to promote the resolver-
+/// discovered URL.
+///
+/// Exit codes:
+///   0 — no drift (or no resolvers configured)
+///   1 — at least one resolver returned a URL different from static
+///   2 — at least one resolver errored (network / parse)
+///
+/// Network is best-effort. A resolver failure is reported but
+/// doesn't poison the rest of the run; we want operators to see
+/// "Pop!_OS resolver failed; Debian + Manjaro drifted" not just
+/// "first one failed, stopped."
+fn run_refresh() -> ExitCode {
+    let mut any_drift = false;
+    let mut any_error = false;
+    println!("aegis-boot recommend --refresh — checking resolvers (#646)\n");
+    for entry in CATALOG {
+        let Some(resolver) = entry.resolver else {
+            continue;
+        };
+        match resolver() {
+            Ok(live) => {
+                let drifted = live.iso_url != entry.iso_url
+                    || live.sha256_url != entry.sha256_url
+                    || live.sig_url != entry.sig_url;
+                if drifted {
+                    any_drift = true;
+                    println!("[DRIFT] {}", entry.slug);
+                    if live.iso_url != entry.iso_url {
+                        println!("    iso     static: {}", entry.iso_url);
+                        println!("            current: {}", live.iso_url);
+                    }
+                    if live.sha256_url != entry.sha256_url {
+                        println!("    sha     static: {}", entry.sha256_url);
+                        println!("            current: {}", live.sha256_url);
+                    }
+                    if live.sig_url != entry.sig_url {
+                        println!("    sig     static: {}", entry.sig_url);
+                        println!("            current: {}", live.sig_url);
+                    }
+                } else {
+                    println!("[OK]    {} (matches static)", entry.slug);
+                }
+            }
+            Err(e) => {
+                any_error = true;
+                println!("[ERROR] {}: {}", entry.slug, e);
+            }
+        }
+    }
+    println!();
+    if any_error {
+        ExitCode::from(2)
+    } else if any_drift {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
     }
 }
 

--- a/crates/aegis-cli/src/catalog_resolvers.rs
+++ b/crates/aegis-cli/src/catalog_resolvers.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-distro URL resolvers for the [`crate::catalog`] (#646).
+//!
+//! Static catalog entries embed a specific point release in their
+//! filenames (`debian-13.4.0-amd64-netinst.iso`,
+//! `pop-os_24.04_amd64_intel_9.iso`). Every release bump means a
+//! manual catalog edit. The resolver framework discovers the current
+//! filename programmatically by walking each project's directory
+//! listing or following its "latest" redirect.
+//!
+//! ## Trust model
+//!
+//! Resolvers do NOT verify ISO contents — they only update the URL
+//! we tell operators to download from. The signed SHA256SUMS still
+//! anchors trust at fetch time; if a resolver returns a malicious
+//! URL, the GPG signature on SHA256SUMS at that URL won't validate
+//! against the project's known public key. So resolver compromise
+//! is detectable via the existing trust chain.
+//!
+//! ## Why curl, not reqwest?
+//!
+//! Matches `crates/aegis-cli/src/fetch.rs`'s convention. Keeps the
+//! static-musl release binary small (no Rust HTTP stack).
+
+use std::process::Command;
+
+/// Result of a successful URL resolution. Mirrors the static
+/// catalog-entry fields — when present, callers prefer these over
+/// the [`crate::catalog::Entry`]'s static defaults.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::struct_field_names)] // mirrors Entry's *_url field names
+pub struct ResolvedUrls {
+    pub iso_url: String,
+    pub sha256_url: String,
+    pub sig_url: String,
+}
+
+/// Errors a resolver can raise.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolverError {
+    #[error("network: failed to fetch {url}: {detail}")]
+    Network { url: String, detail: String },
+    #[error("parse: no matching ISO filename in listing at {url}")]
+    NoMatch { url: String },
+    #[error("parse: response from {url} was not valid utf-8")]
+    NotUtf8 { url: String },
+}
+
+/// Run `curl -fsSL <url>` and return the response body. Used by
+/// resolvers that need to scrape a directory listing for the
+/// current ISO filename.
+fn http_get(url: &str) -> Result<String, ResolverError> {
+    let out = Command::new("curl")
+        .args(["-fsSL", "--max-time", "30", url])
+        .output()
+        .map_err(|e| ResolverError::Network {
+            url: url.to_string(),
+            detail: format!("spawn: {e}"),
+        })?;
+    if !out.status.success() {
+        return Err(ResolverError::Network {
+            url: url.to_string(),
+            detail: format!(
+                "curl exit {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        });
+    }
+    String::from_utf8(out.stdout).map_err(|_| ResolverError::NotUtf8 {
+        url: url.to_string(),
+    })
+}
+
+/// Debian — list `cdimage.debian.org/debian-cd/current/amd64/iso-cd/`
+/// and find the highest `debian-X.Y.Z-amd64-netinst.iso` filename.
+/// SHA512SUMS / SHA512SUMS.sign live in the same directory.
+pub fn debian_netinst() -> Result<ResolvedUrls, ResolverError> {
+    const BASE: &str = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/";
+    let html = http_get(BASE)?;
+    resolve_debian_netinst_from_html(&html, BASE)
+}
+
+fn resolve_debian_netinst_from_html(html: &str, base: &str) -> Result<ResolvedUrls, ResolverError> {
+    // Extract `debian-X.Y.Z-amd64-netinst.iso` filenames from the
+    // directory listing. Prefer the highest version.
+    let re = simple_regex_match_all(html, r"debian-", "-amd64-netinst.iso");
+    let mut versions: Vec<String> = re
+        .into_iter()
+        // s is the inner version segment like "13.4.0"; reassemble
+        // into the full filename for sort + use.
+        .map(|s| format!("debian-{s}-amd64-netinst.iso"))
+        .collect();
+    versions.sort();
+    versions.dedup();
+    let latest = versions.last().ok_or(ResolverError::NoMatch {
+        url: base.to_string(),
+    })?;
+    Ok(ResolvedUrls {
+        iso_url: format!("{base}{latest}"),
+        sha256_url: format!("{base}SHA512SUMS"),
+        sig_url: format!("{base}SHA512SUMS.sign"),
+    })
+}
+
+/// Pull "X.Y.Z" version segments from `<a href="debian-X.Y.Z-..."`
+/// patterns. Conservative — operates on raw HTML without a real
+/// parser — but the directory listings we care about are simple
+/// auto-generated index pages where this works.
+///
+/// Returns the inner segments (without the prefix/suffix).
+fn simple_regex_match_all(haystack: &str, prefix: &str, suffix: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut pos = 0;
+    while let Some(start) = haystack[pos..].find(prefix) {
+        let after_prefix = pos + start + prefix.len();
+        if let Some(end_off) = haystack[after_prefix..].find(suffix) {
+            let inner = &haystack[after_prefix..after_prefix + end_off];
+            // Validate it looks like a version: digits + dots only.
+            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit() || c == '.') {
+                out.push(inner.to_string());
+            }
+            pos = after_prefix + end_off + suffix.len();
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+/// Pull the highest integer-named subdirectory from an HTML
+/// directory listing. Reserved for resolvers whose layout uses
+/// integer build numbers (e.g. Pop!_OS, once their server returns
+/// HTML listings instead of HTTP 403).
+#[allow(dead_code)] // wired in when the next resolver lands (#646)
+fn parse_highest_numeric_subdir(html: &str) -> Option<u32> {
+    // Find all `href="N/"` references where N is an integer.
+    let mut max_n: Option<u32> = None;
+    let mut pos = 0;
+    while let Some(start) = html[pos..].find("href=\"") {
+        let after = pos + start + "href=\"".len();
+        if let Some(end_off) = html[after..].find('"') {
+            let candidate = &html[after..after + end_off];
+            if let Some(stripped) = candidate.strip_suffix('/')
+                && let Ok(n) = stripped.parse::<u32>()
+            {
+                max_n = Some(max_n.map_or(n, |m| m.max(n)));
+            }
+            pos = after + end_off + 1;
+        } else {
+            break;
+        }
+    }
+    max_n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debian_resolver_picks_highest_version_from_listing() {
+        // Realistic snippet of cdimage.debian.org's directory index.
+        let html = r#"<html><body>
+            <a href="debian-13.3.0-amd64-netinst.iso">debian-13.3.0-amd64-netinst.iso</a>
+            <a href="debian-13.4.0-amd64-netinst.iso">debian-13.4.0-amd64-netinst.iso</a>
+            <a href="debian-13.4.0-amd64-netinst.iso.torrent">…</a>
+        </body></html>"#;
+        let r = resolve_debian_netinst_from_html(html, "https://example.test/dir/")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert_eq!(
+            r.iso_url,
+            "https://example.test/dir/debian-13.4.0-amd64-netinst.iso"
+        );
+        assert_eq!(r.sha256_url, "https://example.test/dir/SHA512SUMS");
+        assert_eq!(r.sig_url, "https://example.test/dir/SHA512SUMS.sign");
+    }
+
+    #[test]
+    fn debian_resolver_errors_on_empty_listing() {
+        let html = "<html><body>nothing here</body></html>";
+        let err = resolve_debian_netinst_from_html(html, "https://example.test/")
+            .err()
+            .unwrap_or_else(|| panic!("should fail"));
+        assert!(matches!(err, ResolverError::NoMatch { .. }));
+    }
+
+    #[test]
+    fn popos_subdir_parser_picks_highest_build() {
+        let html = r#"<html><body>
+            <a href="7/">7/</a>
+            <a href="8/">8/</a>
+            <a href="9/">9/</a>
+            <a href="../">…</a>
+        </body></html>"#;
+        assert_eq!(parse_highest_numeric_subdir(html), Some(9));
+    }
+
+    #[test]
+    fn popos_subdir_parser_returns_none_when_no_build_dirs() {
+        let html = r#"<html><body><a href="../">…</a></body></html>"#;
+        assert_eq!(parse_highest_numeric_subdir(html), None);
+    }
+
+    #[test]
+    fn simple_regex_extracts_version_segments() {
+        let s = "<a>debian-12.0.0-foo</a> <a>debian-12.5.0-foo</a> <a>debian-bad-foo</a>";
+        let v = simple_regex_match_all(s, "debian-", "-foo");
+        assert_eq!(v, vec!["12.0.0", "12.5.0"]);
+    }
+}

--- a/crates/aegis-cli/src/main.rs
+++ b/crates/aegis-cli/src/main.rs
@@ -39,6 +39,7 @@ mod bundle_cache;
 mod bundle_fetch;
 mod bundle_verify;
 mod catalog;
+mod catalog_resolvers;
 mod cmd_path;
 mod compat;
 mod completions;


### PR DESCRIPTION
## Summary

The catalog hardcodes specific point releases in URLs (`debian-13.4.0-amd64-netinst.iso`, etc.). Every distro release means a manual catalog edit. This PR adds a small resolver framework so resolvers can discover the current ISO filename programmatically.

## Phase 1 scope

- New `crates/aegis-cli/src/catalog_resolvers.rs` module with `ResolvedUrls`, `ResolverError`, an HTTP client wrapping `curl` (matches `fetch.rs` convention; keeps static-musl release binary small).
- First concrete resolver: `debian_netinst()`. Walks `cdimage.debian.org/debian-cd/current/amd64/iso-cd/`, parses the HTML directory listing for `debian-X.Y.Z-amd64-netinst.iso`, returns the highest-version URL.
- `Entry` struct gains optional `resolver: Option<fn() -> Result<...>>`. Static URL fields stay the authoritative fast-path; resolver is opt-in freshness check.
- New CLI verb: `aegis-boot recommend --refresh`. Walks all entries with resolvers, calls each, prints diff.

## Live test

```
$ aegis-boot recommend --refresh
aegis-boot recommend --refresh — checking resolvers (#646)

[OK]    debian-13-netinst (matches static)
```

## Exit codes

- `0` no drift / no resolvers configured
- `1` at least one resolver returned a drifted URL  
- `2` at least one resolver errored (network / parse)

Best-effort: an erroring resolver doesn't poison the rest of the run.

## Deferred to follow-up phases under #646

- More resolvers (Fedora redirect, Ubuntu point release, Manjaro/MX/openSUSE listings; Pop!_OS via JSON-API since their nginx returns HTTP 403 on directory listings)
- `--refresh --write` to mutate catalog source file
- Weekly auto-refresh GitHub Actions workflow that opens auto-PRs on drift

## Test plan

- [x] 5 unit tests covering Debian listing parser, NoMatch error path, regex helper, numeric-subdir helper. All offline against canned HTML.
- [x] 778 aegis-bootctl tests pass under rustc 1.95
- [x] `cargo clippy -p aegis-bootctl --all-targets -- -D warnings` clean
- [x] Live `--refresh` against current Debian mirror returns OK

Phase 1 of #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)