### PR TITLE
feat(catalog): Ubuntu + Kali resolvers + bump catalog to current point releases (#646 phase 2)

### DIFF
--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -177,12 +177,16 @@ pub const CATALOG: &[Entry] = &[
         name: "Kali Linux 2026.1 (installer)",
         arch: "x86_64",
         size_mib: 4500,
-        iso_url: "https://cdimage.kali.org/kali-2026.1/kali-linux-2026.1-installer-amd64.iso",
-        sha256_url: "https://cdimage.kali.org/kali-2026.1/SHA256SUMS",
-        sig_url: "https://cdimage.kali.org/kali-2026.1/SHA256SUMS.gpg",
+        // Kali publishes a `/current/` symlink that always points at
+        // the latest release; the kali_installer resolver
+        // canonicalizes to that path. Filename still encodes the
+        // version so #646 phase 2 can detect when 2026.1 → 2026.2.
+        iso_url: "https://cdimage.kali.org/current/kali-linux-2026.1-installer-amd64.iso",
+        sha256_url: "https://cdimage.kali.org/current/SHA256SUMS",
+        sig_url: "https://cdimage.kali.org/current/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Kali / Debian shim chain"),
         purpose: "Pentesting + forensics installer. Debian-derived signed chain.",
-        resolver: None,
+        resolver: Some(crate::catalog_resolvers::kali_installer),
     },
     Entry {
         slug: "linuxmint-22-cinnamon",
@@ -273,27 +277,33 @@ pub const CATALOG: &[Entry] = &[
     },
     Entry {
         slug: "ubuntu-24.04-live-server",
-        name: "Ubuntu Server 24.04.2 LTS (live-server)",
+        name: "Ubuntu Server 24.04.4 LTS (live-server)",
         arch: "x86_64",
         size_mib: 2600,
-        iso_url: "https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso",
-        sha256_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS",
-        sig_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS.gpg",
+        // The /24.04/ directory accumulates point releases; the
+        // ubuntu_24_04_live_server resolver picks the highest. As of
+        // April 2026 that's 24.04.4 (resolver detected drift from
+        // the prior static 24.04.2 — promoted here in #646 phase 2).
+        iso_url: "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-live-server-amd64.iso",
+        sha256_url: "https://releases.ubuntu.com/24.04/SHA256SUMS",
+        sig_url: "https://releases.ubuntu.com/24.04/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS server installer. Validated under aegis-boot v0.12.0 #109.",
-        resolver: None,
+        resolver: Some(crate::catalog_resolvers::ubuntu_24_04_live_server),
     },
     Entry {
         slug: "ubuntu-24.04-desktop",
-        name: "Ubuntu Desktop 24.04.2 LTS",
+        name: "Ubuntu Desktop 24.04.4 LTS",
         arch: "x86_64",
         size_mib: 5800,
-        iso_url: "https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-desktop-amd64.iso",
-        sha256_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS",
-        sig_url: "https://releases.ubuntu.com/24.04.2/SHA256SUMS.gpg",
+        // Promoted from 24.04.2 → 24.04.4 by #646 phase 2 resolver
+        // detecting drift on releases.ubuntu.com/24.04/.
+        iso_url: "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+        sha256_url: "https://releases.ubuntu.com/24.04/SHA256SUMS",
+        sig_url: "https://releases.ubuntu.com/24.04/SHA256SUMS.gpg",
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS desktop installer. >4 GB → requires ext4 data partition.",
-        resolver: None,
+        resolver: Some(crate::catalog_resolvers::ubuntu_24_04_desktop),
     },
 ];
 

--- a/crates/aegis-cli/src/catalog_resolvers.rs
+++ b/crates/aegis-cli/src/catalog_resolvers.rs
@@ -104,10 +104,88 @@ fn resolve_debian_netinst_from_html(html: &str, base: &str) -> Result<ResolvedUr
     })
 }
 
+/// Ubuntu — list `releases.ubuntu.com/24.04/` and find the highest
+/// `ubuntu-24.04.X-live-server-amd64.iso` filename. The 24.04
+/// directory stays the canonical LTS path; point releases (.0, .1,
+/// .2, .3, ...) accumulate as new files in the same directory.
+pub fn ubuntu_24_04_live_server() -> Result<ResolvedUrls, ResolverError> {
+    const BASE: &str = "https://releases.ubuntu.com/24.04/";
+    let html = http_get(BASE)?;
+    resolve_ubuntu_24_04_with_html(&html, BASE, "live-server")
+}
+
+/// Ubuntu Desktop — same shape as live-server, different infix.
+pub fn ubuntu_24_04_desktop() -> Result<ResolvedUrls, ResolverError> {
+    const BASE: &str = "https://releases.ubuntu.com/24.04/";
+    let html = http_get(BASE)?;
+    resolve_ubuntu_24_04_with_html(&html, BASE, "desktop")
+}
+
+fn resolve_ubuntu_24_04_with_html(
+    html: &str,
+    base: &str,
+    variant: &str,
+) -> Result<ResolvedUrls, ResolverError> {
+    // Look for `ubuntu-24.04.X-<variant>-amd64.iso` filenames.
+    let prefix = "ubuntu-";
+    let suffix = format!("-{variant}-amd64.iso");
+    let mut versions: Vec<String> = simple_regex_match_all(html, prefix, &suffix);
+    versions.sort();
+    versions.dedup();
+    let latest = versions.last().ok_or(ResolverError::NoMatch {
+        url: base.to_string(),
+    })?;
+    let filename = format!("ubuntu-{latest}-{variant}-amd64.iso");
+    Ok(ResolvedUrls {
+        iso_url: format!("{base}{filename}"),
+        sha256_url: format!("{base}SHA256SUMS"),
+        sig_url: format!("{base}SHA256SUMS.gpg"),
+    })
+}
+
+/// Kali Linux — list `cdimage.kali.org/current/` and find the
+/// highest `kali-linux-X.Y-installer-amd64.iso` filename. The
+/// `current` symlink redirects to the latest cycle; the version
+/// embedded in the filename is what we need to surface.
+pub fn kali_installer() -> Result<ResolvedUrls, ResolverError> {
+    const BASE: &str = "https://cdimage.kali.org/current/";
+    let html = http_get(BASE)?;
+    resolve_kali_with_html(&html, BASE)
+}
+
+fn resolve_kali_with_html(html: &str, base: &str) -> Result<ResolvedUrls, ResolverError> {
+    // Pattern: `kali-linux-2026.1-installer-amd64.iso`. The version
+    // segment is Y.M (e.g. 2026.1).
+    let mut versions: Vec<String> =
+        simple_regex_match_all(html, "kali-linux-", "-installer-amd64.iso");
+    versions.sort();
+    versions.dedup();
+    let latest = versions.last().ok_or(ResolverError::NoMatch {
+        url: base.to_string(),
+    })?;
+    let filename = format!("kali-linux-{latest}-installer-amd64.iso");
+    Ok(ResolvedUrls {
+        iso_url: format!("{base}{filename}"),
+        // Kali ships SHA256SUMS + SHA256SUMS.gpg in the same dir.
+        sha256_url: format!("{base}SHA256SUMS"),
+        sig_url: format!("{base}SHA256SUMS.gpg"),
+    })
+}
+
 /// Pull "X.Y.Z" version segments from `<a href="debian-X.Y.Z-..."`
 /// patterns. Conservative — operates on raw HTML without a real
 /// parser — but the directory listings we care about are simple
 /// auto-generated index pages where this works.
+///
+/// Multiple prefixes can appear in the haystack with different
+/// suffixes (Ubuntu's listing has both `-live-server-amd64.iso` and
+/// `-desktop-amd64.iso` entries). When the version validity check
+/// fails — meaning the suffix we found wasn't the suffix for this
+/// particular prefix occurrence — we advance only past the current
+/// prefix so the next iteration sees subsequent prefix occurrences.
+/// Without this, looking for `-desktop-amd64.iso` would skip past
+/// the first prefix's `-live-server-amd64.iso` suffix and miss all
+/// the desktop entries.
 ///
 /// Returns the inner segments (without the prefix/suffix).
 fn simple_regex_match_all(haystack: &str, prefix: &str, suffix: &str) -> Vec<String> {
@@ -115,15 +193,20 @@ fn simple_regex_match_all(haystack: &str, prefix: &str, suffix: &str) -> Vec<Str
     let mut pos = 0;
     while let Some(start) = haystack[pos..].find(prefix) {
         let after_prefix = pos + start + prefix.len();
-        if let Some(end_off) = haystack[after_prefix..].find(suffix) {
-            let inner = &haystack[after_prefix..after_prefix + end_off];
-            // Validate it looks like a version: digits + dots only.
-            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit() || c == '.') {
-                out.push(inner.to_string());
-            }
+        let Some(end_off) = haystack[after_prefix..].find(suffix) else {
+            break;
+        };
+        let inner = &haystack[after_prefix..after_prefix + end_off];
+        // Validate it looks like a version: digits + dots only.
+        if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit() || c == '.') {
+            out.push(inner.to_string());
             pos = after_prefix + end_off + suffix.len();
         } else {
-            break;
+            // Suffix matched but inner isn't a clean version — the
+            // suffix we found belongs to a later prefix occurrence,
+            // not this one. Advance past the current prefix only so
+            // the next iteration can check subsequent prefixes.
+            pos = after_prefix;
         }
     }
     out
@@ -208,5 +291,48 @@ mod tests {
         let s = "<a>debian-12.0.0-foo</a> <a>debian-12.5.0-foo</a> <a>debian-bad-foo</a>";
         let v = simple_regex_match_all(s, "debian-", "-foo");
         assert_eq!(v, vec!["12.0.0", "12.5.0"]);
+    }
+
+    #[test]
+    fn ubuntu_resolver_picks_highest_point_release() {
+        // Realistic snippet of releases.ubuntu.com/24.04/ where
+        // operators see all point releases accumulating in one dir.
+        let html = r#"<html><body>
+            <a href="ubuntu-24.04.2-live-server-amd64.iso">…</a>
+            <a href="ubuntu-24.04.3-live-server-amd64.iso">…</a>
+            <a href="ubuntu-24.04.4-live-server-amd64.iso">…</a>
+            <a href="ubuntu-24.04.4-desktop-amd64.iso">…</a>
+        </body></html>"#;
+        let r = resolve_ubuntu_24_04_with_html(html, "https://example.test/", "live-server")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert_eq!(
+            r.iso_url,
+            "https://example.test/ubuntu-24.04.4-live-server-amd64.iso"
+        );
+
+        // Desktop variant filters separately.
+        let r2 = resolve_ubuntu_24_04_with_html(html, "https://example.test/", "desktop")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert_eq!(
+            r2.iso_url,
+            "https://example.test/ubuntu-24.04.4-desktop-amd64.iso"
+        );
+    }
+
+    #[test]
+    fn kali_resolver_picks_highest_release() {
+        // Realistic snippet of cdimage.kali.org/current/.
+        let html = r#"<html><body>
+            <a href="kali-linux-2025.4-installer-amd64.iso">…</a>
+            <a href="kali-linux-2026.1-installer-amd64.iso">…</a>
+            <a href="kali-linux-2026.1-hyperv-amd64.7z">…</a>
+        </body></html>"#;
+        let r = resolve_kali_with_html(html, "https://example.test/")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert_eq!(
+            r.iso_url,
+            "https://example.test/kali-linux-2026.1-installer-amd64.iso"
+        );
+        assert_eq!(r.sha256_url, "https://example.test/SHA256SUMS");
     }
 }


### PR DESCRIPTION
## Summary

Adds three more URL resolvers on top of the framework from #647:

| Resolver | Source | Pattern |
| --- | --- | --- |
| `ubuntu_24_04_live_server` | `releases.ubuntu.com/24.04/` | highest `ubuntu-24.04.X-live-server-amd64.iso` |
| `ubuntu_24_04_desktop` | same dir | desktop variant |
| `kali_installer` | `cdimage.kali.org/current/` | highest `kali-linux-X.Y-installer-amd64.iso` |

## Live drift detected + fixed

Running `--refresh` against the production sources caught two real catalog staleness bugs the resolver framework was designed to surface:

- **ubuntu-24.04**: static was `.2`, mirror serves `.4` (TWO point bumps in flight)
- **kali-2026.1**: static used `/kali-2026.1/` path; current is `/current/`

Both static URLs in this PR are promoted to what the resolvers returned. Subsequent `--refresh` runs report `[OK]` until the next bump.

## Regex bug fix

The shared `simple_regex_match_all` had a bug where mixed-suffix listings (Ubuntu's `/24.04/` has both `-live-server-amd64.iso` and `-desktop-amd64.iso` filenames) would skip past the wrong suffix and miss subsequent matches. When the suffix's inner segment isn't a clean version (digits + dots), now advance past the prefix only — not past the mismatched suffix — so the next iteration sees subsequent prefix occurrences.

Caught by the new `ubuntu_resolver_picks_highest_point_release` test exercising both variants against the same mixed listing.

## Live `--refresh` after this PR

```
$ aegis-boot recommend --refresh
aegis-boot recommend --refresh — checking resolvers (#646)

[OK]    debian-13-netinst (matches static)
[OK]    kali-2026.1-installer (matches static)
[OK]    ubuntu-24.04-live-server (matches static)
[OK]    ubuntu-24.04-desktop (matches static)
```

## Test plan

- [x] 3 new unit tests (Ubuntu live + desktop, Kali) against canned HTML; all offline
- [x] 780 aegis-bootctl tests pass under rustc 1.95
- [x] `cargo clippy -p aegis-bootctl --all-targets -- -D warnings` clean
- [x] Live `--refresh` reports `[OK]` for all four resolved entries

Phase 2 of #646. Future phases tracked under that issue:
- Manjaro / openSUSE / MX / Fedora / Linux Mint resolvers
- Pop!_OS via JSON-API (HTTP 403 on directory listing)
- `--refresh --write` to mutate catalog source file in-tree
- Weekly auto-PR GitHub Actions workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)