### PR TITLE
feat(catalog): Linux Mint resolver + bump static to 22.3 (#646 phase 3)

### DIFF
--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -190,15 +190,20 @@ pub const CATALOG: &[Entry] = &[
     },
     Entry {
         slug: "linuxmint-22-cinnamon",
-        name: "Linux Mint 22 Cinnamon",
+        name: "Linux Mint 22.3 Cinnamon",
         arch: "x86_64",
         size_mib: 2900,
-        iso_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22/linuxmint-22-cinnamon-64bit.iso",
-        sha256_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22/sha256sum.txt",
-        sig_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22/sha256sum.txt.gpg",
+        // Promoted from /22/ to /22.3/ by #646 phase 3 resolver
+        // detecting drift on mirrors.edge.kernel.org/linuxmint/stable/.
+        // Mint accumulates point-release dirs (22, 22.1, 22.2, 22.3...)
+        // and the linuxmint_22_cinnamon resolver picks the highest
+        // within the 22 major.
+        iso_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22.3/linuxmint-22.3-cinnamon-64bit.iso",
+        sha256_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22.3/sha256sum.txt",
+        sig_url: "https://mirrors.edge.kernel.org/linuxmint/stable/22.3/sha256sum.txt.gpg",
         sb: SbStatus::Signed("Linux Mint"),
         purpose: "Friendly Ubuntu-derived desktop. Common operator install target.",
-        resolver: None,
+        resolver: Some(crate::catalog_resolvers::linuxmint_22_cinnamon),
     },
     Entry {
         // DistroWatch top-12-month rank #8 (April 2026). Manjaro

--- a/crates/aegis-cli/src/catalog_resolvers.rs
+++ b/crates/aegis-cli/src/catalog_resolvers.rs
@@ -172,6 +172,86 @@ fn resolve_kali_with_html(html: &str, base: &str) -> Result<ResolvedUrls, Resolv
     })
 }
 
+/// Linux Mint Cinnamon — list `/linuxmint/stable/` for the highest
+/// `22.X/` subdirectory (point releases accumulate as new dirs in
+/// the major-version family), then resolve the cinnamon ISO inside.
+///
+/// Major-version 22 is pinned: when 23 ships, this resolver needs a
+/// new major or a major-agnostic variant (tracked under #646).
+pub fn linuxmint_22_cinnamon() -> Result<ResolvedUrls, ResolverError> {
+    const BASE: &str = "https://mirrors.edge.kernel.org/linuxmint/stable/";
+    let html = http_get(BASE)?;
+    resolve_linuxmint_22_with_html(&html, BASE, "cinnamon")
+}
+
+fn resolve_linuxmint_22_with_html(
+    parent_html: &str,
+    parent: &str,
+    flavor: &str,
+) -> Result<ResolvedUrls, ResolverError> {
+    // Find highest 22.X/ subdir. "22/" alone is also a valid major
+    // (the initial release before any point release shipped).
+    // Lexical sort would put "22.10" < "22.9", so compare numeric
+    // tuples (major, minor) instead.
+    let candidates = parse_versioned_subdirs(parent_html, "22");
+    let pick = candidates
+        .into_iter()
+        .max_by_key(|v| {
+            // Parse "22.3" → (22, 3); bare "22" → (22, 0).
+            let mut parts = v.splitn(2, '.');
+            let major = parts
+                .next()
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(0);
+            let minor = parts
+                .next()
+                .and_then(|s| s.parse::<u32>().ok())
+                .unwrap_or(0);
+            (major, minor)
+        })
+        .ok_or(ResolverError::NoMatch {
+            url: parent.to_string(),
+        })?;
+    let dir = format!("{parent}{pick}/");
+    // The file inside is named after the same version (e.g.
+    // linuxmint-22.3-cinnamon-64bit.iso). Don't fetch the subdir's
+    // listing — we know the filename pattern.
+    let filename = format!("linuxmint-{pick}-{flavor}-64bit.iso");
+    Ok(ResolvedUrls {
+        iso_url: format!("{dir}{filename}"),
+        sha256_url: format!("{dir}sha256sum.txt"),
+        sig_url: format!("{dir}sha256sum.txt.gpg"),
+    })
+}
+
+/// Pull `<href="<major>(\.X)?/"` entries from a directory listing
+/// and return the version strings ("22", "22.1", "22.2", "22.3"...).
+/// Used by Linux Mint where point-release dirs accumulate alongside
+/// the bare-major dir.
+fn parse_versioned_subdirs(html: &str, major: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut pos = 0;
+    while let Some(start) = html[pos..].find("href=\"") {
+        let after = pos + start + 6;
+        let Some(end_off) = html[after..].find('"') else {
+            break;
+        };
+        let candidate = &html[after..after + end_off];
+        if let Some(stripped) = candidate.strip_suffix('/')
+            && (stripped == major
+                || (stripped.starts_with(major)
+                    && stripped[major.len()..].starts_with('.')
+                    && stripped[major.len() + 1..]
+                        .chars()
+                        .all(|c| c.is_ascii_digit() || c == '.')))
+        {
+            out.push(stripped.to_string());
+        }
+        pos = after + end_off + 1;
+    }
+    out
+}
+
 /// Pull "X.Y.Z" version segments from `<a href="debian-X.Y.Z-..."`
 /// patterns. Conservative — operates on raw HTML without a real
 /// parser — but the directory listings we care about are simple
@@ -317,6 +397,56 @@ mod tests {
             r2.iso_url,
             "https://example.test/ubuntu-24.04.4-desktop-amd64.iso"
         );
+    }
+
+    #[test]
+    fn linuxmint_resolver_picks_highest_point_release_within_major() {
+        // Realistic snippet of mirrors.edge.kernel.org/linuxmint/stable/.
+        let html = r#"<html><body>
+            <a href="../">…</a>
+            <a href="20.3/">20.3/</a>
+            <a href="21/">21/</a>
+            <a href="22/">22/</a>
+            <a href="22.1/">22.1/</a>
+            <a href="22.2/">22.2/</a>
+            <a href="22.3/">22.3/</a>
+        </body></html>"#;
+        let r = resolve_linuxmint_22_with_html(html, "https://example.test/", "cinnamon")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert_eq!(
+            r.iso_url,
+            "https://example.test/22.3/linuxmint-22.3-cinnamon-64bit.iso"
+        );
+        assert_eq!(r.sha256_url, "https://example.test/22.3/sha256sum.txt");
+    }
+
+    #[test]
+    fn linuxmint_version_compare_is_numeric_not_lexical() {
+        // Future-proofing: when Mint hits 22.10, lexical sort would
+        // pick "22.9" as highest. Numeric tuple compare picks 22.10.
+        let html = r#"<html><body>
+            <a href="22.9/">22.9/</a>
+            <a href="22.10/">22.10/</a>
+        </body></html>"#;
+        let r = resolve_linuxmint_22_with_html(html, "https://example.test/", "cinnamon")
+            .unwrap_or_else(|e| panic!("resolve: {e}"));
+        assert!(
+            r.iso_url.contains("22.10"),
+            "expected 22.10 to win over 22.9: {}",
+            r.iso_url
+        );
+    }
+
+    #[test]
+    fn linuxmint_resolver_errors_when_no_matching_major() {
+        let html = r#"<html><body>
+            <a href="20.3/">20.3/</a>
+            <a href="21/">21/</a>
+        </body></html>"#;
+        let err = resolve_linuxmint_22_with_html(html, "https://example.test/", "cinnamon")
+            .err()
+            .unwrap_or_else(|| panic!("should fail"));
+        assert!(matches!(err, ResolverError::NoMatch { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a fifth resolver: `linuxmint_22_cinnamon`. Walks `mirrors.edge.kernel.org/linuxmint/stable/` for the highest 22.X subdirectory, then resolves the cinnamon ISO inside.

## Live drift detected + fixed

Static catalog had `/22/linuxmint-22-cinnamon-64bit.iso`. Resolver finds `/22.3/` is the current highest 22.X, with filename `linuxmint-22.3-cinnamon-64bit.iso`. Both the directory path AND filename had drifted; static promoted to the resolved values.

## Design note: numeric version compare

Lexical sort would put \"22.10\" < \"22.9\". Mint hasn't reached 22.10 yet, but the resolver uses tuple compare `(major, minor)` so it stays correct when point releases roll over to two-digit minors. `linuxmint_version_compare_is_numeric_not_lexical` test pins this.

## Deferred

Manjaro and Pop!_OS resolvers were considered but their servers return HTTP 404 / 403 on directory listings respectively. Both need different fetch strategies (Manjaro: probably their JSON manifest at `download.manjaro.org/manifests/`; Pop!_OS: their `api.pop-os.org`). Tracked under #646.

## Live `--refresh` after this PR

```
$ aegis-boot recommend --refresh
[OK]    debian-13-netinst (matches static)
[OK]    kali-2026.1-installer (matches static)
[OK]    linuxmint-22-cinnamon (matches static)
[OK]    ubuntu-24.04-live-server (matches static)
[OK]    ubuntu-24.04-desktop (matches static)
```

## Test plan

- [x] 3 new unit tests (Mint highest-point-release, Mint numeric vs lexical compare, Mint NoMatch when major absent)
- [x] 783 aegis-bootctl tests pass under rustc 1.95
- [x] `cargo clippy -p aegis-bootctl --all-targets -- -D warnings` clean
- [x] Live `--refresh` reports `[OK]` for all 5 resolved entries

## Status

Phase 3 of #646. Five resolvers cover ~38% of the catalog (5/13). The remaining 8 distros are either:
- Self-canonicalizing static URLs (AlmaLinux, Rocky, openSUSE — `/latest/` or symlink-named ISOs)
- Servers that block HTML directory listings (Manjaro, Pop!_OS, EndeavourOS — need distro-specific JSON / API paths)
- Lower-priority for catalog freshness (Alpine, Fedora, MX — bumps less frequently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)