### PR TITLE
feat(catalog): add SystemRescue + GParted Live to RESCUE category

### DIFF
--- a/crates/aegis-cli/src/catalog.rs
+++ b/crates/aegis-cli/src/catalog.rs
@@ -270,6 +270,21 @@ pub const CATALOG: &[Entry] = &[
         resolver: None,
     },
     Entry {
+        slug: "gparted-live-1.8.1",
+        name: "GParted Live 1.8.1-3",
+        arch: "x86_64",
+        size_mib: 500,
+        // GParted Live hosts the ISO on SourceForge (download mirror
+        // redirect) and the signed CHECKSUMS on gparted.org directly.
+        iso_url: "https://downloads.sourceforge.net/gparted/gparted-live-1.8.1-3-amd64.iso",
+        sha256_url: "https://gparted.org/gparted-live/stable/CHECKSUMS.TXT",
+        sig_url: "https://gparted.org/gparted-live/stable/CHECKSUMS.TXT.gpg",
+        sb: SbStatus::Signed("Debian shim chain (GParted)"),
+        purpose: "Partition editor live ISO. Resize, repair, image disks.",
+        category: Category::Rescue,
+        resolver: None,
+    },
+    Entry {
         // Not on DistroWatch top-15 but the de-facto pentest distro
         // operators expect to see in a rescue-stick catalog.
         slug: "kali-2026.1-installer",
@@ -384,6 +399,28 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Rocky Linux"),
         purpose: "Free RHEL-rebuild minimal installer. Cross-distro kexec quirk possible.",
         category: Category::Installer,
+        resolver: None,
+    },
+    Entry {
+        slug: "systemrescue-13.00",
+        name: "SystemRescue 13.00",
+        arch: "x86_64",
+        size_mib: 900,
+        // SystemRescue's CDN is fastly-cdn.system-rescue.org; the .asc
+        // is a detached PGP signature on the ISO itself (not on a
+        // SHA256SUMS file — different from the Debian/Ubuntu pattern).
+        // The .sha256 holds the literal `<hash>  <filename>` line; both
+        // are kept for operators who prefer signature-on-ISO vs
+        // hash-list-with-sig flows.
+        iso_url: "https://fastly-cdn.system-rescue.org/releases/13.00/systemrescue-13.00-amd64.iso",
+        sha256_url: "https://fastly-cdn.system-rescue.org/releases/13.00/systemrescue-13.00-amd64.iso.sha256",
+        sig_url: "https://fastly-cdn.system-rescue.org/releases/13.00/systemrescue-13.00-amd64.iso.asc",
+        // Arch-derived; SystemRescue ships their own kernel signed by
+        // their key, but stock-SB machines need MOK enrollment. Same
+        // posture as Manjaro until validated end-to-end (#629 follow).
+        sb: SbStatus::UnsignedNeedsMok,
+        purpose: "Comprehensive rescue toolkit: parted, testdisk, ddrescue, clamav.",
+        category: Category::Rescue,
         resolver: None,
     },
     Entry {


### PR DESCRIPTION
## Summary

The RESCUE category previously contained only Alpine Linux x86_64 + arm64 — minimal busybox shells, useful as last-resort shells but not as recovery toolkits. This PR adds the two canonical recovery distros that operators reach for when something is actually broken:

- **SystemRescue 13.00** (900 MiB, x86_64) — comprehensive toolkit: parted, testdisk, photorec, ddrescue, clamav, network tools.
- **GParted Live 1.8.1-3** (500 MiB, x86_64) — partition-editor specialist. Resize, repair, image disks.

RESCUE category grows 2 → 4 entries. Together SystemRescue + GParted cover ~90% of "I need to actually fix something" use cases that plain Alpine cannot.

## Secure Boot posture

| entry | sb | rationale |
|---|---|---|
| SystemRescue | `UnsignedNeedsMok` | Arch-derived; ships own kernel signed with their key, but stock-SB machines need MOK enrollment. Same conservative posture as Manjaro until validated E2E (#629 follow). |
| GParted Live | `Signed("Debian shim chain (GParted)")` | Built on Debian Live, uses the standard Debian signed shim chain — boots clean under stock Secure Boot. |

## Why these two

Verified against the upstream-catalog research (#646 follow-up, #651) and the existing rescue-category gap. SystemRescue is the kitchen-sink rescue that has been the de-facto answer for ~20 years; GParted Live covers the specialized partitioning case where you don't want to download a 900 MB ISO. Both are actively maintained (SystemRescue 13.00 released 2026-03-28; GParted Live 1.8.1-3 released 2026-04-07) and publish properly-signed checksums.

## Not included (deliberate)

- **SystemRescue arm64** — not officially published. Verified via the release-page scrape: only `-amd64.iso` exists.
- **Clonezilla / CAINE / ShredOS** — nice-to-have follow-ups for a future PR. Not in the "first 90% of rescues" tier.

## Test plan

- [x] All 6 URLs (iso + sha256/CHECKSUMS + sig per entry) HEAD-verified to return HTTP 200 against live mirrors
- [x] 21 catalog unit tests pass (`cargo test -p aegis-bootctl --bin aegis-boot -- catalog::`)
- [x] Local clippy clean: `cargo clippy -p aegis-bootctl --all-targets -- -D warnings`
- [x] `recommend` output verified — RESCUE section now shows 4 entries grouped correctly
- [ ] CI green
- [ ] Maintainer review of SB posture choice (`UnsignedNeedsMok` for SystemRescue — see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)