### PR TITLE
feat(rescue-tui): D-key ISO delete with confirmation prompt

### DIFF
--- a/crates/rescue-tui/README.md
+++ b/crates/rescue-tui/README.md
@@ -50,6 +50,9 @@ and focused pane. Press `?` inside the TUI for the full help overlay.
 | `/` | List | any | no | Open the substring filter — typed chars match label + path |
 | `s` | List | any | no | Cycle sort order: name → size → distro → name |
 | `v` | List, Confirm | any | no | Re-compute sha256 of the selected ISO in a background thread |
+| `D` | List | List | no | Delete the highlighted ISO + sidecar from the data partition (confirm prompt) |
+| `y` | ConfirmDelete | any | no | Confirm — unlink the ISO and its `.aegis.toml` sidecar |
+| `n/Esc` | ConfirmDelete | any | no | Cancel — return to the list without deleting |
 | `Enter` | List | any | yes | Commit the current filter and close the input |
 | `Esc` | List | any | yes | Close the filter input and clear the current filter |
 | `Enter` | Confirm | any | no | Kexec into the selected ISO (may trigger a trust challenge) |

--- a/crates/rescue-tui/src/docgen.rs
+++ b/crates/rescue-tui/src/docgen.rs
@@ -143,6 +143,7 @@ fn screen_short_name(s: ScreenKind) -> String {
         ScreenKind::Quitting => "Quitting",
         ScreenKind::BlockedToast => "BlockedToast",
         ScreenKind::Consent => "Consent",
+        ScreenKind::ConfirmDelete => "ConfirmDelete",
     };
     name.to_string()
 }

--- a/crates/rescue-tui/src/keybindings.rs
+++ b/crates/rescue-tui/src/keybindings.rs
@@ -51,6 +51,8 @@ pub(crate) enum ScreenKind {
     BlockedToast,
     /// Consent screen for elevated-risk boot paths (#347).
     Consent,
+    /// Confirm-before-delete prompt for an ISO on the data partition.
+    ConfirmDelete,
 }
 
 impl ScreenKind {
@@ -69,6 +71,7 @@ impl ScreenKind {
             Screen::Quitting => Self::Quitting,
             Screen::BlockedToast { .. } => Self::BlockedToast,
             Screen::Consent { .. } => Self::Consent,
+            Screen::ConfirmDelete { .. } => Self::ConfirmDelete,
         }
     }
 }
@@ -161,6 +164,31 @@ pub(crate) const KEYBINDINGS: &[Keybinding] = &[
         label: "Verify",
         description: "Re-compute sha256 of the selected ISO in a background thread",
         screens: &[ScreenKind::List, ScreenKind::Confirm],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "D",
+        label: "Delete",
+        description: "Delete the highlighted ISO + sidecar from the data partition (confirm prompt)",
+        screens: &[ScreenKind::List],
+        pane: Some(Pane::List),
+        while_filter_editing: false,
+    },
+    // ---- ConfirmDelete prompt --------------------------------------
+    Keybinding {
+        key: "y",
+        label: "Delete",
+        description: "Confirm — unlink the ISO and its `.aegis.toml` sidecar",
+        screens: &[ScreenKind::ConfirmDelete],
+        pane: None,
+        while_filter_editing: false,
+    },
+    Keybinding {
+        key: "n/Esc",
+        label: "Cancel",
+        description: "Cancel — return to the list without deleting",
+        screens: &[ScreenKind::ConfirmDelete],
         pane: None,
         while_filter_editing: false,
     },
@@ -400,10 +428,11 @@ mod tests {
                 buffer: String::new(),
             }),
             ScreenKind::from_screen(&Screen::Quitting),
+            ScreenKind::from_screen(&Screen::ConfirmDelete { selected: 0 }),
         ];
-        // Sanity: 7 inputs → 7 distinct kinds (Help / ConfirmQuit also
+        // Sanity: 8 inputs → 8 distinct kinds (Help / ConfirmQuit also
         // exist but require a `prior` Screen we'd need to construct).
         let distinct: std::collections::HashSet<ScreenKind> = kinds.iter().copied().collect();
-        assert_eq!(distinct.len(), 7);
+        assert_eq!(distinct.len(), 8);
     }
 }

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -578,9 +578,7 @@ where
             // prompt. `enter_delete` itself self-guards against
             // FailedIso / RescueShell rows (returns None) so this arm
             // is safe to fire even on a non-deletable cursor.
-            (Screen::List { selected }, KeyCode::Char('D'))
-                if state.pane == state::Pane::List =>
-            {
+            (Screen::List { selected }, KeyCode::Char('D')) if state.pane == state::Pane::List => {
                 let _ = state.enter_delete(*selected);
             }
             // ConfirmDelete handlers. `y/Y` performs the unlink and

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -572,6 +572,53 @@ where
                     active_verify = Some(rx);
                 }
             }
+            // `D` opens the ConfirmDelete prompt for the highlighted
+            // ISO row. Limited to pane=List so muscle-memory keypresses
+            // while reading the Info pane don't trigger a destructive
+            // prompt. `enter_delete` itself self-guards against
+            // FailedIso / RescueShell rows (returns None) so this arm
+            // is safe to fire even on a non-deletable cursor.
+            (Screen::List { selected }, KeyCode::Char('D'))
+                if state.pane == state::Pane::List =>
+            {
+                let _ = state.enter_delete(*selected);
+            }
+            // ConfirmDelete handlers. `y/Y` performs the unlink and
+            // updates state on success / surfaces an Error screen on
+            // failure. `n/N/Esc` cancels back to List, cursor preserved.
+            (Screen::ConfirmDelete { selected }, KeyCode::Char('y' | 'Y')) => {
+                let cursor = *selected;
+                let target = state
+                    .real_index(cursor)
+                    .and_then(|i| state.isos.get(i))
+                    .map(|iso| iso.iso_path.clone());
+                if let Some(path) = target {
+                    match perform_iso_delete(&path) {
+                        Ok(()) => {
+                            tracing::info!(
+                                iso = %path.display(),
+                                "rescue-tui: ISO + sidecar removed via D-prompt confirm"
+                            );
+                            state.delete_completed();
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                iso = %path.display(),
+                                error = %e,
+                                "rescue-tui: ISO delete failed"
+                            );
+                            state.record_delete_error(&e);
+                        }
+                    }
+                } else {
+                    // Cursor went stale (filter shifted etc.) — bail
+                    // back to List rather than exploding.
+                    state.cancel_delete();
+                }
+            }
+            (Screen::ConfirmDelete { .. }, KeyCode::Char('n' | 'N') | KeyCode::Esc) => {
+                state.cancel_delete();
+            }
             (Screen::Confirm { selected }, KeyCode::Char('v')) => {
                 let real_idx = *selected;
                 if let Some(iso) = state.isos.get(real_idx) {
@@ -980,6 +1027,23 @@ fn epoch_to_civil_date(epoch_secs: u64) -> (i32, u32, u32) {
 /// just logs and continues; the operator already saw the verdict in
 /// the TUI).
 ///
+/// Unlink an ISO file and its `<iso>.aegis.toml` sidecar. Used by the
+/// `D` keybinding's confirm flow.
+///
+/// Returns Ok on success. Errors out at the first filesystem failure;
+/// in particular a missing sidecar is OK (returns Ok), but a sidecar
+/// that exists yet won't unlink (read-only mount, perms) is surfaced
+/// to the operator since an orphaned sidecar would mislead the next
+/// `iso-probe` walk into showing a tier-4 row for a non-existent ISO.
+fn perform_iso_delete(iso_path: &std::path::Path) -> Result<(), String> {
+    std::fs::remove_file(iso_path).map_err(|e| format!("unlink ISO: {e}"))?;
+    let sidecar = iso_probe::sidecar_path_for(iso_path);
+    if sidecar.exists() {
+        std::fs::remove_file(&sidecar).map_err(|e| format!("unlink sidecar: {e}"))?;
+    }
+    Ok(())
+}
+
 /// JSON record shape:
 /// `{"timestamp_epoch": 1700000000, "iso_path": "...", "outcome": {...}}`
 /// where `outcome` is the serialized [`iso_probe::HashVerification`].

--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -65,6 +65,9 @@ pub fn draw(frame: &mut Frame<'_>, state: &AppState) {
     if let Screen::Consent { kind, .. } = &state.screen {
         draw_consent_overlay(frame, area, state, *kind);
     }
+    if let Screen::ConfirmDelete { selected } = &state.screen {
+        draw_confirm_delete_overlay(frame, area, state, *selected);
+    }
 }
 
 fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
@@ -75,7 +78,11 @@ fn draw_body(frame: &mut Frame<'_>, area: Rect, state: &AppState) {
         other => other,
     };
     match effective {
-        Screen::List { selected } => draw_list(frame, area, state, *selected),
+        // List is the canonical backdrop; ConfirmDelete reuses it so
+        // the row about to be removed stays visible behind the prompt.
+        Screen::List { selected } | Screen::ConfirmDelete { selected } => {
+            draw_list(frame, area, state, *selected);
+        }
         // Confirm + Consent share the same backdrop: Consent (#347)
         // renders the Confirm screen underneath at the selected ISO so
         // the operator sees verdict context, then the consent overlay
@@ -450,6 +457,79 @@ fn draw_confirm_quit_overlay(frame: &mut Frame<'_>, area: Rect, state: &AppState
         )),
     ];
     let block = Block::default().borders(Borders::ALL).title(" Confirm ");
+    // Clear underlying buffer before rendering — see #629.
+    frame.render_widget(Clear, panel);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        panel,
+    );
+}
+
+/// Centered popup overlay for [`Screen::ConfirmDelete`]. Sits over the
+/// List screen — the underneath cursor still shows which row will be
+/// removed, and the y/N default biases against accidental deletes.
+fn draw_confirm_delete_overlay(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &AppState,
+    selected: usize,
+) {
+    const HINT: &str = " [y] delete    [n/Esc] cancel";
+
+    // Resolve the ISO under the cursor so the prompt names it. If the
+    // cursor doesn't point at a real ISO row we shouldn't be here at
+    // all (state guards against it), but render a fallback for safety.
+    let iso_label = state
+        .real_index(selected)
+        .and_then(|i| state.isos.get(i))
+        .map_or_else(|| "<unknown>".to_string(), |iso| iso.label.clone());
+    let iso_path = state
+        .real_index(selected)
+        .and_then(|i| state.isos.get(i))
+        .map_or_else(String::new, |iso| iso.iso_path.display().to_string());
+
+    let title_line = format!("Delete \"{iso_label}\"?");
+    let path_line = if iso_path.is_empty() {
+        String::new()
+    } else {
+        format!("Path: {iso_path}")
+    };
+    // Width: hug the longest line; cap to a comfortable panel size.
+    let content_width = title_line
+        .len()
+        .max(path_line.len())
+        .max(HINT.len())
+        .max("This also removes the .aegis.toml sidecar.".len());
+    let w = u16::try_from(content_width.saturating_add(4))
+        .unwrap_or(u16::MAX)
+        .min(area.width)
+        .min(80);
+    let h: u16 = 9;
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let panel = Rect::new(x, y, w, h);
+    let mut lines = vec![Line::from(Span::styled(
+        title_line,
+        Style::default()
+            .fg(state.theme.warning)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    if !path_line.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(path_line));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from("This also removes the .aegis.toml sidecar."));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        HINT,
+        Style::default().fg(state.theme.warning),
+    )));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Confirm delete ");
     // Clear underlying buffer before rendering — see #629.
     frame.render_widget(Clear, panel);
     frame.render_widget(

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -1094,7 +1094,13 @@ impl AppState {
         let shifted: std::collections::HashMap<usize, String> = self
             .cmdline_overrides
             .drain()
-            .map(|(idx, val)| if idx > real_idx { (idx - 1, val) } else { (idx, val) })
+            .map(|(idx, val)| {
+                if idx > real_idx {
+                    (idx - 1, val)
+                } else {
+                    (idx, val)
+                }
+            })
             .collect();
         self.cmdline_overrides = shifted;
         self.isos.remove(real_idx);
@@ -2704,8 +2710,7 @@ mod tests {
         // its new position (idx=1), not stay attached to a now-empty
         // slot or float into a different ISO.
         let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
-        s.cmdline_overrides
-            .insert(2, "console=ttyS0".to_string());
+        s.cmdline_overrides.insert(2, "console=ttyS0".to_string());
         // sort=Name → visible order matches insertion. enter_delete(1)
         // picks "b" (real_idx=1 too).
         let _ = s.enter_delete(1);

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -110,6 +110,16 @@ pub enum Screen {
         /// (granted → kexec; dismissed → Confirm).
         selected: usize,
     },
+    /// Confirm-before-delete prompt for the highlighted ISO. Opened
+    /// from the List screen via the `D` keybinding. `y` unlinks the
+    /// ISO + its `<iso>.aegis.toml` sidecar from the data partition;
+    /// `n`/`Esc` cancels back to List preserving the cursor.
+    ConfirmDelete {
+        /// View-cursor index (NOT the real index) of the ISO under
+        /// confirmation, mirroring [`Screen::List`]'s coordinate
+        /// space so the cursor returns to the same row on cancel.
+        selected: usize,
+    },
 }
 
 /// Reason for a [`Screen::Consent`] prompt. Each variant pairs with a
@@ -1033,6 +1043,86 @@ impl AppState {
         self.screen = Screen::Error {
             message,
             remedy,
+            return_to,
+        };
+    }
+
+    /// Open the [`Screen::ConfirmDelete`] prompt against the highlighted
+    /// list cursor. Returns the path of the ISO that's about to be
+    /// confirmed (caller may show a preview line). Returns `None` and
+    /// leaves screen unchanged when the cursor doesn't point at a real
+    /// ISO row (`FailedIso` / `RescueShell` are non-deletable here —
+    /// those rows aren't backed by a removable on-disk ISO file under
+    /// our management).
+    pub fn enter_delete(&mut self, selected: usize) -> Option<std::path::PathBuf> {
+        if !matches!(self.screen, Screen::List { .. }) {
+            return None;
+        }
+        let real_idx = self.real_index(selected)?;
+        let path = self.isos.get(real_idx)?.iso_path.clone();
+        self.screen = Screen::ConfirmDelete { selected };
+        Some(path)
+    }
+
+    /// Cancel the delete prompt, returning to the List with the cursor
+    /// preserved at the same row.
+    pub fn cancel_delete(&mut self) {
+        if let Screen::ConfirmDelete { selected } = self.screen {
+            self.screen = Screen::List { selected };
+        }
+    }
+
+    /// Apply a successful unlink: drop the corresponding ISO from
+    /// [`Self::isos`], clamp the cursor, and return to the List screen.
+    /// Caller is responsible for performing the actual filesystem
+    /// removal BEFORE invoking this; on filesystem failure use
+    /// [`Self::record_delete_error`] instead.
+    pub fn delete_completed(&mut self) {
+        let Screen::ConfirmDelete { selected } = self.screen else {
+            return;
+        };
+        let Some(real_idx) = self.real_index(selected) else {
+            self.screen = Screen::List { selected: 0 };
+            return;
+        };
+        // Drop any cmdline override pinned to this index, AND shift
+        // every override at a higher index down by one — vec-remove
+        // shifts the trailing entries' positions. Without this fix
+        // an operator who'd edited the cmdline of an ISO past the
+        // deleted one would see their edit attached to the wrong row.
+        self.cmdline_overrides.remove(&real_idx);
+        let shifted: std::collections::HashMap<usize, String> = self
+            .cmdline_overrides
+            .drain()
+            .map(|(idx, val)| if idx > real_idx { (idx - 1, val) } else { (idx, val) })
+            .collect();
+        self.cmdline_overrides = shifted;
+        self.isos.remove(real_idx);
+        let new_total = self.visible_entries().len();
+        let clamped = if new_total == 0 {
+            0
+        } else {
+            selected.min(new_total - 1)
+        };
+        self.screen = Screen::List { selected: clamped };
+    }
+
+    /// Record a delete-time filesystem error and surface it on the
+    /// Error screen. Mirrors [`Self::record_kexec_error`] so the
+    /// post-failure UX is uniform — one Error screen variant the
+    /// operator already knows how to dismiss.
+    pub fn record_delete_error(&mut self, err: &str) {
+        let return_to = match &self.screen {
+            Screen::ConfirmDelete { selected } => *selected,
+            _ => 0,
+        };
+        self.screen = Screen::Error {
+            message: format!("Delete failed: {err}"),
+            remedy: Some(
+                "Check that the data partition is mounted read-write \
+                 and that no other process holds the ISO open."
+                    .to_string(),
+            ),
             return_to,
         };
     }
@@ -2507,5 +2597,146 @@ mod tests {
     fn pane_toggle_method_returns_opposite() {
         assert_eq!(Pane::List.toggle(), Pane::Info);
         assert_eq!(Pane::Info.toggle(), Pane::List);
+    }
+
+    // ---- Delete-with-confirmation transitions ---------------------
+
+    #[test]
+    fn enter_delete_transitions_to_confirm_delete_for_real_iso() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        let Some(path) = s.enter_delete(0) else {
+            panic!("real ISO row should accept delete");
+        };
+        assert!(path.to_string_lossy().contains('a'));
+        match s.screen {
+            Screen::ConfirmDelete { selected } => assert_eq!(selected, 0),
+            other => panic!("expected ConfirmDelete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enter_delete_returns_none_outside_list_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        s.screen = Screen::Confirm { selected: 0 };
+        assert!(
+            s.enter_delete(0).is_none(),
+            "delete prompt must not open from non-List screen"
+        );
+        assert!(
+            matches!(s.screen, Screen::Confirm { .. }),
+            "screen must be unchanged on refusal"
+        );
+    }
+
+    #[test]
+    fn enter_delete_returns_none_for_rescue_shell_row() {
+        // The rescue-shell synthetic row is the last entry. Cursor at
+        // that index must NOT open the delete prompt — there's no
+        // on-disk file backing it.
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        let last = s.visible_entries().len() - 1; // == 1 (one ISO + shell)
+        assert!(
+            s.enter_delete(last).is_none(),
+            "rescue-shell row must not be deletable"
+        );
+        assert!(
+            matches!(s.screen, Screen::List { .. }),
+            "screen unchanged when cursor is on a non-deletable row"
+        );
+    }
+
+    #[test]
+    fn cancel_delete_returns_to_list_preserving_cursor() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b")]);
+        let _ = s.enter_delete(1);
+        s.cancel_delete();
+        match s.screen {
+            Screen::List { selected } => assert_eq!(selected, 1, "cursor preserved on cancel"),
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_completed_removes_iso_and_clamps_cursor() {
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
+        // Sort defaults to Name, so visible order is a, b, c, <shell>.
+        let _ = s.enter_delete(2); // pick "c"
+        s.delete_completed();
+        assert_eq!(s.isos.len(), 2, "isos vec shrunk");
+        assert!(
+            s.isos.iter().all(|i| !i.label.contains('c')),
+            "deleted ISO removed from vec"
+        );
+        match s.screen {
+            Screen::List { selected } => {
+                // Visible len now = 2 ISOs + shell = 3; cursor was 2,
+                // new last is 2, so it stays put.
+                assert_eq!(selected, 2);
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_completed_clamps_cursor_when_last_iso_removed() {
+        let mut s = AppState::new(vec![fake_iso("only")]);
+        let _ = s.enter_delete(0);
+        s.delete_completed();
+        // Now list = [<rescue-shell>] only — the synthetic row.
+        match s.screen {
+            Screen::List { selected } => {
+                assert_eq!(
+                    selected, 0,
+                    "cursor clamped to 0 when only the rescue-shell row remains"
+                );
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+        let entries = s.visible_entries();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0], ViewEntry::RescueShell));
+    }
+
+    #[test]
+    fn delete_completed_shifts_cmdline_overrides_for_higher_indices() {
+        // Operator edited cmdline of ISO at idx=2, then deletes ISO at
+        // idx=1. The override must follow the surviving ISO down to
+        // its new position (idx=1), not stay attached to a now-empty
+        // slot or float into a different ISO.
+        let mut s = AppState::new(vec![fake_iso("a"), fake_iso("b"), fake_iso("c")]);
+        s.cmdline_overrides
+            .insert(2, "console=ttyS0".to_string());
+        // sort=Name → visible order matches insertion. enter_delete(1)
+        // picks "b" (real_idx=1 too).
+        let _ = s.enter_delete(1);
+        s.delete_completed();
+        assert_eq!(
+            s.cmdline_overrides.get(&1),
+            Some(&"console=ttyS0".to_string()),
+            "override at idx=2 must shift down to idx=1 after the deletion"
+        );
+        assert!(
+            !s.cmdline_overrides.contains_key(&2),
+            "no stale override at the now-out-of-range idx=2"
+        );
+    }
+
+    #[test]
+    fn record_delete_error_transitions_to_error_screen() {
+        let mut s = AppState::new(vec![fake_iso("a")]);
+        let _ = s.enter_delete(0);
+        s.record_delete_error("read-only filesystem");
+        match s.screen {
+            Screen::Error {
+                message,
+                remedy,
+                return_to,
+            } => {
+                assert!(message.contains("read-only filesystem"));
+                assert_eq!(return_to, 0);
+                assert!(remedy.is_some(), "delete-error always carries remedy");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
     }
 }

--- a/docs/TOUR.md
+++ b/docs/TOUR.md
@@ -145,6 +145,9 @@ screen and focused pane. Press `?` inside the TUI for a help overlay.
 | `/` | List | any | no | Open the substring filter — typed chars match label + path |
 | `s` | List | any | no | Cycle sort order: name → size → distro → name |
 | `v` | List, Confirm | any | no | Re-compute sha256 of the selected ISO in a background thread |
+| `D` | List | List | no | Delete the highlighted ISO + sidecar from the data partition (confirm prompt) |
+| `y` | ConfirmDelete | any | no | Confirm — unlink the ISO and its `.aegis.toml` sidecar |
+| `n/Esc` | ConfirmDelete | any | no | Cancel — return to the list without deleting |
 | `Enter` | List | any | yes | Commit the current filter and close the input |
 | `Esc` | List | any | yes | Close the filter input and clear the current filter |
 | `Enter` | Confirm | any | no | Kexec into the selected ISO (may trigger a trust challenge) |


### PR DESCRIPTION
## Summary

Lets the operator remove an ISO + its `.aegis.toml` sidecar from the data partition without leaving the rescue stick. Pure local file operation — no networking, no signing-chain interaction. The download counterpart (in-rescue ISO fetch over HTTPS) is filed as a separate epic with phased plan because it requires initramfs networking that doesn't exist today.

## UX

`List` screen, list pane focused, cursor on a real ISO row:

```
  Press D → ConfirmDelete overlay:

  ┌─ Confirm delete ─────────────────────────────┐
  │  Delete "Ubuntu Server 24.04.4 LTS"?         │
  │                                              │
  │  Path: /run/media/aegis-isos/ubuntu.iso      │
  │                                              │
  │  This also removes the .aegis.toml sidecar.  │
  │                                              │
  │   [y] delete    [n/Esc] cancel               │
  └──────────────────────────────────────────────┘
```

- `y`/`Y` → unlink + sidecar removal + return to List with cursor clamped to surviving entries
- `n`/`N`/`Esc` → cancel; cursor preserved on the original row
- filesystem err → Error screen with "Delete failed: `<reason>`" plus remedy hint

## Guards

- `D` is only honored when `pane == Pane::List` — muscle-memory keypresses while reading the Info pane do not trigger a destructive prompt.
- `enter_delete` self-rejects `FailedIso` (tier-4) and `RescueShell` rows by returning `None` and leaving the screen unchanged. Only rows backed by a removable on-disk ISO file are deletable.
- After delete: cmdline overrides for the removed index are dropped, AND every override at a higher index is shifted down by one (vec-remove shifts trailing elements). Without the shift, an operator who'd edited cmdline of an ISO past the deleted one would see their edit attached to the wrong row.

## Not touched

`<iso>.sha256` / `<iso>.asc` / `<iso>.minisig` — user-managed upstream sidecars, may be useful for re-verification of a re-downloaded ISO. Symmetric with `aegis-boot add` which only writes the `.aegis.toml`.

## Test plan

- [x] 8 new unit tests in `state::tests`:
  - `enter_delete_transitions_to_confirm_delete_for_real_iso`
  - `enter_delete_returns_none_outside_list_screen`
  - `enter_delete_returns_none_for_rescue_shell_row`
  - `cancel_delete_returns_to_list_preserving_cursor`
  - `delete_completed_removes_iso_and_clamps_cursor`
  - `delete_completed_clamps_cursor_when_last_iso_removed`
  - `delete_completed_shifts_cmdline_overrides_for_higher_indices`
  - `record_delete_error_transitions_to_error_screen`
- [x] Keybindings exhaustiveness test extended to cover `ConfirmDelete`
- [x] 231/231 rescue-tui tests pass (was 223 baseline)
- [x] Local clippy clean: `cargo clippy -p rescue-tui --all-targets -- -D warnings`
- [ ] CI green
- [ ] Maintainer review of the destructive-key choice (`D` capital)

🤖 Generated with [Claude Code](https://claude.com/claude-code)