### PR TITLE
feat(aegis-fetch): shared download + signed-chain verify crate (#655 Phase 2B)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -30,6 +30,13 @@ mis = "mis"
 # (c12a7328-f81f-11d2-ba4b-00a0c93ec93b): `ba4b` triggers a `ba → by/be`
 # flag on pure-substring matching.
 ba4b = "ba4b"
+# Hex prefixes / fragments used in aegis-fetch verify tests
+# (#655 Phase 2B). `ba7816bf` is the canonical SHA-256("abc") test
+# vector; `ba78`/`ba79` are synthetic single-digit-flipped fragments
+# the tamper tests use to invalidate a signed hash.
+ba7816bf = "ba7816bf"
+ba78 = "ba78"
+ba79 = "ba79"
 # Synthetic hardware serial used in init_wizard doc examples.
 AKE74Z1Y00098765 = "AKE74Z1Y00098765"
 # "NAMEs" abbreviated as "NAM" in a comment describing man-page sections.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ version = "0.17.0"
 dependencies = [
  "aegis-catalog",
  "pgp",
+ "rand",
  "sha2 0.10.9",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "bytes",
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aegis-bootctl"
 version = "0.17.0"
 dependencies = [
@@ -34,6 +51,18 @@ name = "aegis-core"
 version = "0.17.0"
 
 [[package]]
+name = "aegis-fetch"
+version = "0.17.0"
+dependencies = [
+ "aegis-catalog",
+ "pgp",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror",
+ "ureq",
+]
+
+[[package]]
 name = "aegis-fitness"
 version = "0.17.0"
 dependencies = [
@@ -62,6 +91,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,10 +146,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -107,6 +249,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,10 +279,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "castaway"
@@ -130,6 +340,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -146,6 +375,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -187,6 +427,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -219,6 +465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,12 +498,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -269,6 +534,59 @@ name = "ct-codecs"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "darling"
@@ -306,12 +624,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -334,6 +703,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -343,6 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -354,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -368,16 +748,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2 0.10.9",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "base64ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "serde_json",
+ "serdect 0.2.0",
+ "subtle",
+ "tap",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -408,6 +881,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +945,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -448,6 +972,27 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -489,6 +1034,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +1050,22 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -511,6 +1081,15 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ident_case"
@@ -627,6 +1206,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +1228,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -651,6 +1253,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -659,10 +1264,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "line-clipping"
@@ -719,6 +1336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aefd422a7a8b5efced01cd7cdf3771e62ebecbc90e3d27695002d3af6af94586"
 dependencies = [
  "ct-codecs",
- "getrandom",
+ "getrandom 0.4.2",
  "rpassword",
  "scrypt",
 ]
@@ -741,6 +1368,16 @@ name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -755,10 +1392,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num_threads"
@@ -770,10 +1485,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -799,6 +1570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,16 +1591,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgp"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64",
+ "bitfields",
+ "block-padding",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "bzip2",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "idea",
+ "k256",
+ "log",
+ "md-5",
+ "nom",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand",
+ "regex",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "sha3",
+ "signature",
+ "smallvec",
+ "snafu",
+ "twofish",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -833,6 +1732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +1748,24 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -865,6 +1791,42 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -959,6 +1921,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1948,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "rescue-tui"
@@ -996,6 +1976,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +2017,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1036,6 +2069,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1099,6 +2167,21 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1171,6 +2254,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+ "zeroize",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +2318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +2335,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1233,6 +2374,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +2420,43 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1315,13 +2509,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1431,6 +2631,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +2718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +2772,56 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "valuable"
@@ -1668,6 +2939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +3041,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1846,6 +3135,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1934,6 +3226,73 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,15 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
-
-[[package]]
 name = "camellia"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,12 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
-
-[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1609,6 @@ dependencies = [
  "buffer-redux",
  "byteorder",
  "bytes",
- "bzip2",
  "camellia",
  "cast5",
  "cfb-mode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/aegis-catalog",
     "crates/aegis-core",
+    "crates/aegis-fetch",
     "crates/iso-parser",
     "crates/iso-probe",
     "crates/rescue-tui",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,49 @@
+# Third-Party Licenses
+
+aegis-boot ships under the dual `MIT OR Apache-2.0` outbound
+license. This file inventories notable third-party dependencies
+that contribute distinctive licenses or that warrant explicit
+attribution.
+
+The full transitive license graph is enforced by `cargo-deny`
+against the allow-list in `deny.toml`. CI fails the build on any
+crate whose license is not in that allow-list. This document
+covers the human-readable rationale for each non-permissive
+license and for the cryptographic-trust-path crates.
+
+## Cryptographic trust path (#655 aegis-fetch)
+
+The `aegis-fetch` crate downloads + verifies catalog ISOs against
+vendor PGP signatures. Its dependencies include:
+
+| Crate           | License           | Notes                                                                                     |
+| --------------- | ----------------- | ----------------------------------------------------------------------------------------- |
+| `pgp` (rpgp)    | MIT OR Apache-2.0 | Pure-Rust OpenPGP implementation. Verify-only consumer; we never sign or encrypt with it. |
+| `ureq`          | MIT OR Apache-2.0 | HTTPS transport with `https_only(true)` enforcement.                                      |
+| `rustls`        | Apache-2.0 OR ISC OR MIT | TLS 1.3 implementation. Pulled in via ureq's `rustls` feature.                      |
+| `ring`          | Apache-2.0 + ISC + OpenSSL  | Crypto primitives backing rustls. Mixed-license; the Apache-2.0 portion is the dominant component for our usage. |
+| `webpki-roots`  | (code) ISC; (data) CDLA-Permissive-2.0 | Mozilla CA root certificate bundle. The data-license split is intentional upstream — the cert bundle data is published under the Linux Foundation's permissive data license; the crate code itself remains ISC. |
+| `sha2`          | MIT OR Apache-2.0 | SHA-256 of the downloaded ISO.                                                            |
+| `webpki`        | ISC               | X.509 path validation used by rustls.                                                     |
+
+We picked `pgp` (rpgp) over `sequoia-openpgp` for licensing
+compatibility: sequoia is `LGPL-2.0-or-later`, which `deny.toml`
+explicitly excludes from the workspace's allow-list (LGPL §6
+imposes "object file" disclosure obligations on every static-musl
+rescue-tui binary we ship). rpgp's `MIT OR Apache-2.0` is the
+clean fit. See `crates/aegis-fetch/README.md` for the API
+contract.
+
+## Allow-listed licenses (deny.toml)
+
+The full allow-list is in `deny.toml`. Inclusion criteria:
+permissive, statically-link-friendly, and either OSI-approved or
+documented above with a rationale.
+
+## Updates
+
+When a new third-party dependency is added that ships under a
+license not already in `deny.toml`, the PR adding the dependency
+must also update both `deny.toml` (the enforcement) and this
+file (the human-readable rationale). The CI license gate fails
+the build until the policy update lands.

--- a/crates/aegis-catalog/src/lib.rs
+++ b/crates/aegis-catalog/src/lib.rs
@@ -115,6 +115,136 @@ impl Category {
     }
 }
 
+/// Cryptographic signature-verification pattern an [`Entry`] expects.
+///
+/// Distros publish three distinct shapes today, all driven by the
+/// same `iso_url` / `sha256_url` / `sig_url` triple but with
+/// different semantics for what the signature actually authenticates:
+///
+/// - [`SigPattern::ClearsignedSums`] — the SUMS file is a PGP
+///   cleartext-signed envelope (RFC 9580 §7) wrapping the
+///   plaintext checksum lines. `sha256_url == sig_url` for these
+///   entries because the signature is embedded in the file. Used
+///   by `AlmaLinux`, Fedora, Rocky.
+/// - [`SigPattern::DetachedSigOnSums`] — `sig_url` is a detached
+///   binary or armored signature over the SUMS file. `sha256_url
+///   != sig_url`. Used by Debian, Ubuntu, Kali, Linux Mint,
+///   `GParted`, openSUSE, Pop!\_OS.
+/// - [`SigPattern::DetachedSigOnIso`] — `sig_url` is a detached
+///   signature over the ISO bytes themselves; the `.sha256`
+///   sidecar is unsigned and used only for byte-integrity
+///   reporting. Used by Alpine, Manjaro, MX Linux, `SystemRescue`.
+///
+/// `aegis-fetch` dispatches on this enum exhaustively. Choosing
+/// the wrong variant verifies the signature against the wrong
+/// bytes and silently downgrades trust, so the field is required
+/// (no `Default`) and the variant is reviewed on every catalog
+/// addition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigPattern {
+    /// Signature is embedded in the SUMS file as a PGP cleartext
+    /// envelope. `sha256_url == sig_url`.
+    ClearsignedSums,
+    /// Signature is a separate file authenticating the SUMS file.
+    /// `sha256_url != sig_url`; both URLs must be fetched.
+    DetachedSigOnSums,
+    /// Signature is a separate file authenticating the ISO itself.
+    /// The `sha256_url` sidecar (when present) is unsigned and
+    /// informational; the cryptographic gate is the ISO signature.
+    DetachedSigOnIso,
+}
+
+/// Identifier for the project / organization that signed an
+/// [`Entry`]'s release artifacts. Drives keyring lookup in
+/// `aegis-fetch` — each variant maps to a single PGP cert in
+/// `crates/aegis-catalog/keyring/<slug>.asc` whose fingerprint is
+/// pinned in `crates/aegis-catalog/keyring/fingerprints.toml`.
+///
+/// New variants are added in the same PR that adds the
+/// corresponding `<slug>.asc` keyring file. The lockstep is
+/// enforced by a unit test that asserts every catalog entry's
+/// vendor has a keyring file present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Vendor {
+    /// `AlmaLinux` — RHEL rebuild signed by the `AlmaLinux` release key.
+    AlmaLinux,
+    /// Alpine Linux — signed by the Alpine release key.
+    Alpine,
+    /// Debian — signed by the Debian CD-signing key.
+    Debian,
+    /// Fedora — signed by the Fedora release-signing key.
+    Fedora,
+    /// `GParted` Live — signed by the `GParted` release key (Curtis Gedak).
+    Gparted,
+    /// Kali Linux — signed by the Kali release-signing key.
+    Kali,
+    /// Linux Mint — signed by the Linux Mint release key.
+    LinuxMint,
+    /// Manjaro Linux — signed by the Manjaro release-signing key.
+    Manjaro,
+    /// MX Linux — signed by the MX Linux release key.
+    Mx,
+    /// openSUSE — signed by the openSUSE project signing key.
+    Opensuse,
+    /// Rocky Linux — RHEL rebuild signed by the Rocky release key.
+    Rocky,
+    /// `SystemRescue` — signed by the `SystemRescue` release key.
+    SystemRescue,
+    /// System76 — signs Pop!_OS releases.
+    System76,
+    /// Ubuntu — signed by the Ubuntu CD-signing key (Canonical).
+    Ubuntu,
+}
+
+impl Vendor {
+    /// Stable lowercase slug used as the keyring filename stem
+    /// (`<slug>.asc` and `<slug>.txt`) and as the
+    /// `fingerprints.toml` table key.
+    #[must_use]
+    pub fn slug(self) -> &'static str {
+        match self {
+            Vendor::AlmaLinux => "almalinux",
+            Vendor::Alpine => "alpine",
+            Vendor::Debian => "debian",
+            Vendor::Fedora => "fedora",
+            Vendor::Gparted => "gparted",
+            Vendor::Kali => "kali",
+            Vendor::LinuxMint => "linuxmint",
+            Vendor::Manjaro => "manjaro",
+            Vendor::Mx => "mx",
+            Vendor::Opensuse => "opensuse",
+            Vendor::Rocky => "rocky",
+            Vendor::SystemRescue => "system-rescue",
+            Vendor::System76 => "system76",
+            Vendor::Ubuntu => "ubuntu",
+        }
+    }
+
+    /// All vendors currently referenced by the catalog. Used by
+    /// the keyring loader test to assert every vendor has a
+    /// keyring file present, and by the catalog-refresh
+    /// workflow to iterate the upstream key fetch loop.
+    #[must_use]
+    pub fn all() -> &'static [Vendor] {
+        &[
+            Vendor::AlmaLinux,
+            Vendor::Alpine,
+            Vendor::Debian,
+            Vendor::Fedora,
+            Vendor::Gparted,
+            Vendor::Kali,
+            Vendor::LinuxMint,
+            Vendor::Manjaro,
+            Vendor::Mx,
+            Vendor::Opensuse,
+            Vendor::Rocky,
+            Vendor::SystemRescue,
+            Vendor::System76,
+            Vendor::Ubuntu,
+        ]
+    }
+}
+
 /// One catalog entry.
 pub struct Entry {
     /// Stable slug operators type: `ubuntu-24.04-live-server`.
@@ -137,6 +267,13 @@ pub struct Entry {
     pub purpose: &'static str,
     /// Operator-facing usage category — drives `recommend` table grouping.
     pub category: Category,
+    /// Project / organization whose PGP key signs this entry's
+    /// release artifacts. Drives keyring lookup in `aegis-fetch`.
+    pub vendor: Vendor,
+    /// Cryptographic shape of the signature for this entry. See
+    /// [`SigPattern`] for the three patterns. `aegis-fetch`
+    /// dispatches verify behavior exhaustively on this field.
+    pub verify: SigPattern,
     /// Optional URL resolver that walks the project's directory
     /// listing or follows a "latest" redirect to discover the current
     /// ISO filename + sibling SHA / sig URLs (#646). Used by
@@ -520,6 +657,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Red Hat / AlmaLinux"),
         purpose: "Free RHEL-rebuild minimal installer. Cross-distro kexec quirk possible.",
         category: Category::Installer,
+        vendor: Vendor::AlmaLinux,
+        verify: SigPattern::ClearsignedSums,
         resolver: None,
     },
     Entry {
@@ -533,6 +672,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Minimal recovery / forensic shell. Tiny footprint.",
         category: Category::Rescue,
+        vendor: Vendor::Alpine,
+        verify: SigPattern::DetachedSigOnIso,
         resolver: None,
     },
     Entry {
@@ -546,6 +687,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Minimal recovery shell for arm64 hosts (Pi 4/5, ARM servers).",
         category: Category::Rescue,
+        vendor: Vendor::Alpine,
+        verify: SigPattern::DetachedSigOnIso,
         resolver: None,
     },
     Entry {
@@ -563,6 +706,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Debian CA via shim"),
         purpose: "Minimal Debian network installer. DistroWatch top-5 popularity.",
         category: Category::Installer,
+        vendor: Vendor::Debian,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: Some(debian_netinst),
     },
     Entry {
@@ -576,6 +721,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Debian CA via shim"),
         purpose: "Debian network installer for arm64 (Pi, ARM servers, AWS Graviton).",
         category: Category::Installer,
+        vendor: Vendor::Debian,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: None,
     },
     Entry {
@@ -589,6 +736,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Red Hat / Fedora"),
         purpose: "Fedora server install media (full DVD; non-live).",
         category: Category::Server,
+        vendor: Vendor::Fedora,
+        verify: SigPattern::ClearsignedSums,
         resolver: None,
     },
     Entry {
@@ -605,6 +754,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Red Hat / Fedora"),
         purpose: "Fedora desktop live ISO. Cross-distro kexec quirk possible.",
         category: Category::Desktop,
+        vendor: Vendor::Fedora,
+        verify: SigPattern::ClearsignedSums,
         resolver: None,
     },
     Entry {
@@ -618,6 +769,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Red Hat / Fedora"),
         purpose: "Fedora desktop live ISO for arm64 (Pi, ARM laptops).",
         category: Category::Desktop,
+        vendor: Vendor::Fedora,
+        verify: SigPattern::ClearsignedSums,
         resolver: None,
     },
     Entry {
@@ -633,6 +786,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Debian shim chain (GParted)"),
         purpose: "Partition editor live ISO. Resize, repair, image disks.",
         category: Category::Rescue,
+        vendor: Vendor::Gparted,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: None,
     },
     Entry {
@@ -651,6 +806,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Kali / Debian shim chain"),
         purpose: "Pentesting + forensics installer. Debian-derived signed chain.",
         category: Category::Installer,
+        vendor: Vendor::Kali,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: Some(kali_installer),
     },
     Entry {
@@ -666,6 +823,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Linux Mint"),
         purpose: "Friendly Ubuntu-derived desktop. Common operator install target.",
         category: Category::Desktop,
+        vendor: Vendor::LinuxMint,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: Some(linuxmint_22_cinnamon),
     },
     Entry {
@@ -682,6 +841,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Arch-derived rolling release with KDE Plasma. Unsigned kernel.",
         category: Category::Desktop,
+        vendor: Vendor::Manjaro,
+        verify: SigPattern::DetachedSigOnIso,
         resolver: None,
     },
     Entry {
@@ -696,6 +857,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Debian shim chain (MX kernel)"),
         purpose: "Debian-based Xfce desktop with newer kernel. Top-3 popularity.",
         category: Category::Desktop,
+        vendor: Vendor::Mx,
+        verify: SigPattern::DetachedSigOnIso,
         resolver: None,
     },
     Entry {
@@ -710,6 +873,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("SUSE CA"),
         purpose: "Enterprise-derived stable distribution. Full DVD installer.",
         category: Category::Installer,
+        vendor: Vendor::Opensuse,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: None,
     },
     Entry {
@@ -726,6 +891,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("System76 / Canonical CA"),
         purpose: "Ubuntu-derived desktop tuned for System76 hardware.",
         category: Category::Desktop,
+        vendor: Vendor::System76,
+        verify: SigPattern::DetachedSigOnSums,
         // No resolver yet: iso.pop-os.org returns HTTP 403 on
         // directory listings (nginx autoindex off). Tracked under #646.
         resolver: None,
@@ -742,6 +909,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Rocky Linux"),
         purpose: "Free RHEL-rebuild minimal installer. Cross-distro kexec quirk possible.",
         category: Category::Installer,
+        vendor: Vendor::Rocky,
+        verify: SigPattern::ClearsignedSums,
         resolver: None,
     },
     Entry {
@@ -760,6 +929,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::UnsignedNeedsMok,
         purpose: "Comprehensive rescue toolkit: parted, testdisk, ddrescue, clamav.",
         category: Category::Rescue,
+        vendor: Vendor::SystemRescue,
+        verify: SigPattern::DetachedSigOnIso,
         resolver: None,
     },
     Entry {
@@ -775,6 +946,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS server installer. Validated under aegis-boot v0.12.0 #109.",
         category: Category::Server,
+        vendor: Vendor::Ubuntu,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: Some(ubuntu_24_04_live_server),
     },
     Entry {
@@ -789,6 +962,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS server installer for arm64 (Graviton, Ampere, Pi 4/5).",
         category: Category::Server,
+        vendor: Vendor::Ubuntu,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: None,
     },
     Entry {
@@ -802,6 +977,8 @@ pub const CATALOG: &[Entry] = &[
         sb: SbStatus::Signed("Canonical CA"),
         purpose: "Ubuntu LTS desktop installer. >4 GB → requires ext4 data partition.",
         category: Category::Desktop,
+        vendor: Vendor::Ubuntu,
+        verify: SigPattern::DetachedSigOnSums,
         resolver: Some(ubuntu_24_04_desktop),
     },
 ];
@@ -1095,6 +1272,75 @@ mod tests {
             .err()
             .unwrap_or_else(|| panic!("should fail"));
         assert!(matches!(err, ResolverError::NoMatch { .. }));
+    }
+
+    // ---- SigPattern / Vendor coherence --------------------------
+
+    #[test]
+    fn every_entry_has_sigpattern_consistent_with_url_shape() {
+        // Cross-check the explicit `verify` field against the URL
+        // triple's observable shape today. Drift here means a vendor
+        // changed their layout or a new entry was tagged with the
+        // wrong pattern — either way the trust path needs review,
+        // not silent re-classification.
+        for e in CATALOG {
+            let iso_filename = e.iso_url.rsplit('/').next().unwrap_or("");
+            let sums_eq_sig = e.sha256_url == e.sig_url;
+            let sig_targets_iso = !iso_filename.is_empty()
+                && (e.sig_url.ends_with(&format!("{iso_filename}.asc"))
+                    || e.sig_url.ends_with(&format!("{iso_filename}.sig")));
+            match e.verify {
+                SigPattern::ClearsignedSums => assert!(
+                    sums_eq_sig,
+                    "{} declared ClearsignedSums but sha256_url != sig_url",
+                    e.slug
+                ),
+                SigPattern::DetachedSigOnIso => assert!(
+                    sig_targets_iso && !sums_eq_sig,
+                    "{} declared DetachedSigOnIso but sig_url does not target the ISO filename",
+                    e.slug
+                ),
+                SigPattern::DetachedSigOnSums => assert!(
+                    !sums_eq_sig && !sig_targets_iso,
+                    "{} declared DetachedSigOnSums but URL shape suggests another pattern",
+                    e.slug
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn every_vendor_in_catalog_is_in_vendor_all() {
+        // Vendor::all() drives the keyring loader test (#655 PR-B)
+        // and the catalog-refresh fetch loop. Any catalog entry
+        // tagged with a Vendor must appear in all() so the
+        // upstream fetch loop can iterate over every vendor we ship.
+        use std::collections::HashSet;
+        let referenced: HashSet<Vendor> = CATALOG.iter().map(|e| e.vendor).collect();
+        let listed: HashSet<Vendor> = Vendor::all().iter().copied().collect();
+        for v in &referenced {
+            assert!(
+                listed.contains(v),
+                "Vendor {v:?} is used in CATALOG but not in Vendor::all()"
+            );
+        }
+    }
+
+    #[test]
+    fn vendor_slugs_are_distinct_kebab_case() {
+        let mut slugs: Vec<&str> = Vendor::all().iter().map(|v| v.slug()).collect();
+        slugs.sort_unstable();
+        let pre = slugs.len();
+        slugs.dedup();
+        assert_eq!(pre, slugs.len(), "duplicate Vendor::slug()");
+        for s in Vendor::all().iter().map(|v| v.slug()) {
+            assert!(!s.is_empty(), "empty vendor slug");
+            assert!(
+                s.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "vendor slug not kebab-case: {s}"
+            );
+        }
     }
 
     #[test]

--- a/crates/aegis-fetch/Cargo.toml
+++ b/crates/aegis-fetch/Cargo.toml
@@ -33,6 +33,11 @@ sha2 = "0.10"
 [dev-dependencies]
 # Hermetic fixture I/O for the verify-path tests.
 tempfile = "3.14"
+# Used by verify-path tests to generate Ed25519 test certs at
+# runtime, so signed fixtures don't need to be checked into git.
+# rpgp re-exports its own `rand` types but the keygen API takes
+# any RngCore + CryptoRng, so we bring the trait directly.
+rand = "0.8"
 
 [lints]
 workspace = true

--- a/crates/aegis-fetch/Cargo.toml
+++ b/crates/aegis-fetch/Cargo.toml
@@ -25,7 +25,13 @@ ureq = { version = "3.3", default-features = false, features = ["rustls"] }
 # outbound dual license without LGPL static-linking obligations.
 # See project_aegis_fetch_design_decisions for why this is rpgp
 # rather than sequoia-openpgp.
-pgp = "0.19"
+#
+# default-features = false drops the `bzip2` feature, which would
+# otherwise pull in `libbz2-rs-sys` (`bzip2-1.0.6` license — not
+# in deny.toml allow-list). aegis-fetch is verify-only on
+# clearsigned + detached signatures; OpenPGP message
+# decompression isn't part of that path.
+pgp = { version = "0.19", default-features = false }
 
 # SHA-256 for the sha256_url verification step. MIT OR Apache-2.0.
 sha2 = "0.10"

--- a/crates/aegis-fetch/Cargo.toml
+++ b/crates/aegis-fetch/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "aegis-fetch"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HTTPS download + signed-chain verification for aegis-boot catalog ISOs (#655 Phase 2B). Shared by the host CLI and the rescue-tui in-rescue fetch path."
+readme = "README.md"
+
+include = ["src/**/*", "README.md", "Cargo.toml"]
+
+[lib]
+
+[dependencies]
+aegis-catalog = { path = "../aegis-catalog" }
+thiserror = { workspace = true }
+
+# HTTPS via rustls + ring. default-features = false drops gzip
+# decompression we don't need for ISO downloads (vendors serve
+# binary content uncompressed).
+ureq = { version = "3.3", default-features = false, features = ["rustls"] }
+
+# Pure-Rust OpenPGP impl. MIT OR Apache-2.0 — fits the workspace
+# outbound dual license without LGPL static-linking obligations.
+# See project_aegis_fetch_design_decisions for why this is rpgp
+# rather than sequoia-openpgp.
+pgp = "0.19"
+
+# SHA-256 for the sha256_url verification step. MIT OR Apache-2.0.
+sha2 = "0.10"
+
+[dev-dependencies]
+# Hermetic fixture I/O for the verify-path tests.
+tempfile = "3.14"
+
+[lints]
+workspace = true

--- a/crates/aegis-fetch/README.md
+++ b/crates/aegis-fetch/README.md
@@ -1,0 +1,50 @@
+# aegis-fetch
+
+HTTPS download + signed-chain verification for aegis-boot catalog ISOs.
+Shared by the host CLI (`aegis-boot fetch <slug>`) and the rescue-tui's
+in-rescue Catalog screen (#655 Phase 2B).
+
+## Trust model
+
+Each fetch performs three steps:
+
+1. HTTPS GET the ISO + its signature artifacts from `aegis_catalog::Entry`.
+2. Verify the OpenPGP signature against the pinned vendor cert in
+   `crates/aegis-catalog/keyring/<vendor>.asc` (fingerprint pinned in
+   `fingerprints.toml`).
+3. SHA-256 the ISO bytes and match against the (now authenticated)
+   sums file.
+
+Three signature shapes are dispatched on `aegis_catalog::SigPattern`:
+
+- `ClearsignedSums` — sums file is a PGP cleartext envelope; signature
+  authenticates the inline checksum lines (AlmaLinux, Fedora, Rocky).
+- `DetachedSigOnSums` — `.gpg` / `.sign` / `.asc` separate file
+  authenticates the sums file, sums then authenticates the ISO
+  (Debian, Ubuntu, Kali, Linux Mint, GParted, openSUSE, Pop!_OS).
+- `DetachedSigOnIso` — sig directly authenticates the ISO bytes
+  (Alpine, Manjaro, MX Linux, SystemRescue).
+
+## Public API
+
+```rust
+use aegis_fetch::{fetch_catalog_entry, FetchEvent, VendorKeyring};
+
+let keyring = VendorKeyring::embedded()?;
+let outcome = fetch_catalog_entry(
+    entry,
+    &dest_dir,
+    &keyring,
+    &mut |event| match event {
+        FetchEvent::Downloading(p) => render_progress(p),
+        FetchEvent::VerifyingSig => println!("verifying signature..."),
+        _ => {}
+    },
+)?;
+println!("verified: {}", outcome.iso_path.display());
+```
+
+## License
+
+MIT OR Apache-2.0. See `THIRD_PARTY_LICENSES.md` at the workspace
+root for the licenses of bundled crypto dependencies.

--- a/crates/aegis-fetch/src/download.rs
+++ b/crates/aegis-fetch/src/download.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! HTTPS GET with progress callbacks.
+//!
+//! [`download_to_file`] streams a response into a file, calling
+//! `on_event(Downloading)` per chunk. [`download_to_vec`] reads
+//! the entire body into memory — used for SHA256SUMS / signature
+//! sidecars whose payloads are KB-scale.
+//!
+//! ## Trust posture
+//!
+//! - `https_only(true)` — rejects `http://` URLs at the request
+//!   level AND across the redirect chain. A vendor redirecting
+//!   from HTTPS to HTTP fails the fetch loudly.
+//! - `max_redirects(10)` — most distro mirrors redirect through
+//!   1-3 hops (e.g., `download.fedoraproject.org` → mirror); 10
+//!   is room for outliers without enabling a redirect-spam attack.
+//! - Generous request timeout: ISO downloads on slow links can
+//!   take many minutes. We set the connect timeout tight (30 s)
+//!   but leave the body-read timeout generous (no fixed cap; the
+//!   stall-detection comes from the missing-progress signal at
+//!   the rescue-tui UI layer).
+//! - Maximum body size is set to [`u64::MAX`] for the ISO path —
+//!   ureq's default is a 10 MB cap that would truncate every
+//!   real catalog ISO. The sidecar path keeps the default.
+
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use ureq::Agent;
+
+use crate::{FetchError, FetchEvent, FetchProgress};
+
+/// Identical 1 MiB chunk size as the SHA-256 hasher; keeps the
+/// progress-callback cadence consistent across phases.
+const CHUNK_BYTES: usize = 1 << 20;
+
+/// Build the HTTPS-only ureq agent used by both download paths.
+fn build_agent() -> Agent {
+    Agent::config_builder()
+        .https_only(true)
+        .max_redirects(10)
+        .max_redirects_will_error(true)
+        .timeout_connect(Some(Duration::from_secs(30)))
+        .build()
+        .into()
+}
+
+/// Stream `url` into `dest`, calling `on_event(Downloading(...))`
+/// per chunk. Returns the total bytes written.
+///
+/// # Errors
+///
+/// - [`FetchError::Network`] for transport / non-2xx / redirect-
+///   to-http failures.
+/// - [`FetchError::Filesystem`] for create/write/sync errors on
+///   `dest`. On error the partial file is left in place — caller
+///   chooses whether to retain (Phase 3 resume) or remove.
+pub(crate) fn download_to_file(
+    url: &str,
+    dest: &Path,
+    on_event: &mut dyn FnMut(FetchEvent),
+) -> Result<u64, FetchError> {
+    on_event(FetchEvent::Connecting);
+    let agent = build_agent();
+    let mut resp = agent.get(url).call().map_err(|e| FetchError::Network {
+        url: url.to_string(),
+        detail: format!("{e}"),
+    })?;
+    let total = resp.body().content_length();
+    let reader = resp.body_mut().with_config().limit(u64::MAX).reader();
+    let file = File::create(dest).map_err(|e| FetchError::Filesystem {
+        detail: format!("create {}: {e}", dest.display()),
+    })?;
+    let written = pump_to_writer(reader, BufWriter::new(file), total, on_event, dest)?;
+    Ok(written)
+}
+
+/// Read `url`'s body into a `Vec<u8>`. Used for sums/signature
+/// sidecars whose payloads are small. Caps the body at 4 MiB —
+/// signed sums files are typically < 100 KB.
+///
+/// # Errors
+///
+/// [`FetchError::Network`] for transport / size-limit / non-2xx.
+pub(crate) fn download_to_vec(url: &str) -> Result<Vec<u8>, FetchError> {
+    let agent = build_agent();
+    let mut resp = agent.get(url).call().map_err(|e| FetchError::Network {
+        url: url.to_string(),
+        detail: format!("{e}"),
+    })?;
+    resp.body_mut()
+        .with_config()
+        .limit(4 * 1024 * 1024)
+        .read_to_vec()
+        .map_err(|e| FetchError::Network {
+            url: url.to_string(),
+            detail: format!("read body: {e}"),
+        })
+}
+
+/// Pump bytes from `reader` to `writer` in 1 MiB chunks, emitting
+/// progress events. Hermetically testable — no network involved.
+fn pump_to_writer<R: Read, W: Write>(
+    mut reader: R,
+    mut writer: W,
+    total: Option<u64>,
+    on_event: &mut dyn FnMut(FetchEvent),
+    dest: &Path,
+) -> Result<u64, FetchError> {
+    let mut buf = vec![0u8; CHUNK_BYTES];
+    let mut written: u64 = 0;
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| FetchError::Network {
+            url: dest.display().to_string(),
+            detail: format!("read body: {e}"),
+        })?;
+        if n == 0 {
+            break;
+        }
+        writer
+            .write_all(&buf[..n])
+            .map_err(|e| FetchError::Filesystem {
+                detail: format!("write {}: {e}", dest.display()),
+            })?;
+        written += n as u64;
+        on_event(FetchEvent::Downloading(FetchProgress {
+            bytes: written,
+            total,
+        }));
+    }
+    writer.flush().map_err(|e| FetchError::Filesystem {
+        detail: format!("flush {}: {e}", dest.display()),
+    })?;
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn pump_writes_all_bytes_and_emits_progress() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("dl");
+        // Three full chunks plus a partial.
+        let payload: Vec<u8> = (0..(CHUNK_BYTES * 3 + 17))
+            .map(|i| u8::try_from(i & 0xff).unwrap_or(0))
+            .collect();
+        let cursor = Cursor::new(payload.clone());
+        let file = File::create(&dest).expect("create");
+        let mut events: Vec<FetchEvent> = Vec::new();
+        let mut on_event = |e: FetchEvent| events.push(e);
+        let n = pump_to_writer(
+            cursor,
+            BufWriter::new(file),
+            Some(payload.len() as u64),
+            &mut on_event,
+            &dest,
+        )
+        .expect("pump");
+        assert_eq!(n, payload.len() as u64);
+        // File on disk matches.
+        let on_disk = std::fs::read(&dest).expect("read");
+        assert_eq!(on_disk, payload);
+        // Progress events: at least 4 (3 full + 1 partial).
+        let downloading: Vec<&FetchProgress> = events
+            .iter()
+            .filter_map(|e| match e {
+                FetchEvent::Downloading(p) => Some(p),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            downloading.len() >= 4,
+            "expected >=4 progress events, got {}",
+            downloading.len()
+        );
+        assert_eq!(downloading.last().expect("at least one").bytes, n);
+        for p in &downloading {
+            assert_eq!(p.total, Some(payload.len() as u64));
+        }
+        // Monotonic.
+        for w in downloading.windows(2) {
+            assert!(w[0].bytes <= w[1].bytes);
+        }
+    }
+
+    #[test]
+    fn pump_zero_bytes_emits_no_downloading_events() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("dl");
+        let cursor: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let file = File::create(&dest).expect("create");
+        let mut events: Vec<FetchEvent> = Vec::new();
+        let mut on_event = |e: FetchEvent| events.push(e);
+        let n = pump_to_writer(cursor, BufWriter::new(file), Some(0), &mut on_event, &dest)
+            .expect("pump");
+        assert_eq!(n, 0);
+        let downloading = events
+            .iter()
+            .filter(|e| matches!(e, FetchEvent::Downloading(_)))
+            .count();
+        assert_eq!(downloading, 0);
+    }
+
+    #[test]
+    fn pump_with_unknown_total_still_emits_progress() {
+        // Chunked / streaming responses have no Content-Length;
+        // progress events still fire with `total: None`.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("dl");
+        let payload: Vec<u8> = (0..CHUNK_BYTES + 5).map(|_| 0u8).collect();
+        let cursor = Cursor::new(payload.clone());
+        let file = File::create(&dest).expect("create");
+        let mut downloading_seen = 0u32;
+        let mut totals: Vec<Option<u64>> = Vec::new();
+        let mut on_event = |e: FetchEvent| {
+            if let FetchEvent::Downloading(p) = e {
+                downloading_seen += 1;
+                totals.push(p.total);
+            }
+        };
+        let _ =
+            pump_to_writer(cursor, BufWriter::new(file), None, &mut on_event, &dest).expect("pump");
+        assert!(downloading_seen >= 2);
+        assert!(totals.iter().all(Option::is_none));
+    }
+}

--- a/crates/aegis-fetch/src/keyring.rs
+++ b/crates/aegis-fetch/src/keyring.rs
@@ -131,7 +131,6 @@ impl VendorKeyring {
     pub fn is_empty(&self) -> bool {
         self.armored.is_empty()
     }
-
 }
 
 impl Default for VendorKeyring {

--- a/crates/aegis-fetch/src/keyring.rs
+++ b/crates/aegis-fetch/src/keyring.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Vendor public-key registry consumed by the verify path.
+//!
+//! A [`VendorKeyring`] is a map from [`aegis_catalog::Vendor`] →
+//! parsed PGP cert. It's constructed once per process and passed
+//! by reference into [`crate::fetch_catalog_entry`].
+//!
+//! ## Sources
+//!
+//! Three constructors:
+//!
+//! - [`VendorKeyring::embedded`] — loads keys baked into the
+//!   binary at compile time via `include_bytes!`. This is the
+//!   production path used by both `aegis-cli` and `rescue-tui`.
+//!   Empty stub until #655 PR-B populates the keyring.
+//! - [`VendorKeyring::from_dir`] — loads keys from a directory of
+//!   `<vendor>.asc` files at runtime. Used by the
+//!   catalog-refresh GitHub Action to validate a freshly-fetched
+//!   keyring before opening the auto-PR.
+//! - [`VendorKeyring::empty`] — for tests; subsequent commits in
+//!   this PR add a `pub(crate)` cert-injection helper for the
+//!   verify-path fixture tests.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use aegis_catalog::Vendor;
+
+use crate::FetchError;
+
+/// Map from [`Vendor`] → its pinned PGP cert.
+///
+/// Constructed once per process, then passed into the fetch
+/// pipeline by reference. Cert bytes are kept in memory; rpgp
+/// re-parses for each verification (cheap relative to the
+/// signature verification itself).
+pub struct VendorKeyring {
+    /// Raw ASCII-armored cert bytes per vendor. Stored armored so
+    /// the rpgp parser can re-deserialize on each verify call;
+    /// keeping a parsed `SignedPublicKey` here would force the
+    /// rpgp type into our public API, which we want to avoid for
+    /// API-stability reasons.
+    armored: HashMap<Vendor, Vec<u8>>,
+}
+
+impl VendorKeyring {
+    /// Construct an empty keyring. Production callers should use
+    /// [`VendorKeyring::embedded`] or [`VendorKeyring::from_dir`].
+    /// Tests use this together with the `pub(crate)` injection
+    /// helper added in the verify-path commit.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            armored: HashMap::new(),
+        }
+    }
+
+    /// Load the keyring baked into the binary at compile time via
+    /// `include_bytes!`. This is the production path.
+    ///
+    /// Until #655 PR-B populates `crates/aegis-catalog/keyring/`,
+    /// this returns an empty keyring — meaning every fetch in this
+    /// build will fail with [`FetchError::UnknownVendor`]. The
+    /// scaffold exists so the public API can be reviewed
+    /// independently of the keyring rollout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FetchError::Filesystem`] only when an embedded
+    /// keyring exists but is malformed. The empty case is
+    /// `Ok(Self::empty())`.
+    pub fn embedded() -> Result<Self, FetchError> {
+        // PR-B will replace this with a static array of
+        // (Vendor, &'static [u8]) pairs from include_bytes!.
+        Ok(Self::empty())
+    }
+
+    /// Load the keyring from a directory containing one
+    /// `<vendor>.asc` file per [`Vendor::all`] entry. Missing
+    /// files are tolerated (recorded as absent vendors); malformed
+    /// armor surfaces as a parse error.
+    ///
+    /// # Errors
+    ///
+    /// [`FetchError::Filesystem`] for I/O failures. A file that
+    /// doesn't parse as ASCII-armored PGP is logged but does not
+    /// fail the load — verification using that vendor will
+    /// surface the parse error at fetch time. (This makes
+    /// sub-vendor key rotations recoverable without bricking the
+    /// whole keyring.)
+    pub fn from_dir(dir: &Path) -> Result<Self, FetchError> {
+        let mut armored = HashMap::new();
+        for vendor in Vendor::all() {
+            let path = dir.join(format!("{}.asc", vendor.slug()));
+            match std::fs::read(&path) {
+                Ok(bytes) => {
+                    armored.insert(*vendor, bytes);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // Tolerated — vendor not yet rolled out.
+                }
+                Err(e) => {
+                    return Err(FetchError::Filesystem {
+                        detail: format!("read {}: {e}", path.display()),
+                    });
+                }
+            }
+        }
+        Ok(Self { armored })
+    }
+
+    /// Look up the armored cert bytes for a vendor. Returns
+    /// `None` when the vendor has no entry in this keyring.
+    #[must_use]
+    pub fn cert_armor(&self, vendor: Vendor) -> Option<&[u8]> {
+        self.armored.get(&vendor).map(Vec::as_slice)
+    }
+
+    /// Number of vendors with a cert in this keyring. Useful for
+    /// audit logs and the `aegis-boot doctor` keyring health
+    /// reporter.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.armored.len()
+    }
+
+    /// True when no vendor has a cert in this keyring. Equivalent
+    /// to `len() == 0`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.armored.is_empty()
+    }
+
+}
+
+impl Default for VendorKeyring {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn empty_is_empty() {
+        let k = VendorKeyring::empty();
+        assert!(k.is_empty());
+        assert_eq!(k.len(), 0);
+        assert!(k.cert_armor(Vendor::Ubuntu).is_none());
+    }
+
+    #[test]
+    fn embedded_returns_empty_until_pr_b() {
+        let k = VendorKeyring::embedded().expect("embedded ok");
+        assert!(k.is_empty(), "PR-B will populate this");
+    }
+
+    #[test]
+    fn from_dir_handles_missing_directory_gracefully() {
+        // `Vendor::all` returns 14 entries; from_dir against a
+        // missing dir reads zero of them and returns an empty
+        // keyring. The directory-doesn't-exist case is the same
+        // as every-vendor-file-missing.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let k = VendorKeyring::from_dir(dir.path()).expect("load ok");
+        assert!(k.is_empty());
+    }
+
+    #[test]
+    fn from_dir_loads_present_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Ubuntu's keyring file present, Debian's absent.
+        let path = dir.path().join("ubuntu.asc");
+        std::fs::write(
+            &path,
+            b"-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        )
+        .expect("write");
+        let k = VendorKeyring::from_dir(dir.path()).expect("load ok");
+        assert_eq!(k.len(), 1);
+        assert!(k.cert_armor(Vendor::Ubuntu).is_some());
+        assert!(k.cert_armor(Vendor::Debian).is_none());
+    }
+}

--- a/crates/aegis-fetch/src/lib.rs
+++ b/crates/aegis-fetch/src/lib.rs
@@ -42,6 +42,9 @@ use std::path::{Path, PathBuf};
 use aegis_catalog::{Entry, Vendor};
 
 mod keyring;
+mod sha256;
+mod sums;
+mod verify;
 
 pub use keyring::VendorKeyring;
 

--- a/crates/aegis-fetch/src/lib.rs
+++ b/crates/aegis-fetch/src/lib.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! HTTPS download + signed-chain verification for aegis-boot
+//! catalog ISOs. See [`fetch_catalog_entry`] for the entry point.
+//!
+//! ## Why this crate exists (#655 Phase 2B)
+//!
+//! Both `aegis-cli` (host) and `rescue-tui` (in-rescue) need to
+//! download + verify catalog ISOs via the same trust path. Before
+//! this crate landed, the host CLI shelled out to `curl` + `gpg` +
+//! `sha256sum`; the rescue env couldn't reuse that because the
+//! initramfs doesn't ship those binaries. Pulling the verify path
+//! into a Rust library that links into both binaries gives us:
+//!
+//! - One trust implementation, audited once.
+//! - Static-musl friendly (rustls, no native TLS, pure-Rust PGP).
+//! - Progress callbacks the TUI can render without a child-process
+//!   stdout-scraping shim.
+//!
+//! ## Trust posture
+//!
+//! The PGP verifier is [rpgp][rpgp] (MIT OR Apache-2.0), pinned via
+//! workspace [`Cargo.toml`]. The HTTPS stack is [ureq][ureq] +
+//! [rustls][rustls] + [ring][ring] + [webpki-roots][webpki-roots]
+//! (Mozilla's CA bundle). Vendor certs live in
+//! `crates/aegis-catalog/keyring/<vendor>.asc` with fingerprints
+//! pinned in `fingerprints.toml`; this crate refuses to load a cert
+//! whose fingerprint disagrees with the pin.
+//!
+//! No signing, no key generation, no encryption — verify-only.
+//!
+//! [rpgp]: https://crates.io/crates/pgp
+//! [ureq]: https://crates.io/crates/ureq
+//! [rustls]: https://crates.io/crates/rustls
+//! [ring]: https://crates.io/crates/ring
+//! [webpki-roots]: https://crates.io/crates/webpki-roots
+
+#![warn(missing_docs)]
+
+use std::path::{Path, PathBuf};
+
+use aegis_catalog::{Entry, Vendor};
+
+mod keyring;
+
+pub use keyring::VendorKeyring;
+
+/// Streaming progress for the ISO download. Emitted from
+/// [`FetchEvent::Downloading`].
+#[derive(Debug, Clone, Copy)]
+pub struct FetchProgress {
+    /// Bytes downloaded so far.
+    pub bytes: u64,
+    /// Content-Length when the server provided it. `None` for
+    /// chunked / streaming responses; UIs should fall back to a
+    /// spinner in that case.
+    pub total: Option<u64>,
+}
+
+/// Lifecycle event emitted by [`fetch_catalog_entry`] via the
+/// caller-supplied callback. Downstream UIs (the host CLI's
+/// `indicatif` bar, the rescue-tui's progress overlay) translate
+/// these into rendering decisions.
+#[derive(Debug, Clone)]
+pub enum FetchEvent {
+    /// TLS handshake is in progress; no bytes received yet.
+    Connecting,
+    /// ISO bytes are streaming. `bytes` is the running total since
+    /// the request started; reset on retry.
+    Downloading(FetchProgress),
+    /// SHA-256 of the downloaded ISO is being computed and matched
+    /// against the (already authenticated) sums file.
+    VerifyingHash,
+    /// PGP signature is being verified against the pinned vendor
+    /// cert. The exact target depends on the entry's
+    /// [`aegis_catalog::SigPattern`].
+    VerifyingSig,
+    /// Terminal event. Carries the verified ISO path and the
+    /// fingerprint of the cert that authenticated it.
+    Done(FetchOutcome),
+}
+
+/// Successful fetch result.
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    /// Absolute path to the verified ISO on disk.
+    pub iso_path: PathBuf,
+    /// ISO size in bytes.
+    pub bytes: u64,
+    /// Lowercase hex SHA-256 digest of the ISO.
+    pub sha256_hex: String,
+    /// Vendor whose cert authenticated this fetch.
+    pub vendor: Vendor,
+    /// Hex fingerprint of the cert that signed the verified
+    /// artifact. Useful for audit logs / `aegis-boot doctor`.
+    pub key_fingerprint: String,
+}
+
+/// All errors [`fetch_catalog_entry`] can raise.
+///
+/// On any error, callers should treat any partial file at the
+/// destination as untrusted: this crate's contract is "the file at
+/// `iso_path` is verified iff the call returns `Ok`". A future
+/// Phase 3 may change this contract by writing to `<iso>.partial`
+/// and renaming on success.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    /// HTTPS transport failed (DNS, TLS, non-2xx, timeout, etc.).
+    #[error("network: failed to fetch {url}: {detail}")]
+    Network {
+        /// Upstream URL that the fetch was directed at.
+        url: String,
+        /// Detail string forwarded from the underlying transport.
+        detail: String,
+    },
+    /// Filesystem operation failed (mkdir, create, write, sync).
+    #[error("filesystem: {detail}")]
+    Filesystem {
+        /// Operator-readable cause description.
+        detail: String,
+    },
+    /// SHA-256 of the downloaded ISO did not match the vendor's
+    /// authenticated checksum. Most likely cause: corrupted /
+    /// truncated download. Less likely but worth flagging:
+    /// MITM substitution that made it past TLS (compromised CA?).
+    #[error("sha256: expected {expected}, got {actual} for {iso}")]
+    Sha256Mismatch {
+        /// Hex digest the vendor's authenticated sums file reports.
+        expected: String,
+        /// Hex digest of the bytes we downloaded.
+        actual: String,
+        /// ISO filename we were verifying.
+        iso: String,
+    },
+    /// PGP signature verification failed. Either the artifact was
+    /// tampered with or the pinned vendor cert is wrong (key
+    /// rotation we haven't picked up yet). Operator-facing
+    /// remediation: re-fetch from a different network, or update
+    /// to a newer aegis-boot release.
+    #[error("signature: verify failed for {entry}: {detail}")]
+    SignatureVerifyFailed {
+        /// Catalog entry slug being fetched.
+        entry: String,
+        /// Detail from the PGP verifier.
+        detail: String,
+    },
+    /// Vendor cert for the entry is not in the keyring. Indicates
+    /// a missing keyring file in `crates/aegis-catalog/keyring/`,
+    /// caught at runtime rather than compile time when the keyring
+    /// is loaded via [`VendorKeyring::from_dir`].
+    #[error("keyring: no cert for vendor {vendor:?}")]
+    UnknownVendor {
+        /// The vendor whose cert was missing.
+        vendor: Vendor,
+    },
+    /// Sums file was authenticated successfully but doesn't list
+    /// the ISO filename. Vendor mirror layout drift —
+    /// `aegis-catalog::Entry::iso_url` is no longer correct.
+    #[error("sums: no entry for {iso} in authenticated sums file")]
+    IsoNotInSums {
+        /// ISO filename we were looking for.
+        iso: String,
+    },
+    /// Sums file parsed but did not appear to be a sha256-format
+    /// digest list. Defensive: detects a vendor switching to a
+    /// different digest algorithm under our feet.
+    #[error("sums: malformed (no sha256 lines found)")]
+    MalformedSums,
+    /// Cleartext-signed sums file did not contain a recognizable
+    /// signature envelope. Returned when an entry tagged
+    /// [`aegis_catalog::SigPattern::ClearsignedSums`] fetched a
+    /// file that wasn't actually a clearsigned envelope.
+    #[error("sums: not a clearsigned envelope")]
+    NotClearsigned,
+}
+
+/// Download + verify a catalog [`Entry`] end-to-end, writing the
+/// authenticated ISO to `dest_dir`. Emits lifecycle events via
+/// `on_event` so the caller can render progress.
+///
+/// On `Ok`, the ISO at `iso_path` is byte-for-byte what the vendor
+/// signed. On `Err`, the destination directory may contain partial
+/// or unverified files — caller is responsible for cleanup or
+/// retry semantics.
+///
+/// This is a synchronous, blocking call. The caller chooses the
+/// thread (rescue-tui spawns a worker; the host CLI calls inline).
+///
+/// # Errors
+///
+/// See [`FetchError`] for the failure taxonomy.
+pub fn fetch_catalog_entry(
+    _entry: &Entry,
+    _dest_dir: &Path,
+    _keyring: &VendorKeyring,
+    _on_event: &mut dyn FnMut(FetchEvent),
+) -> Result<FetchOutcome, FetchError> {
+    // Implemented in successive commits in this PR:
+    //   1. HTTPS downloader  (commit 2)
+    //   2. SHA-256 hasher    (commit 3)
+    //   3. PGP verify dispatch on SigPattern (commit 4)
+    //   4. wire-up           (commit 5)
+    //
+    // Until then, callers can construct + validate the keyring,
+    // inspect the type surface, and write fixture-driven tests
+    // against the verify primitives directly.
+    Err(FetchError::Filesystem {
+        detail: "fetch_catalog_entry not yet wired (#655 Phase 2B in progress)".to_string(),
+    })
+}

--- a/crates/aegis-fetch/src/lib.rs
+++ b/crates/aegis-fetch/src/lib.rs
@@ -39,8 +39,9 @@
 
 use std::path::{Path, PathBuf};
 
-use aegis_catalog::{Entry, Vendor};
+use aegis_catalog::{Entry, SigPattern, Vendor};
 
+mod download;
 mod keyring;
 mod sha256;
 mod sums;
@@ -193,21 +194,192 @@ pub enum FetchError {
 ///
 /// See [`FetchError`] for the failure taxonomy.
 pub fn fetch_catalog_entry(
-    _entry: &Entry,
-    _dest_dir: &Path,
-    _keyring: &VendorKeyring,
-    _on_event: &mut dyn FnMut(FetchEvent),
+    entry: &Entry,
+    dest_dir: &Path,
+    keyring: &VendorKeyring,
+    on_event: &mut dyn FnMut(FetchEvent),
 ) -> Result<FetchOutcome, FetchError> {
-    // Implemented in successive commits in this PR:
-    //   1. HTTPS downloader  (commit 2)
-    //   2. SHA-256 hasher    (commit 3)
-    //   3. PGP verify dispatch on SigPattern (commit 4)
-    //   4. wire-up           (commit 5)
-    //
-    // Until then, callers can construct + validate the keyring,
-    // inspect the type surface, and write fixture-driven tests
-    // against the verify primitives directly.
-    Err(FetchError::Filesystem {
-        detail: "fetch_catalog_entry not yet wired (#655 Phase 2B in progress)".to_string(),
+    let cert_bytes = keyring
+        .cert_armor(entry.vendor)
+        .ok_or(FetchError::UnknownVendor {
+            vendor: entry.vendor,
+        })?;
+
+    std::fs::create_dir_all(dest_dir).map_err(|e| FetchError::Filesystem {
+        detail: format!("create {}: {e}", dest_dir.display()),
+    })?;
+
+    let iso_filename = filename_from_url(entry.iso_url);
+    let iso_path = dest_dir.join(iso_filename);
+    let bytes = download::download_to_file(entry.iso_url, &iso_path, on_event)?;
+
+    let fingerprint = match entry.verify {
+        SigPattern::ClearsignedSums => {
+            verify_clearsigned_path(entry, cert_bytes, &iso_path, on_event)?
+        }
+        SigPattern::DetachedSigOnSums => {
+            verify_detached_on_sums_path(entry, cert_bytes, &iso_path, on_event)?
+        }
+        SigPattern::DetachedSigOnIso => {
+            verify_detached_on_iso_path(entry, cert_bytes, &iso_path, on_event)?
+        }
+    };
+
+    let outcome = FetchOutcome {
+        iso_path,
+        bytes,
+        sha256_hex: fingerprint.iso_sha256_hex,
+        vendor: entry.vendor,
+        key_fingerprint: fingerprint.signer_fingerprint_hex,
+    };
+    on_event(FetchEvent::Done(outcome.clone()));
+    Ok(outcome)
+}
+
+/// Result of a verify dispatch — both the cert fingerprint that
+/// authenticated the artifact and the ISO's sha256, since both
+/// flow into [`FetchOutcome`].
+struct VerifyResult {
+    iso_sha256_hex: String,
+    signer_fingerprint_hex: String,
+}
+
+fn verify_clearsigned_path(
+    entry: &Entry,
+    cert_bytes: &[u8],
+    iso_path: &Path,
+    on_event: &mut dyn FnMut(FetchEvent),
+) -> Result<VerifyResult, FetchError> {
+    // sha256_url == sig_url for ClearsignedSums; one fetch.
+    let sums_bytes = download::download_to_vec(entry.sha256_url)?;
+    let sums_text =
+        std::str::from_utf8(&sums_bytes).map_err(|e| FetchError::SignatureVerifyFailed {
+            entry: entry.slug.to_string(),
+            detail: format!("clearsigned sums not utf-8: {e}"),
+        })?;
+
+    on_event(FetchEvent::VerifyingSig);
+    let verified = verify::verify_clearsigned_sums(cert_bytes, sums_text, entry.slug)?;
+
+    on_event(FetchEvent::VerifyingHash);
+    let mut last_hash_bytes: u64 = 0;
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |b| last_hash_bytes = b)?;
+    let _ = last_hash_bytes;
+
+    let iso_filename = filename_from_url(entry.iso_url);
+    let expected = sums::find_iso_sha256(&verified.signed_text, iso_filename)?;
+    if !iso_sha256_hex.eq_ignore_ascii_case(&expected) {
+        return Err(FetchError::Sha256Mismatch {
+            expected,
+            actual: iso_sha256_hex,
+            iso: iso_filename.to_string(),
+        });
+    }
+    Ok(VerifyResult {
+        iso_sha256_hex,
+        signer_fingerprint_hex: verified.fingerprint_hex,
     })
+}
+
+fn verify_detached_on_sums_path(
+    entry: &Entry,
+    cert_bytes: &[u8],
+    iso_path: &Path,
+    on_event: &mut dyn FnMut(FetchEvent),
+) -> Result<VerifyResult, FetchError> {
+    let sums_bytes = download::download_to_vec(entry.sha256_url)?;
+    let sig_bytes = download::download_to_vec(entry.sig_url)?;
+
+    on_event(FetchEvent::VerifyingSig);
+    let signer_fingerprint_hex =
+        verify::verify_detached_sig_on_sums(cert_bytes, &sig_bytes, &sums_bytes, entry.slug)?;
+
+    on_event(FetchEvent::VerifyingHash);
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {})?;
+
+    let sums_text = std::str::from_utf8(&sums_bytes).map_err(|_| FetchError::MalformedSums)?;
+    let iso_filename = filename_from_url(entry.iso_url);
+    let expected = sums::find_iso_sha256(sums_text, iso_filename)?;
+    if !iso_sha256_hex.eq_ignore_ascii_case(&expected) {
+        return Err(FetchError::Sha256Mismatch {
+            expected,
+            actual: iso_sha256_hex,
+            iso: iso_filename.to_string(),
+        });
+    }
+    Ok(VerifyResult {
+        iso_sha256_hex,
+        signer_fingerprint_hex,
+    })
+}
+
+fn verify_detached_on_iso_path(
+    entry: &Entry,
+    cert_bytes: &[u8],
+    iso_path: &Path,
+    on_event: &mut dyn FnMut(FetchEvent),
+) -> Result<VerifyResult, FetchError> {
+    let sig_bytes = download::download_to_vec(entry.sig_url)?;
+
+    on_event(FetchEvent::VerifyingSig);
+    let signer_fingerprint_hex =
+        verify::verify_detached_sig_on_iso(cert_bytes, &sig_bytes, iso_path, entry.slug)?;
+
+    // The signature already authenticates the ISO bytes; the
+    // sha256 here is informational, surfaced in FetchOutcome for
+    // audit logs and `aegis-boot doctor` output.
+    on_event(FetchEvent::VerifyingHash);
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {})?;
+
+    Ok(VerifyResult {
+        iso_sha256_hex,
+        signer_fingerprint_hex,
+    })
+}
+
+fn filename_from_url(url: &str) -> &str {
+    url.rsplit('/').next().unwrap_or("download")
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+    use aegis_catalog::CATALOG;
+
+    #[test]
+    fn empty_keyring_short_circuits_with_unknown_vendor() {
+        // An empty keyring should make fetch_catalog_entry return
+        // UnknownVendor before any network or filesystem
+        // interaction. This is the production posture until #655
+        // PR-B populates the keyring — every fetch must fail
+        // cleanly instead of silently bypassing verification.
+        let entry = CATALOG
+            .iter()
+            .find(|e| e.slug == "ubuntu-24.04-live-server")
+            .expect("seeded entry");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let keyring = VendorKeyring::empty();
+        let mut events: Vec<FetchEvent> = Vec::new();
+        let err = fetch_catalog_entry(entry, dir.path(), &keyring, &mut |e| events.push(e))
+            .expect_err("must fail without keyring");
+        assert!(matches!(
+            err,
+            FetchError::UnknownVendor {
+                vendor: Vendor::Ubuntu
+            }
+        ));
+        // No events emitted; we short-circuit before Connecting.
+        assert!(events.is_empty(), "no events on UnknownVendor path");
+    }
+
+    #[test]
+    fn filename_from_url_handles_basic_paths() {
+        assert_eq!(
+            filename_from_url("https://x.example/a/b/file.iso"),
+            "file.iso"
+        );
+        assert_eq!(filename_from_url("https://x.example/file"), "file");
+        assert_eq!(filename_from_url("https://x.example/"), "");
+    }
 }

--- a/crates/aegis-fetch/src/sha256.rs
+++ b/crates/aegis-fetch/src/sha256.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Streaming SHA-256 over a file on disk.
+//!
+//! [`hash_file`] reads the file in 1 MiB chunks and emits a
+//! progress callback per chunk so the caller can render a
+//! progress bar without loading the entire ISO into memory.
+
+// Used by `fetch_catalog_entry`'s VerifyingHash phase, wired in
+// after the HTTPS downloader commit.
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::FetchError;
+
+/// One-MiB read buffer. Big enough that syscall overhead is
+/// dominated by SHA-256 + disk read; small enough that a stalled
+/// disk shows up as a missed callback within ~50 ms of CPU time
+/// at sustained read speeds.
+const CHUNK_BYTES: usize = 1 << 20;
+
+/// Stream-hash a file and return its lowercase-hex SHA-256 digest
+/// plus total byte count. Calls `on_progress(bytes_so_far)` once
+/// per [`CHUNK_BYTES`] of input so the caller can render a
+/// progress bar.
+///
+/// # Errors
+///
+/// Wraps `std::io::Error` as [`FetchError::Filesystem`] with the
+/// path included for operator-readable diagnostics.
+pub(crate) fn hash_file(
+    path: &Path,
+    on_progress: &mut dyn FnMut(u64),
+) -> Result<(String, u64), FetchError> {
+    let file = File::open(path).map_err(|e| FetchError::Filesystem {
+        detail: format!("open {} for hashing: {e}", path.display()),
+    })?;
+    let mut reader = BufReader::with_capacity(CHUNK_BYTES, file);
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; CHUNK_BYTES];
+    let mut total: u64 = 0;
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| FetchError::Filesystem {
+            detail: format!("read {}: {e}", path.display()),
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        total += n as u64;
+        on_progress(total);
+    }
+    let digest = hasher.finalize();
+    Ok((hex_lower(&digest), total))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // 8 + 4 = 12 hex digits per byte? No — 2 hex digits per byte.
+        // {b:02x} formats as exactly 2 lowercase hex digits.
+        use std::fmt::Write;
+        let _ = write!(&mut s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn hash_empty_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("empty");
+        std::fs::write(&path, b"").expect("write");
+        let (hex, n) = hash_file(&path, &mut |_| {}).expect("hash");
+        // SHA-256 of empty input is a well-known fixed value.
+        assert_eq!(
+            hex,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn hash_known_vector() {
+        // SHA-256("abc") = ba7816bf...
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("abc");
+        std::fs::write(&path, b"abc").expect("write");
+        let (hex, n) = hash_file(&path, &mut |_| {}).expect("hash");
+        assert_eq!(
+            hex,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn hash_emits_progress_for_multi_chunk_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("big");
+        // Write 2.5 MiB so we get 3 read iterations at 1 MiB each.
+        let big = vec![0u8; (CHUNK_BYTES * 5) / 2];
+        std::fs::write(&path, &big).expect("write");
+        let mut callbacks: Vec<u64> = Vec::new();
+        let (_, n) = hash_file(&path, &mut |b| callbacks.push(b)).expect("hash");
+        assert_eq!(n, big.len() as u64);
+        assert!(
+            callbacks.len() >= 3,
+            "expected multiple progress callbacks, got {callbacks:?}"
+        );
+        assert_eq!(*callbacks.last().expect("at least one"), n);
+        // Monotonic non-decreasing.
+        for w in callbacks.windows(2) {
+            assert!(w[0] <= w[1], "progress regressed: {} -> {}", w[0], w[1]);
+        }
+    }
+
+    #[test]
+    fn hash_missing_file_is_filesystem_error() {
+        let err = hash_file(
+            std::path::Path::new("/nonexistent/aegis-fetch-test"),
+            &mut |_| {},
+        )
+        .expect_err("should fail");
+        assert!(matches!(err, FetchError::Filesystem { .. }));
+    }
+}

--- a/crates/aegis-fetch/src/sha256.rs
+++ b/crates/aegis-fetch/src/sha256.rs
@@ -6,10 +6,6 @@
 //! progress callback per chunk so the caller can render a
 //! progress bar without loading the entire ISO into memory.
 
-// Used by `fetch_catalog_entry`'s VerifyingHash phase, wired in
-// after the HTTPS downloader commit.
-#![allow(dead_code)]
-
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;

--- a/crates/aegis-fetch/src/sums.rs
+++ b/crates/aegis-fetch/src/sums.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Parse SHA-256 / SHA-512 sums files of the shape vendors publish.
+
+// Used by the verify-dispatch path inside `fetch_catalog_entry`,
+// wired in after the HTTPS downloader commit.
+#![allow(dead_code)]
+//!
+//! Two layouts are common:
+//!
+//! 1. The `sha256sum -b` format — `<hex>  <filename>` per line. One
+//!    line per ISO. Used by Debian, Ubuntu, Kali, openSUSE,
+//!    Pop!\_OS, Linux Mint, `GParted`.
+//! 2. Per-ISO sidecar — single line, often `<hex>  <filename>`.
+//!    Used by Alpine, Manjaro, MX, `SystemRescue`.
+//! 3. Fedora/AlmaLinux/Rocky `CHECKSUM` — multi-line format with
+//!    `SHA256 (<filename>) = <hex>` syntax (the BSD-style format
+//!    `coreutils` accepts via `--tag`). Embedded inside the
+//!    clearsigned envelope.
+//!
+//! The parser tolerates leading `*` (binary) / single-space /
+//! double-space separators and the BSD-style. Returns the first
+//! sha256 line that matches `iso_filename`. SHA-512 lines are
+//! ignored — Debian's SHA512SUMS is currently the only catalog
+//! entry that publishes 512-bit digests, and our SHA-256 path
+//! doesn't accept 512-bit hashes regardless. (When that
+//! cross-distro case bites, add a parallel sha512 module.)
+
+use crate::FetchError;
+
+/// Parsed `(filename, lowercase-hex digest)` pairs.
+type Pair<'a> = (&'a str, String);
+
+/// Find the SHA-256 hex digest for `iso_filename` inside a sums
+/// file (already authenticated by the caller). Returns the
+/// lowercase-hex digest as a `String`. Errors with
+/// [`FetchError::IsoNotInSums`] when no matching line is present
+/// or [`FetchError::MalformedSums`] when no parseable sha256 lines
+/// exist at all.
+///
+/// # Errors
+///
+/// See [`FetchError::IsoNotInSums`] / [`FetchError::MalformedSums`].
+pub(crate) fn find_iso_sha256(sums_text: &str, iso_filename: &str) -> Result<String, FetchError> {
+    let mut any_sha256 = false;
+    for (name, hex) in iter_sha256_lines(sums_text) {
+        any_sha256 = true;
+        if name == iso_filename {
+            return Ok(hex);
+        }
+    }
+    if any_sha256 {
+        Err(FetchError::IsoNotInSums {
+            iso: iso_filename.to_string(),
+        })
+    } else {
+        Err(FetchError::MalformedSums)
+    }
+}
+
+fn iter_sha256_lines(sums_text: &str) -> impl Iterator<Item = Pair<'_>> {
+    sums_text.lines().filter_map(parse_sha256_line)
+}
+
+fn parse_sha256_line(line: &str) -> Option<Pair<'_>> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+
+    // BSD-style: "SHA256 (<filename>) = <hex>"
+    if let Some(rest) = line.strip_prefix("SHA256 (") {
+        let close = rest.find(')')?;
+        let filename = &rest[..close];
+        let after = rest[close..].strip_prefix(") = ")?;
+        if is_sha256_hex(after) {
+            return Some((filename, after.to_lowercase()));
+        }
+        return None;
+    }
+
+    // GNU coreutils format: "<hex>  <filename>" (two spaces) or
+    // "<hex> *<filename>" (binary mode marker). Accept either.
+    let mut parts = line.splitn(2, char::is_whitespace);
+    let hex = parts.next()?;
+    if !is_sha256_hex(hex) {
+        return None;
+    }
+    let rest = parts.next()?.trim_start();
+    let filename = rest.strip_prefix('*').unwrap_or(rest);
+    Some((filename, hex.to_lowercase()))
+}
+
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+
+    const FAKE_HEX: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn parses_gnu_two_space_format() {
+        let body = format!("{FAKE_HEX}  ubuntu.iso\n");
+        let r = find_iso_sha256(&body, "ubuntu.iso").expect("parse");
+        assert_eq!(r, FAKE_HEX);
+    }
+
+    #[test]
+    fn parses_gnu_binary_marker_format() {
+        let body = format!("{FAKE_HEX} *alpine.iso\n");
+        let r = find_iso_sha256(&body, "alpine.iso").expect("parse");
+        assert_eq!(r, FAKE_HEX);
+    }
+
+    #[test]
+    fn parses_bsd_tag_format() {
+        let body = format!("SHA256 (Fedora-Server-dvd-x86_64-43-1.6.iso) = {FAKE_HEX}\n");
+        let r = find_iso_sha256(&body, "Fedora-Server-dvd-x86_64-43-1.6.iso").expect("parse");
+        assert_eq!(r, FAKE_HEX);
+    }
+
+    #[test]
+    fn returns_specific_iso_among_many() {
+        let other = "1234567890abcdef".repeat(4); // 64-char fake hex
+        let body = format!("{other}  desktop.iso\n{FAKE_HEX}  server.iso\n{other}  netinst.iso\n");
+        let r = find_iso_sha256(&body, "server.iso").expect("parse");
+        assert_eq!(r, FAKE_HEX);
+    }
+
+    #[test]
+    fn iso_not_in_sums_when_filename_absent() {
+        let body = format!("{FAKE_HEX}  some-other.iso\n");
+        let err = find_iso_sha256(&body, "missing.iso").expect_err("missing");
+        assert!(matches!(err, FetchError::IsoNotInSums { .. }));
+    }
+
+    #[test]
+    fn malformed_sums_when_no_sha256_lines_at_all() {
+        let body = "this is a regular text file, not a sums file\n";
+        let err = find_iso_sha256(body, "x.iso").expect_err("malformed");
+        assert!(matches!(err, FetchError::MalformedSums));
+    }
+
+    #[test]
+    fn ignores_comments_and_blank_lines() {
+        let body = format!("# comment\n\n{FAKE_HEX}  alpine.iso\n# another comment\n");
+        let r = find_iso_sha256(&body, "alpine.iso").expect("parse");
+        assert_eq!(r, FAKE_HEX);
+    }
+
+    #[test]
+    fn ignores_sha512_lines_so_a_pure_sha512_file_is_malformed() {
+        // Debian's SHA512SUMS — 128-char hex, not 64. We're a
+        // sha256 finder; a pure sha512 file should report
+        // MalformedSums so the caller can decide what to do.
+        let sha512 = "0".repeat(128);
+        let body = format!("{sha512}  debian.iso\n");
+        let err = find_iso_sha256(&body, "debian.iso").expect_err("malformed");
+        assert!(matches!(err, FetchError::MalformedSums));
+    }
+
+    #[test]
+    fn rejects_garbage_in_hex_field() {
+        let bad = "Z".repeat(64);
+        let body = format!("{bad}  alpine.iso\n");
+        let err = find_iso_sha256(&body, "alpine.iso").expect_err("malformed");
+        assert!(matches!(err, FetchError::MalformedSums));
+    }
+}

--- a/crates/aegis-fetch/src/sums.rs
+++ b/crates/aegis-fetch/src/sums.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Parse SHA-256 / SHA-512 sums files of the shape vendors publish.
-
-// Used by the verify-dispatch path inside `fetch_catalog_entry`,
-// wired in after the HTTPS downloader commit.
-#![allow(dead_code)]
 //!
 //! Two layouts are common:
 //!

--- a/crates/aegis-fetch/src/verify.rs
+++ b/crates/aegis-fetch/src/verify.rs
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! PGP verification primitives for the three [`SigPattern`] variants.
+//!
+//! Each function takes vendor cert bytes (armored or binary,
+//! sniffed) plus the message bytes and returns the signing key's
+//! fingerprint on success. The fingerprint is surfaced in
+//! [`crate::FetchOutcome`] for audit logs.
+//!
+//! [`SigPattern`]: aegis_catalog::SigPattern
+
+// Warnings on `pub(crate)` items in this module are silenced until
+// the HTTPS downloader commit lands and `fetch_catalog_entry`
+// dispatches into them. The verify primitives are tested
+// in-isolation in this module's `#[cfg(test)]` block.
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use pgp::composed::{CleartextSignedMessage, Deserializable, DetachedSignature, SignedPublicKey};
+
+use crate::FetchError;
+
+/// Returned from [`verify_clearsigned_sums`].
+#[derive(Debug)]
+pub(crate) struct VerifiedClearsign {
+    /// The signed plaintext (sums lines, dash-unescaped, with
+    /// normalized line endings). Caller parses with
+    /// [`crate::sums::find_iso_sha256`].
+    pub signed_text: String,
+    /// Hex fingerprint (uppercase) of the cert that authenticated
+    /// the envelope. Surfaced in [`crate::FetchOutcome`].
+    pub fingerprint_hex: String,
+}
+
+/// Verify a PGP cleartext-signed envelope (RFC 9580 §7) against
+/// the vendor's pinned cert. Used by `AlmaLinux`, Fedora, Rocky.
+///
+/// `clearsigned_text` is the raw text of the downloaded `CHECKSUM`
+/// file (`-----BEGIN PGP SIGNED MESSAGE-----` envelope). On
+/// success, the verified plaintext is returned for the caller to
+/// scan for the ISO's sha256 line.
+///
+/// # Errors
+///
+/// - [`FetchError::NotClearsigned`] when the input has no
+///   clearsign envelope.
+/// - [`FetchError::SignatureVerifyFailed`] when the signature
+///   does not authenticate against the vendor's cert.
+pub(crate) fn verify_clearsigned_sums(
+    cert_bytes: &[u8],
+    clearsigned_text: &str,
+    entry_slug: &str,
+) -> Result<VerifiedClearsign, FetchError> {
+    let cert = parse_cert(cert_bytes, entry_slug)?;
+    let (msg, _hdr) = CleartextSignedMessage::from_string(clearsigned_text).map_err(|e| {
+        // rpgp surfaces an error variant for "no envelope found".
+        // Distinguish it from a verification failure so the
+        // operator gets the right remediation hint.
+        if format!("{e}").contains("clearsigned")
+            || format!("{e}").contains("BEGIN PGP SIGNED")
+            || !clearsigned_text.contains("-----BEGIN PGP SIGNED MESSAGE-----")
+        {
+            FetchError::NotClearsigned
+        } else {
+            FetchError::SignatureVerifyFailed {
+                entry: entry_slug.to_string(),
+                detail: format!("parse clearsigned envelope: {e}"),
+            }
+        }
+    })?;
+    msg.verify(&cert)
+        .map_err(|e| FetchError::SignatureVerifyFailed {
+            entry: entry_slug.to_string(),
+            detail: format!("clearsign verify: {e}"),
+        })?;
+    Ok(VerifiedClearsign {
+        signed_text: msg.signed_text(),
+        fingerprint_hex: fingerprint_hex(&cert),
+    })
+}
+
+/// Verify a detached PGP signature over a sums file. Used by
+/// Debian, Ubuntu, Kali, Linux Mint, `GParted`, openSUSE, Pop!\_OS.
+///
+/// `sig_bytes` is the body of the `.gpg` / `.sign` / `.asc` file;
+/// `sums_bytes` is the body of the SHA256SUMS / SHA512SUMS file.
+///
+/// # Errors
+///
+/// [`FetchError::SignatureVerifyFailed`] on parse or verify
+/// failure.
+pub(crate) fn verify_detached_sig_on_sums(
+    cert_bytes: &[u8],
+    sig_bytes: &[u8],
+    sums_bytes: &[u8],
+    entry_slug: &str,
+) -> Result<String, FetchError> {
+    let cert = parse_cert(cert_bytes, entry_slug)?;
+    let sig = parse_detached_sig(sig_bytes, entry_slug)?;
+    sig.verify(&cert, sums_bytes)
+        .map_err(|e| FetchError::SignatureVerifyFailed {
+            entry: entry_slug.to_string(),
+            detail: format!("detached-on-sums verify: {e}"),
+        })?;
+    Ok(fingerprint_hex(&cert))
+}
+
+/// Verify a detached PGP signature over the ISO bytes
+/// themselves. Used by Alpine, Manjaro, MX Linux, `SystemRescue`.
+///
+/// Streams the ISO from disk via [`File`] + [`BufReader`] so
+/// multi-GB ISOs don't have to fit in memory. Calls
+/// `on_progress(bytes_read)` on each 1 MiB chunk so the caller
+/// can render a verify-progress UI parallel to the download bar.
+///
+/// # Errors
+///
+/// - [`FetchError::Filesystem`] for I/O failures opening or
+///   reading the ISO.
+/// - [`FetchError::SignatureVerifyFailed`] for parse or verify
+///   failure.
+pub(crate) fn verify_detached_sig_on_iso(
+    cert_bytes: &[u8],
+    sig_bytes: &[u8],
+    iso_path: &Path,
+    entry_slug: &str,
+) -> Result<String, FetchError> {
+    let cert = parse_cert(cert_bytes, entry_slug)?;
+    let sig = parse_detached_sig(sig_bytes, entry_slug)?;
+    let file = File::open(iso_path).map_err(|e| FetchError::Filesystem {
+        detail: format!("open {} for sig verify: {e}", iso_path.display()),
+    })?;
+    let reader = BufReader::with_capacity(1 << 20, file);
+    sig.signature
+        .verify(&cert, reader)
+        .map_err(|e| FetchError::SignatureVerifyFailed {
+            entry: entry_slug.to_string(),
+            detail: format!("detached-on-iso verify: {e}"),
+        })?;
+    Ok(fingerprint_hex(&cert))
+}
+
+/// Parse a [`SignedPublicKey`] from armored or binary cert bytes.
+fn parse_cert(bytes: &[u8], entry_slug: &str) -> Result<SignedPublicKey, FetchError> {
+    let parsed = if is_armored(bytes) {
+        SignedPublicKey::from_armor_single(bytes).map(|(k, _)| k)
+    } else {
+        SignedPublicKey::from_bytes(BufReader::new(bytes))
+    };
+    parsed.map_err(|e| FetchError::SignatureVerifyFailed {
+        entry: entry_slug.to_string(),
+        detail: format!("parse vendor cert: {e}"),
+    })
+}
+
+/// Parse a [`DetachedSignature`] from armored or binary signature
+/// bytes. Sniffs the leading bytes to choose the parser.
+fn parse_detached_sig(bytes: &[u8], entry_slug: &str) -> Result<DetachedSignature, FetchError> {
+    let parsed = if is_armored(bytes) {
+        DetachedSignature::from_armor_single(bytes).map(|(s, _)| s)
+    } else {
+        DetachedSignature::from_bytes(BufReader::new(bytes))
+    };
+    parsed.map_err(|e| FetchError::SignatureVerifyFailed {
+        entry: entry_slug.to_string(),
+        detail: format!("parse detached signature: {e}"),
+    })
+}
+
+fn is_armored(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"-----BEGIN PGP")
+}
+
+fn fingerprint_hex(cert: &SignedPublicKey) -> String {
+    use pgp::types::KeyDetails;
+    format!("{:X}", cert.fingerprint())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+    use pgp::composed::{
+        ArmorOptions, EncryptionCaps, KeyType, SecretKeyParamsBuilder, SignedSecretKey,
+    };
+    use pgp::crypto::hash::HashAlgorithm;
+    use pgp::ser::Serialize;
+    use pgp::types::Password;
+    use rand::thread_rng;
+
+    /// Hermetic test cert + signing helper. Generates an Ed25519
+    /// primary key (microseconds) so test fixtures don't have to
+    /// be checked in. Returns (armored pubkey bytes, signing key).
+    fn gen_test_cert() -> (Vec<u8>, SignedSecretKey) {
+        let mut rng = thread_rng();
+        let mut p = SecretKeyParamsBuilder::default();
+        p.key_type(KeyType::Ed25519Legacy)
+            .can_certify(true)
+            .can_sign(true)
+            .can_encrypt(EncryptionCaps::None)
+            .primary_user_id("aegis-fetch test <test@example.invalid>".into());
+        let params = p.build().expect("build params");
+        // params.generate(rng) already returns a self-signed
+        // SignedSecretKey — see rpgp/examples/generate_key.rs.
+        let secret = params.generate(&mut rng).expect("keygen");
+        // Derive the equivalent transferable public key (TPK).
+        // SignedSecretKey::public_key() returns just the inner
+        // primary public key packet; for the armored cert (with
+        // user IDs and binding signatures) we need the From impl.
+        let public = SignedPublicKey::from(secret.clone());
+        let armored = public
+            .to_armored_bytes(ArmorOptions::default())
+            .expect("armor");
+        (armored, secret)
+    }
+
+    fn sign_clearsigned(secret: &SignedSecretKey, text: &str) -> String {
+        let mut rng = thread_rng();
+        let msg = CleartextSignedMessage::sign(&mut rng, text, &**secret, &Password::empty())
+            .expect("sign clearsigned");
+        msg.to_armored_string(ArmorOptions::default())
+            .expect("armor clearsigned")
+    }
+
+    fn sign_detached(secret: &SignedSecretKey, data: &[u8]) -> Vec<u8> {
+        let mut rng = thread_rng();
+        let sig = DetachedSignature::sign_binary_data(
+            &mut rng,
+            &**secret,
+            &Password::empty(),
+            HashAlgorithm::Sha256,
+            data,
+        )
+        .expect("sign detached");
+        sig.to_armored_bytes(ArmorOptions::default())
+            .expect("armor sig")
+    }
+
+    // ---- ClearsignedSums ----------------------------------------
+
+    #[test]
+    fn clearsigned_roundtrip_verifies() {
+        let (cert, secret) = gen_test_cert();
+        let sums = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  alpine.iso\n";
+        let clearsigned = sign_clearsigned(&secret, sums);
+        let r = verify_clearsigned_sums(&cert, &clearsigned, "alpine-3.20-standard")
+            .expect("verify ok");
+        // signed_text() normalizes line endings; the sha256 line is preserved.
+        assert!(r.signed_text.contains("alpine.iso"));
+        assert!(!r.fingerprint_hex.is_empty());
+    }
+
+    #[test]
+    fn clearsigned_tampered_payload_fails_verify() {
+        let (cert, secret) = gen_test_cert();
+        let original =
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  alpine.iso\n";
+        let clearsigned = sign_clearsigned(&secret, original);
+        // Flip a hex digit inside the signed plaintext. rpgp's
+        // verify recomputes the digest over the signed text and
+        // should reject.
+        let tampered = clearsigned.replace("ba78", "ba79");
+        let err = verify_clearsigned_sums(&cert, &tampered, "alpine-3.20-standard")
+            .expect_err("should fail");
+        assert!(matches!(err, FetchError::SignatureVerifyFailed { .. }));
+    }
+
+    #[test]
+    fn clearsigned_wrong_cert_fails_verify() {
+        let (_, secret) = gen_test_cert();
+        let (other_cert, _) = gen_test_cert();
+        let clearsigned = sign_clearsigned(&secret, "abc  alpine.iso\n");
+        let err = verify_clearsigned_sums(&other_cert, &clearsigned, "alpine-3.20-standard")
+            .expect_err("should fail");
+        assert!(matches!(err, FetchError::SignatureVerifyFailed { .. }));
+    }
+
+    #[test]
+    fn clearsigned_no_envelope_returns_not_clearsigned() {
+        let (cert, _) = gen_test_cert();
+        let err = verify_clearsigned_sums(&cert, "just plain text, no envelope", "x")
+            .expect_err("should fail");
+        assert!(matches!(err, FetchError::NotClearsigned));
+    }
+
+    // ---- DetachedSigOnSums --------------------------------------
+
+    #[test]
+    fn detached_on_sums_roundtrip_verifies() {
+        let (cert, secret) = gen_test_cert();
+        let sums = b"ba7816bf  ubuntu.iso\n" as &[u8];
+        let sig = sign_detached(&secret, sums);
+        let fp = verify_detached_sig_on_sums(&cert, &sig, sums, "ubuntu-24.04-live-server")
+            .expect("verify ok");
+        assert!(!fp.is_empty());
+    }
+
+    #[test]
+    fn detached_on_sums_tampered_message_fails_verify() {
+        let (cert, secret) = gen_test_cert();
+        let sums = b"ba7816bf  ubuntu.iso\n" as &[u8];
+        let sig = sign_detached(&secret, sums);
+        let tampered = b"ba7816bf  ubuntu.iso\n# extra line\n" as &[u8];
+        let err =
+            verify_detached_sig_on_sums(&cert, &sig, tampered, "ubuntu").expect_err("should fail");
+        assert!(matches!(err, FetchError::SignatureVerifyFailed { .. }));
+    }
+
+    // ---- DetachedSigOnIso ---------------------------------------
+
+    #[test]
+    fn detached_on_iso_roundtrip_verifies() {
+        let (cert, secret) = gen_test_cert();
+        // 4 KiB of arbitrary bytes; doesn't have to look like a
+        // real ISO — rpgp signs whatever bytes you hand it.
+        let iso_bytes: Vec<u8> = (0..4096_u32).map(|i| (i & 0xff) as u8).collect();
+        let sig = sign_detached(&secret, &iso_bytes);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let iso_path = dir.path().join("alpine.iso");
+        std::fs::write(&iso_path, &iso_bytes).expect("write");
+        let fp = verify_detached_sig_on_iso(&cert, &sig, &iso_path, "alpine-3.20-standard")
+            .expect("verify ok");
+        assert!(!fp.is_empty());
+    }
+
+    #[test]
+    fn detached_on_iso_tampered_bytes_fails_verify() {
+        let (cert, secret) = gen_test_cert();
+        let iso_bytes: Vec<u8> = (0..4096_u32).map(|i| (i & 0xff) as u8).collect();
+        let sig = sign_detached(&secret, &iso_bytes);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let iso_path = dir.path().join("alpine.iso");
+        // Write a different set of bytes — sig should reject.
+        let tampered: Vec<u8> = (0..4096_u32).map(|i| ((i + 1) & 0xff) as u8).collect();
+        std::fs::write(&iso_path, &tampered).expect("write");
+        let err = verify_detached_sig_on_iso(&cert, &sig, &iso_path, "alpine-3.20-standard")
+            .expect_err("should fail");
+        assert!(matches!(err, FetchError::SignatureVerifyFailed { .. }));
+    }
+
+    #[test]
+    fn detached_on_iso_missing_file_is_filesystem_error() {
+        let (cert, secret) = gen_test_cert();
+        let sig = sign_detached(&secret, b"data");
+        let err = verify_detached_sig_on_iso(
+            &cert,
+            &sig,
+            std::path::Path::new("/nonexistent/aegis-fetch-test"),
+            "x",
+        )
+        .expect_err("should fail");
+        assert!(matches!(err, FetchError::Filesystem { .. }));
+    }
+
+    // ---- Cert parser sniffing -----------------------------------
+
+    #[test]
+    fn parses_armored_cert() {
+        let (armored, _) = gen_test_cert();
+        assert!(armored.starts_with(b"-----BEGIN PGP"));
+        let _ = parse_cert(&armored, "x").expect("parse armored");
+    }
+
+    #[test]
+    fn parses_binary_cert() {
+        let (armored, _) = gen_test_cert();
+        // Re-serialize as binary (no armor) using rpgp's writer.
+        // Roundtrip via from_armor → to_writer.
+        let (cert, _) = SignedPublicKey::from_armor_single(&armored[..]).expect("parse");
+        let mut binary = Vec::new();
+        cert.to_writer(&mut binary).expect("to_writer");
+        let _ = parse_cert(&binary, "x").expect("parse binary");
+    }
+}

--- a/crates/aegis-fetch/src/verify.rs
+++ b/crates/aegis-fetch/src/verify.rs
@@ -9,12 +9,6 @@
 //!
 //! [`SigPattern`]: aegis_catalog::SigPattern
 
-// Warnings on `pub(crate)` items in this module are silenced until
-// the HTTPS downloader commit lands and `fetch_catalog_entry`
-// dispatches into them. The verify primitives are tested
-// in-isolation in this module's `#[cfg(test)]` block.
-#![allow(dead_code)]
-
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,16 @@ allow = [
     "Zlib",
     "CC0-1.0",
     "MPL-2.0",
+    # Linux Foundation's Community Data License Agreement —
+    # Permissive 2.0. Data-license analog of MIT/Apache: free
+    # use, redistribution, and modification with attribution.
+    # Reaches our graph via `webpki-roots` (Mozilla CA root
+    # certificate bundle), pulled in by `ureq[rustls]` from
+    # `aegis-fetch` (#655 Phase 2B). The crate's code is ISC;
+    # only the embedded CA bundle data is CDLA-Permissive-2.0,
+    # which is the appropriate data license. Compatible with our
+    # dual MIT/Apache-2.0 outbound.
+    "CDLA-Permissive-2.0",
 ]
 # NOT allowed (blocked by omission from `allow`, listed here for audit):
 #   GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0, LGPL-2.0, LGPL-2.1, LGPL-3.0,

--- a/deny.toml
+++ b/deny.toml
@@ -38,6 +38,19 @@ ignore = [
     # crate, core dep for rescue-tui). Resolved when ratatui drops it
     # (ratatui 0.30 is tracked in #258 but blocked on MSRV bump).
     { id = "RUSTSEC-2024-0436", reason = "transitive via ratatui 0.29; resolved with #258 ratatui bump" },
+    # rsa Marvin Attack — timing sidechannel on private-key
+    # operations. Pulled in transitively by pgp (rpgp) → aegis-fetch
+    # (#655 Phase 2B). aegis-fetch is verify-only: we hold no RSA
+    # private keys and never decrypt or sign. The Marvin Attack
+    # extracts private-key bits via observation of decryption /
+    # signing timing — there is no such key or operation in our
+    # process. The advisory's own workaround says: "avoid using rsa
+    # in settings where attackers are able to observe timing
+    # information." We satisfy that by not exposing any
+    # private-key-using primitive. Re-evaluate if rpgp ever gains a
+    # signing-side consumer here, or if a constant-time rsa fix
+    # ships and rpgp picks it up.
+    { id = "RUSTSEC-2023-0071", reason = "transitive via pgp/rpgp; aegis-fetch is verify-only and holds no RSA private keys, so the timing sidechannel on private-key operations is not exploitable in our threat model" },
 ]
 
 # ─── Licenses ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New workspace crate `aegis-fetch` that does HTTPS download + PGP signed-chain verification of catalog ISOs, designed to be linked into both `aegis-cli` (host) and `rescue-tui` (in-rescue, post-#655 Phase 1A/1B). Replaces the host CLI's `curl` + `gpg` + `sha256sum` shell-outs with a single Rust trust path that also works inside the static-musl initramfs.

This is **PR-A** of the Phase 2B sub-plan. PR-B (keyring sync workflow + populated vendor `.asc` files) and PR-C (CLI refactor onto `aegis-fetch` + rescue-tui Catalog screen) follow as separate PRs.

## What changed

- **`aegis_catalog::Entry`** gains `verify: SigPattern` (`ClearsignedSums | DetachedSigOnSums | DetachedSigOnIso`) and `vendor: Vendor`. All 20 catalog entries tagged. Coherence test asserts URL shape ↔ declared pattern.
- **New `aegis-fetch` crate** with the full verify dispatch:
  - `fetch_catalog_entry(entry, dest_dir, keyring, on_event)` — download + verify + emit `FetchEvent` lifecycle.
  - Three verify primitives covering all vendor shapes (clearsigned envelope, detached-on-sums, detached-on-iso). Streaming SHA-256 + streaming PGP-verify so multi-GB ISOs don't load into memory.
  - `VendorKeyring` with `empty()` / `embedded()` / `from_dir()` constructors. `embedded()` is a documented stub until PR-B populates `crates/aegis-catalog/keyring/`.
  - HTTPS via `ureq[rustls]` with `https_only(true)` + `max_redirects(10)` — a vendor redirecting from HTTPS to HTTP fails the fetch loudly.

## Architecture deviations from the original Phase 2B sketch

Both confirmed with maintainer mid-PR after surfacing as license blockers:

1. **PGP verifier is `pgp` (rpgp), not `sequoia-openpgp`.** sequoia-openpgp 2.2.0 ships under `LGPL-2.0-or-later` (verified from their gitlab `Cargo.toml`), which is on `deny.toml`'s explicit "NOT allowed" list — and LGPL §6 disclosure obligations would attach to every static-musl rescue-tui binary distributed on a stick. `pgp` (rpgp) is `MIT OR Apache-2.0`, pure Rust, and exposes `CleartextSignedMessage` + `DetachedSignature` for the three-pattern verify matrix.
2. **`deny.toml` allow-list adds `CDLA-Permissive-2.0`.** Comes via `webpki-roots` (Mozilla CA root cert bundle data license, used by ureq+rustls). Permissive, compatible with our outbound dual MIT/Apache. Documented in `THIRD_PARTY_LICENSES.md` at the workspace root.

`pgp` is also configured `default-features = false` to drop the `bzip2` feature — that pulls in `libbz2-rs-sys` whose `bzip2-1.0.6` license is not allow-listed, and OpenPGP message decompression is not part of our verify-only path.

## What's NOT in this PR (intentional)

- **Real vendor PGP keys.** Keyring stays empty until PR-B populates it via the catalog-refresh workflow + fingerprint pinning + `.txt` metadata sidecar.
- **CLI refactor.** `aegis-cli/src/fetch.rs` still shells out to `curl` + `gpg` + `sha256sum`. The refactor onto `aegis-fetch` is PR-C, after PR-B lands real keys — otherwise the CLI would regress to always returning `UnknownVendor`.
- **rescue-tui Catalog screen.** Same dependency chain — PR-C or later.

## Test plan

- [x] 33 new tests in `aegis-fetch`: 4 keyring loader, 4 sha256 hasher (incl. multi-chunk progress), 8 sums-file parser (GNU + BSD + sha512-rejection + garbage-hex), 11 verify primitives (3 patterns × roundtrip + tampered + wrong-cert + missing-file), 3 HTTP downloader (hermetic, via `pump_to_writer` + `Cursor`), 2 fetch-dispatcher integration tests.
- [x] 3 new tests in `aegis-catalog`: SigPattern↔URL coherence, Vendor::all() coverage, vendor-slug kebab-case.
- [x] `cargo fmt --check` workspace-wide clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (`doc_markdown` lint family included).
- [x] `cargo test --workspace` — 1294 tests pass, 0 failures.
- [x] `cargo deny check licenses` clean after CDLA-Permissive-2.0 allow-list addition + `bzip2` feature drop.
- [ ] CI green (this PR).

## Trust posture (recap)

Each verify path returns the signing cert's fingerprint, surfaced in `FetchOutcome.key_fingerprint` for `aegis-boot doctor` audit logs. On any error the destination directory may contain partial / unverified files — caller's responsibility (Phase 3 will introduce `.partial` + rename-on-verify).

Refs #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)