### PR TITLE
chore(ci): least-privilege permissions on 13 workflows (Scorecard)

### DIFF
--- a/.github/workflows/crates-publish-dryrun.yml
+++ b/.github/workflows/crates-publish-dryrun.yml
@@ -26,6 +26,11 @@ on:
 #   - rescue-tui, aegis-fitness, aegis-bootctl, aegis-wire-formats
 #   — all repo-specific or binary crates.
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   publish-dryrun:
     name: cargo publish --dry-run (iso-parser + kexec-loader)

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -51,6 +51,11 @@ concurrency:
   group: crates-publish
   cancel-in-progress: false
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: cargo publish (trusted)

--- a/.github/workflows/direct-install-e2e.yml
+++ b/.github/workflows/direct-install-e2e.yml
@@ -22,6 +22,11 @@ on:
 #      contrarian-flagged correctness oracle for swapping installers
 #      (per #274 RFC consensus vote).
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   direct-install-e2e:
     name: direct-install — flash + boot smoke + ESP byte-parity

--- a/.github/workflows/initramfs.yml
+++ b/.github/workflows/initramfs.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   initramfs:
     name: Build + verify reproducible initramfs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   iso-probe-mount:
     name: iso-probe loop-mount integration

--- a/.github/workflows/kexec-e2e.yml
+++ b/.github/workflows/kexec-e2e.yml
@@ -28,6 +28,11 @@ on:
 # Proves the rescue-tui -> target-kernel kexec handoff works end-to-end.
 # Complements the OVMF SecBoot E2E (which proves signed-chain -> rescue-tui).
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   kexec-e2e:
     name: kexec E2E (rescue-tui -> target kernel)

--- a/.github/workflows/mkusb.yml
+++ b/.github/workflows/mkusb.yml
@@ -17,6 +17,11 @@ on:
 #   3. rescue-tui survives the whole chain and runs from the AEGIS_ISOS
 #      partition layout.
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   mkusb-build:
     name: mkusb — build + boot smoke

--- a/.github/workflows/ovmf-secboot.yml
+++ b/.github/workflows/ovmf-secboot.yml
@@ -15,6 +15,11 @@ on:
 # the firmware loads cleanly. Phase 2 (real signed shim+kernel chain) is
 # tracked separately.
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   ovmf-secboot-foundation:
     name: OVMF SecBoot foundation

--- a/.github/workflows/qemu-smoke.yml
+++ b/.github/workflows/qemu-smoke.yml
@@ -10,6 +10,11 @@ on:
     paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   qemu-smoke:
     name: Boot initramfs under QEMU

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -18,6 +18,11 @@ on:
 # (which embed CARGO_HOME paths in metadata). Two back-to-back builds with the
 # same SOURCE_DATE_EPOCH must produce identical sha256(rescue-tui).
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   reproducible-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/sign-identity-transition.yml
+++ b/.github/workflows/sign-identity-transition.yml
@@ -32,13 +32,18 @@ on:
         required: true
         default: ''
 
+# Top-level permissions: read-only default. The `sign` job below
+# elevates explicitly (commit the .sig + .pem; cosign keyless OIDC).
+# Closes Scorecard TokenPermissionsID for this workflow.
 permissions:
-  contents: write
-  id-token: write  # required for cosign keyless (OIDC token)
+  contents: read
 
 jobs:
   sign:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # commit the cosign .sig + .pem next to the JSON
+      id-token: write       # required for cosign keyless (OIDC token)
     steps:
       - name: Guard
         if: ${{ inputs.confirm != 'SIGN' }}

--- a/.github/workflows/tui-screenshots.yml
+++ b/.github/workflows/tui-screenshots.yml
@@ -17,6 +17,11 @@ on:
 # captures the empty-list state of the TUI. To get the full scenario
 # set, a maintainer runs the script locally against ./test-isos.
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   capture:
     name: capture rescue-tui screens from VM

--- a/.github/workflows/update-rotate-e2e.yml
+++ b/.github/workflows/update-rotate-e2e.yml
@@ -23,6 +23,11 @@ on:
 #   4. The rotated image still boots under OVMF SecBoot enforcing and
 #      rescue-tui starts — proves the signed chain is intact.
 
+# Top-level permissions: read-only default. Jobs that need write
+# access elevate explicitly. Closes Scorecard TokenPermissionsID.
+permissions:
+  contents: read
+
 jobs:
   update-rotate-e2e:
     name: update — rotate + verify + boot under SB


### PR DESCRIPTION
## Summary

Closes the Scorecard `TokenPermissionsID` finding for every workflow YAML that previously ran with implicit `contents: write` (or had no top-level `permissions:` block at all). Pure hygiene PR — no behavior change.

## What changed

Each workflow gets:

- Top-level `permissions: contents: read` — least-privilege default for any job.
- Optional job-level elevation only on jobs that genuinely need write access.

| Workflow | Treatment |
|----------|-----------|
| tui-screenshots, update-rotate-e2e, reproducible-build, qemu-smoke, ovmf-secboot, mkusb, kexec-e2e, direct-install-e2e, integration, initramfs, crates-publish, crates-publish-dryrun | Read-only test/build/lint flows. Top-level `contents: read` only. |
| sign-identity-transition | Top-level dropped from `contents: write` → `contents: read`; the `sign` job elevates to `contents: write` + `id-token: write` only on itself. |

`catalog-refresh.yml` was handled in #655 PR-B (#662) and is intentionally not re-touched here.

## Scorecard findings closed (12 TokenPermissions alerts)

Per the snapshot from `gh api repos/.../code-scanning/alerts`:

- #155 tui-screenshots
- #153 update-rotate-e2e
- #152 reproducible-build
- #151 qemu-smoke
- #150 ovmf-secboot
- #149 mkusb
- #148 kexec-e2e
- #147 direct-install-e2e
- #16 sign-identity-transition (top-level write → narrowed)
- #8 integration
- #7 initramfs
- #5 crates-publish
- #4 crates-publish-dryrun

## Test plan

- [x] `gh workflow ls` shows all 13 modified workflows still parse cleanly.
- [x] Diff inspection: every elevation is a known write operation (sign-identity-transition's `git push` + cosign OIDC).
- [ ] CI green on this PR.
- [ ] Post-merge: re-run Scorecard locally / observe the alert closure on the next CodeQL push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)