### PR TITLE
feat(aegis-fetch): .partial streaming + rename-on-verify (#655 Phase 3 slice 1)

### DIFF
--- a/crates/aegis-fetch/src/lib.rs
+++ b/crates/aegis-fetch/src/lib.rs
@@ -210,23 +210,54 @@ pub fn fetch_catalog_entry(
     })?;
 
     let iso_filename = filename_from_url(entry.iso_url);
-    let iso_path = dest_dir.join(iso_filename);
-    let bytes = download::download_to_file(entry.iso_url, &iso_path, on_event)?;
+    let final_path = dest_dir.join(iso_filename);
+    // Stream into `<iso>.partial` so an interrupted / failed fetch
+    // can never masquerade as a verified ISO on the next session's
+    // iso-probe scan. The rename to the final path happens only
+    // after every verify step succeeds — the file at `final_path`
+    // is, by construction, the byte sequence the vendor signed.
+    // (#655 Phase 3 atomicity property.)
+    let partial_path = dest_dir.join(format!("{iso_filename}.partial"));
+    let bytes = download::download_to_file(entry.iso_url, &partial_path, on_event)?;
 
     let fingerprint = match entry.verify {
         SigPattern::ClearsignedSums => {
-            verify_clearsigned_path(entry, cert_bytes, &iso_path, on_event)?
+            verify_clearsigned_path(entry, cert_bytes, &partial_path, on_event)
         }
         SigPattern::DetachedSigOnSums => {
-            verify_detached_on_sums_path(entry, cert_bytes, &iso_path, on_event)?
+            verify_detached_on_sums_path(entry, cert_bytes, &partial_path, on_event)
         }
         SigPattern::DetachedSigOnIso => {
-            verify_detached_on_iso_path(entry, cert_bytes, &iso_path, on_event)?
+            verify_detached_on_iso_path(entry, cert_bytes, &partial_path, on_event)
+        }
+    };
+    // On any verify failure, drop the .partial so a retry doesn't
+    // see a half-stream + skip the download. Best-effort — a stale
+    // .partial left behind by an OS crash mid-fetch is recoverable
+    // because the next session re-downloads from byte 0 (until
+    // resume lands as a follow-up to this slice).
+    let fingerprint = match fingerprint {
+        Ok(fp) => fp,
+        Err(e) => {
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(e);
         }
     };
 
+    // Atomic rename: the file at `final_path` exists iff every
+    // verify step above succeeded. POSIX rename(2) is atomic
+    // within the same filesystem (which is true here — the data
+    // partition is a single mount).
+    std::fs::rename(&partial_path, &final_path).map_err(|e| FetchError::Filesystem {
+        detail: format!(
+            "rename {} -> {}: {e}",
+            partial_path.display(),
+            final_path.display()
+        ),
+    })?;
+
     let outcome = FetchOutcome {
-        iso_path,
+        iso_path: final_path,
         bytes,
         sha256_hex: fingerprint.iso_sha256_hex,
         vendor: entry.vendor,


### PR DESCRIPTION
## Summary

First slice of #655 Phase 3. Establishes the atomicity property for catalog ISO downloads: on any verify failure, the destination directory contains **no file at the final ISO path**. The next iso-probe scan won't pick up a half-stream and mistakenly treat it as a complete, verified ISO.

Phase 3 was originally proposed as 3 sub-features in one PR (~600-800 LOC). This PR ships the most safety-critical of the three; HTTP `Range:` resume + drop-receiver cancellation land as follow-up slices to keep review surface tight.

## What changes

- `aegis-fetch::fetch_catalog_entry` streams downloads to `<iso>.partial` instead of the final filename.
- Verify (sha256 + sig dispatch on `SigPattern`) runs against `.partial`.
- On verify Ok: POSIX `rename(2)` of `.partial` → final path. Atomic within the filesystem (AEGIS_ISOS is one mount).
- On verify Err: best-effort `remove_file(.partial)` before bubbling the error. A stale `.partial` left behind by an OS crash is recoverable — the next `download_to_file` call uses `File::create` which truncates.

## Why slice 1 is this exact cut

The three Phase 3 sub-features have very different trust postures:

1. **`.partial` + rename-on-verify** — closes a real failure mode operators can hit today. Power-loss mid-fetch leaves `<iso>` at the destination, iso-probe sees it, rescue-tui shows it. There is no in-rescue verify of bare ISOs (the trust path runs at fetch time). This PR closes that hole.
2. **HTTP `Range:` resume** — pure UX. No safety bearing.
3. **Drop-receiver cancellation** — pure UX + thread-management hygiene.

Shipping (1) first means the safety property lands before the ergonomic conveniences. (2) and (3) can iterate without re-reviewing the atomicity primitive.

## Test plan

- [x] 34 aegis-fetch tests pass — existing CatalogConfirm / verify-path tests exercise the rename through the `FetchOutcome` struct.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] CI green (this PR).

Refs #655 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)