### PR TITLE
feat(aegis-fetch): cooperative cancel via AtomicBool (#655 Phase 3 slice 3)

### DIFF
--- a/crates/aegis-cli/src/fetch.rs
+++ b/crates/aegis-cli/src/fetch.rs
@@ -41,6 +41,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::atomic::AtomicBool;
 
 use aegis_catalog::{Entry, SbStatus, find_entry};
 use aegis_fetch::{FetchError, FetchEvent, FetchProgress, VendorKeyring};
@@ -116,9 +117,17 @@ pub(crate) fn try_run(args: &[String]) -> Result<(), u8> {
     println!();
 
     let mut renderer = ProgressRenderer::new(show_progress);
-    let outcome = match aegis_fetch::fetch_catalog_entry(entry, &dest, &keyring, &mut |event| {
-        renderer.handle(&event);
-    }) {
+    // CLI has no Esc handler — pass a permanently-false flag.
+    let cancelled = AtomicBool::new(false);
+    let outcome = match aegis_fetch::fetch_catalog_entry(
+        entry,
+        &dest,
+        &keyring,
+        &mut |event| {
+            renderer.handle(&event);
+        },
+        &cancelled,
+    ) {
         Ok(o) => {
             renderer.finish_done();
             o
@@ -214,6 +223,12 @@ fn report_fetch_error(err: &FetchError, entry: &Entry) -> u8 {
             eprintln!("the catalog declared this entry as ClearsignedSums; either the vendor");
             eprintln!("switched format or the entry's verify field is wrong. file an issue.");
             1
+        }
+        FetchError::Cancelled => {
+            // The CLI never sets the cancel flag (no Esc handler);
+            // this arm exists only for exhaustive matching.
+            eprintln!("aegis-boot fetch: cancelled");
+            130
         }
     }
 }

--- a/crates/aegis-fetch/src/download.rs
+++ b/crates/aegis-fetch/src/download.rs
@@ -27,6 +27,7 @@
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use ureq::Agent;
@@ -80,6 +81,7 @@ pub(crate) fn download_to_file(
     url: &str,
     dest: &Path,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<u64, FetchError> {
     on_event(FetchEvent::Connecting);
     let agent = build_agent();
@@ -89,7 +91,7 @@ pub(crate) fn download_to_file(
     let existing = std::fs::metadata(dest).map_or(0, |m| m.len());
 
     if existing > 0 {
-        match try_resume(&agent, url, dest, existing, on_event)? {
+        match try_resume(&agent, url, dest, existing, on_event, cancelled)? {
             ResumeOutcome::Resumed(total) => return Ok(total),
             ResumeOutcome::FullRestart => {
                 // Server returned 200 instead of 206. Fall through
@@ -108,7 +110,14 @@ pub(crate) fn download_to_file(
     let file = File::create(dest).map_err(|e| FetchError::Filesystem {
         detail: format!("create {}: {e}", dest.display()),
     })?;
-    let written = pump_to_writer(reader, BufWriter::new(file), total, on_event, dest)?;
+    let written = pump_to_writer(
+        reader,
+        BufWriter::new(file),
+        total,
+        on_event,
+        dest,
+        cancelled,
+    )?;
     Ok(written)
 }
 
@@ -135,6 +144,7 @@ fn try_resume(
     dest: &Path,
     existing: u64,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<ResumeOutcome, FetchError> {
     let range_header = format!("bytes={existing}-");
     let mut resp = match agent.get(url).header("Range", &range_header).call() {
@@ -187,6 +197,7 @@ fn try_resume(
         existing,
         on_event,
         dest,
+        cancelled,
     )?;
     Ok(ResumeOutcome::Resumed(existing.saturating_add(appended)))
 }
@@ -239,10 +250,14 @@ fn pump_to_writer_with_offset<R: Read, W: Write>(
     offset: u64,
     on_event: &mut dyn FnMut(FetchEvent),
     dest: &Path,
+    cancelled: &AtomicBool,
 ) -> Result<u64, FetchError> {
     let mut buf = vec![0u8; CHUNK_BYTES];
     let mut appended: u64 = 0;
     loop {
+        if cancelled.load(Ordering::Relaxed) {
+            return Err(FetchError::Cancelled);
+        }
         let n = reader.read(&mut buf).map_err(|e| FetchError::Network {
             url: dest.display().to_string(),
             detail: format!("read body: {e}"),
@@ -275,10 +290,14 @@ fn pump_to_writer<R: Read, W: Write>(
     total: Option<u64>,
     on_event: &mut dyn FnMut(FetchEvent),
     dest: &Path,
+    cancelled: &AtomicBool,
 ) -> Result<u64, FetchError> {
     let mut buf = vec![0u8; CHUNK_BYTES];
     let mut written: u64 = 0;
     loop {
+        if cancelled.load(Ordering::Relaxed) {
+            return Err(FetchError::Cancelled);
+        }
         let n = reader.read(&mut buf).map_err(|e| FetchError::Network {
             url: dest.display().to_string(),
             detail: format!("read body: {e}"),
@@ -321,12 +340,14 @@ mod tests {
         let file = File::create(&dest).expect("create");
         let mut events: Vec<FetchEvent> = Vec::new();
         let mut on_event = |e: FetchEvent| events.push(e);
+        let cancelled = AtomicBool::new(false);
         let n = pump_to_writer(
             cursor,
             BufWriter::new(file),
             Some(payload.len() as u64),
             &mut on_event,
             &dest,
+            &cancelled,
         )
         .expect("pump");
         assert_eq!(n, payload.len() as u64);
@@ -364,8 +385,15 @@ mod tests {
         let file = File::create(&dest).expect("create");
         let mut events: Vec<FetchEvent> = Vec::new();
         let mut on_event = |e: FetchEvent| events.push(e);
-        let n = pump_to_writer(cursor, BufWriter::new(file), Some(0), &mut on_event, &dest)
-            .expect("pump");
+        let n = pump_to_writer(
+            cursor,
+            BufWriter::new(file),
+            Some(0),
+            &mut on_event,
+            &dest,
+            &AtomicBool::new(false),
+        )
+        .expect("pump");
         assert_eq!(n, 0);
         let downloading = events
             .iter()
@@ -391,8 +419,15 @@ mod tests {
                 totals.push(p.total);
             }
         };
-        let _ =
-            pump_to_writer(cursor, BufWriter::new(file), None, &mut on_event, &dest).expect("pump");
+        let _ = pump_to_writer(
+            cursor,
+            BufWriter::new(file),
+            None,
+            &mut on_event,
+            &dest,
+            &AtomicBool::new(false),
+        )
+        .expect("pump");
         assert!(downloading_seen >= 2);
         assert!(totals.iter().all(Option::is_none));
     }
@@ -427,6 +462,7 @@ mod tests {
             prior_size,
             &mut on_event,
             &dest,
+            &AtomicBool::new(false),
         )
         .expect("resume pump");
         assert_eq!(appended, new_payload.len() as u64);
@@ -452,8 +488,56 @@ mod tests {
             6,
             &mut |_| {},
             &dest,
+            &AtomicBool::new(false),
         )
         .expect("pump");
         assert_eq!(std::fs::read(&dest).expect("read"), b"hello world");
+    }
+
+    // ---- Phase 3 slice 3: cooperative cancellation ------------------
+
+    #[test]
+    fn pump_with_pre_set_cancel_flag_returns_cancelled() {
+        // Caller flips the AtomicBool before any bytes flow. The
+        // first loop iteration's cancel check must short-circuit
+        // with FetchError::Cancelled — no bytes written, no panic.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("dl");
+        let file = File::create(&dest).expect("create");
+        let payload: Vec<u8> = vec![0u8; CHUNK_BYTES * 2];
+        let cancelled = AtomicBool::new(true);
+        let err = pump_to_writer(
+            Cursor::new(payload),
+            BufWriter::new(file),
+            None,
+            &mut |_| {},
+            &dest,
+            &cancelled,
+        )
+        .expect_err("should be cancelled");
+        assert!(matches!(err, FetchError::Cancelled));
+    }
+
+    #[test]
+    fn pump_with_offset_pre_set_cancel_returns_cancelled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("dl");
+        std::fs::write(&dest, b"prior").expect("seed");
+        let file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&dest)
+            .expect("open");
+        let cancelled = AtomicBool::new(true);
+        let err = pump_to_writer_with_offset(
+            Cursor::new(vec![0u8; CHUNK_BYTES]),
+            BufWriter::new(file),
+            Some((CHUNK_BYTES + 5) as u64),
+            5,
+            &mut |_| {},
+            &dest,
+            &cancelled,
+        )
+        .expect_err("should be cancelled");
+        assert!(matches!(err, FetchError::Cancelled));
     }
 }

--- a/crates/aegis-fetch/src/lib.rs
+++ b/crates/aegis-fetch/src/lib.rs
@@ -38,6 +38,7 @@
 #![warn(missing_docs)]
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use aegis_catalog::{Entry, SigPattern, Vendor};
 
@@ -176,6 +177,14 @@ pub enum FetchError {
     /// file that wasn't actually a clearsigned envelope.
     #[error("sums: not a clearsigned envelope")]
     NotClearsigned,
+    /// Fetch was cancelled by the caller via the `cancelled`
+    /// `AtomicBool` passed to [`fetch_catalog_entry`]. Mid-stream
+    /// cancel is cooperative — checked between chunks, not on every
+    /// byte. Caller's `<iso>.partial` is left on disk so the next
+    /// fetch resumes from where the cancel landed (#655 Phase 3
+    /// slice 3).
+    #[error("fetch cancelled by caller")]
+    Cancelled,
 }
 
 /// Download + verify a catalog [`Entry`] end-to-end, writing the
@@ -198,6 +207,7 @@ pub fn fetch_catalog_entry(
     dest_dir: &Path,
     keyring: &VendorKeyring,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<FetchOutcome, FetchError> {
     let cert_bytes = keyring
         .cert_armor(entry.vendor)
@@ -218,26 +228,27 @@ pub fn fetch_catalog_entry(
     // is, by construction, the byte sequence the vendor signed.
     // (#655 Phase 3 atomicity property.)
     let partial_path = dest_dir.join(format!("{iso_filename}.partial"));
-    let bytes = download::download_to_file(entry.iso_url, &partial_path, on_event)?;
+    let bytes = download::download_to_file(entry.iso_url, &partial_path, on_event, cancelled)?;
 
     let fingerprint = match entry.verify {
         SigPattern::ClearsignedSums => {
-            verify_clearsigned_path(entry, cert_bytes, &partial_path, on_event)
+            verify_clearsigned_path(entry, cert_bytes, &partial_path, on_event, cancelled)
         }
         SigPattern::DetachedSigOnSums => {
-            verify_detached_on_sums_path(entry, cert_bytes, &partial_path, on_event)
+            verify_detached_on_sums_path(entry, cert_bytes, &partial_path, on_event, cancelled)
         }
         SigPattern::DetachedSigOnIso => {
-            verify_detached_on_iso_path(entry, cert_bytes, &partial_path, on_event)
+            verify_detached_on_iso_path(entry, cert_bytes, &partial_path, on_event, cancelled)
         }
     };
     // On any verify failure, drop the .partial so a retry doesn't
-    // see a half-stream + skip the download. Best-effort — a stale
-    // .partial left behind by an OS crash mid-fetch is recoverable
-    // because the next session re-downloads from byte 0 (until
-    // resume lands as a follow-up to this slice).
+    // see a half-stream + skip the download. Cancellation is
+    // intentionally NOT a verify failure — keep the partial so a
+    // resume from the cancel point picks up cleanly (#655 Phase 3
+    // slice 3).
     let fingerprint = match fingerprint {
         Ok(fp) => fp,
+        Err(FetchError::Cancelled) => return Err(FetchError::Cancelled),
         Err(e) => {
             let _ = std::fs::remove_file(&partial_path);
             return Err(e);
@@ -280,6 +291,7 @@ fn verify_clearsigned_path(
     cert_bytes: &[u8],
     iso_path: &Path,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<VerifyResult, FetchError> {
     // sha256_url == sig_url for ClearsignedSums; one fetch.
     let sums_bytes = download::download_to_vec(entry.sha256_url)?;
@@ -293,9 +305,7 @@ fn verify_clearsigned_path(
     let verified = verify::verify_clearsigned_sums(cert_bytes, sums_text, entry.slug)?;
 
     on_event(FetchEvent::VerifyingHash);
-    let mut last_hash_bytes: u64 = 0;
-    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |b| last_hash_bytes = b)?;
-    let _ = last_hash_bytes;
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {}, cancelled)?;
 
     let iso_filename = filename_from_url(entry.iso_url);
     let expected = sums::find_iso_sha256(&verified.signed_text, iso_filename)?;
@@ -317,6 +327,7 @@ fn verify_detached_on_sums_path(
     cert_bytes: &[u8],
     iso_path: &Path,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<VerifyResult, FetchError> {
     let sums_bytes = download::download_to_vec(entry.sha256_url)?;
     let sig_bytes = download::download_to_vec(entry.sig_url)?;
@@ -326,7 +337,7 @@ fn verify_detached_on_sums_path(
         verify::verify_detached_sig_on_sums(cert_bytes, &sig_bytes, &sums_bytes, entry.slug)?;
 
     on_event(FetchEvent::VerifyingHash);
-    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {})?;
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {}, cancelled)?;
 
     let sums_text = std::str::from_utf8(&sums_bytes).map_err(|_| FetchError::MalformedSums)?;
     let iso_filename = filename_from_url(entry.iso_url);
@@ -349,6 +360,7 @@ fn verify_detached_on_iso_path(
     cert_bytes: &[u8],
     iso_path: &Path,
     on_event: &mut dyn FnMut(FetchEvent),
+    cancelled: &AtomicBool,
 ) -> Result<VerifyResult, FetchError> {
     let sig_bytes = download::download_to_vec(entry.sig_url)?;
 
@@ -360,7 +372,7 @@ fn verify_detached_on_iso_path(
     // sha256 here is informational, surfaced in FetchOutcome for
     // audit logs and `aegis-boot doctor` output.
     on_event(FetchEvent::VerifyingHash);
-    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {})?;
+    let (iso_sha256_hex, _bytes) = sha256::hash_file(iso_path, &mut |_| {}, cancelled)?;
 
     Ok(VerifyResult {
         iso_sha256_hex,
@@ -392,8 +404,15 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let keyring = VendorKeyring::empty();
         let mut events: Vec<FetchEvent> = Vec::new();
-        let err = fetch_catalog_entry(entry, dir.path(), &keyring, &mut |e| events.push(e))
-            .expect_err("must fail without keyring");
+        let cancelled = AtomicBool::new(false);
+        let err = fetch_catalog_entry(
+            entry,
+            dir.path(),
+            &keyring,
+            &mut |e| events.push(e),
+            &cancelled,
+        )
+        .expect_err("must fail without keyring");
         assert!(matches!(
             err,
             FetchError::UnknownVendor {

--- a/crates/aegis-fetch/src/sha256.rs
+++ b/crates/aegis-fetch/src/sha256.rs
@@ -9,6 +9,7 @@
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use sha2::{Digest, Sha256};
 
@@ -32,6 +33,7 @@ const CHUNK_BYTES: usize = 1 << 20;
 pub(crate) fn hash_file(
     path: &Path,
     on_progress: &mut dyn FnMut(u64),
+    cancelled: &AtomicBool,
 ) -> Result<(String, u64), FetchError> {
     let file = File::open(path).map_err(|e| FetchError::Filesystem {
         detail: format!("open {} for hashing: {e}", path.display()),
@@ -41,6 +43,9 @@ pub(crate) fn hash_file(
     let mut buf = vec![0u8; CHUNK_BYTES];
     let mut total: u64 = 0;
     loop {
+        if cancelled.load(Ordering::Relaxed) {
+            return Err(FetchError::Cancelled);
+        }
         let n = reader.read(&mut buf).map_err(|e| FetchError::Filesystem {
             detail: format!("read {}: {e}", path.display()),
         })?;
@@ -76,7 +81,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("empty");
         std::fs::write(&path, b"").expect("write");
-        let (hex, n) = hash_file(&path, &mut |_| {}).expect("hash");
+        let (hex, n) = hash_file(&path, &mut |_| {}, &AtomicBool::new(false)).expect("hash");
         // SHA-256 of empty input is a well-known fixed value.
         assert_eq!(
             hex,
@@ -91,7 +96,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("abc");
         std::fs::write(&path, b"abc").expect("write");
-        let (hex, n) = hash_file(&path, &mut |_| {}).expect("hash");
+        let (hex, n) = hash_file(&path, &mut |_| {}, &AtomicBool::new(false)).expect("hash");
         assert_eq!(
             hex,
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
@@ -107,7 +112,8 @@ mod tests {
         let big = vec![0u8; (CHUNK_BYTES * 5) / 2];
         std::fs::write(&path, &big).expect("write");
         let mut callbacks: Vec<u64> = Vec::new();
-        let (_, n) = hash_file(&path, &mut |b| callbacks.push(b)).expect("hash");
+        let (_, n) =
+            hash_file(&path, &mut |b| callbacks.push(b), &AtomicBool::new(false)).expect("hash");
         assert_eq!(n, big.len() as u64);
         assert!(
             callbacks.len() >= 3,
@@ -121,10 +127,23 @@ mod tests {
     }
 
     #[test]
+    fn hash_with_cancelled_flag_returns_cancelled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("big");
+        // Big enough that the cancel check fires between chunks
+        // (one 1 MiB chunk = 1 cancel check minimum).
+        std::fs::write(&path, vec![0u8; CHUNK_BYTES * 3]).expect("write");
+        let cancelled = AtomicBool::new(true); // already-cancelled
+        let err = hash_file(&path, &mut |_| {}, &cancelled).expect_err("cancelled");
+        assert!(matches!(err, FetchError::Cancelled));
+    }
+
+    #[test]
     fn hash_missing_file_is_filesystem_error() {
         let err = hash_file(
             std::path::Path::new("/nonexistent/aegis-fetch-test"),
             &mut |_| {},
+            &AtomicBool::new(false),
         )
         .expect_err("should fail");
         assert!(matches!(err, FetchError::Filesystem { .. }));

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -18,6 +18,8 @@ use std::env;
 use std::io;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
 use std::time::Duration;
@@ -311,11 +313,13 @@ where
     // Active DHCP worker (#655 Phase 1B). Same ownership shape as
     // verify: Some(rx) while udhcpc runs, None otherwise.
     let mut active_dhcp: Option<Receiver<NetworkMsg>> = None;
-    // Active catalog-fetch worker (#655 PR-C step 2). Some(rx) while
-    // fetch_catalog_entry runs in a thread, None otherwise. Single
-    // in-flight by construction — the UI locks Esc on CatalogConfirm
-    // while op is non-terminal so a second fetch can't be spawned.
-    let mut active_fetch: Option<Receiver<FetchMsg>> = None;
+    // Active catalog-fetch worker (#655 PR-C step 2). Some(rx, cancel)
+    // while fetch_catalog_entry runs in a thread, None otherwise.
+    // Single in-flight by construction. The Arc<AtomicBool> is shared
+    // with the worker so Esc-during-fetch flips it and the worker
+    // returns FetchError::Cancelled at the next 1 MiB boundary
+    // (#655 Phase 3 slice 3).
+    let mut active_fetch: Option<(Receiver<FetchMsg>, Arc<AtomicBool>)> = None;
 
     loop {
         terminal.draw(|f| render::draw(f, state))?;
@@ -346,7 +350,7 @@ where
         }
 
         // Drain catalog-fetch worker messages (#655 PR-C step 2).
-        if let Some(rx) = active_fetch.as_ref() {
+        if let Some((rx, _)) = active_fetch.as_ref() {
             loop {
                 match rx.try_recv() {
                     Ok(FetchMsg::Event(ev)) => {
@@ -757,8 +761,10 @@ where
                     match aegis_fetch::VendorKeyring::embedded() {
                         Ok(keyring) => {
                             let dest = std::path::PathBuf::from(CATALOG_FETCH_DEST_DIR);
-                            let rx = spawn_fetch_worker(entry, dest, keyring);
-                            active_fetch = Some(rx);
+                            let cancelled = Arc::new(AtomicBool::new(false));
+                            let rx =
+                                spawn_fetch_worker(entry, dest, keyring, Arc::clone(&cancelled));
+                            active_fetch = Some((rx, cancelled));
                         }
                         Err(e) => {
                             state.catalog_finish_fetch(Err(format!(
@@ -769,7 +775,18 @@ where
                 }
             }
             (Screen::CatalogConfirm { .. }, KeyCode::Esc | KeyCode::Char('q')) => {
-                state.catalog_cancel_confirm();
+                // Esc during a non-terminal fetch flips the shared
+                // cancel flag; the worker returns FetchError::Cancelled
+                // at the next 1 MiB boundary, and catalog_finish_fetch
+                // routes it as a Failed state. If no fetch is in
+                // flight, fall through to the state machine which
+                // dismisses the confirm screen back to the Catalog
+                // list (#655 Phase 3 slice 3).
+                if let Some((_, cancelled)) = active_fetch.as_ref() {
+                    cancelled.store(true, Ordering::Relaxed);
+                } else {
+                    state.catalog_cancel_confirm();
+                }
             }
             (Screen::Confirm { selected }, KeyCode::Char('v')) => {
                 let real_idx = *selected;
@@ -1221,24 +1238,34 @@ enum FetchMsg {
 
 /// Spawn a thread that runs `aegis_fetch::fetch_catalog_entry` and
 /// emits Event + Done messages on the returned Receiver. The
-/// thread terminates after Done is sent. The fetch is synchronous
-/// and uncancellable in this PR — Phase 3 of #655 will add resume
-/// + cancellation.
+/// thread terminates after Done is sent.
+///
+/// `cancelled` is a shared flag the UI flips to request cooperative
+/// cancellation (#655 Phase 3 slice 3). The worker passes the flag
+/// to `aegis_fetch`, which polls it between 1 MiB chunks during
+/// download + hash, returning `FetchError::Cancelled` once set.
 fn spawn_fetch_worker(
     entry: &'static aegis_catalog::Entry,
     dest_dir: std::path::PathBuf,
     keyring: aegis_fetch::VendorKeyring,
+    cancelled: Arc<AtomicBool>,
 ) -> Receiver<FetchMsg> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         let tx_inner = tx.clone();
-        let result = aegis_fetch::fetch_catalog_entry(entry, &dest_dir, &keyring, &mut |ev| {
-            // Suppress the in-band Done — `FetchMsg::Done` below
-            // is the canonical terminal transition.
-            if !matches!(ev, aegis_fetch::FetchEvent::Done(_)) {
-                let _ = tx_inner.send(FetchMsg::Event(ev));
-            }
-        });
+        let result = aegis_fetch::fetch_catalog_entry(
+            entry,
+            &dest_dir,
+            &keyring,
+            &mut |ev| {
+                // Suppress the in-band Done — `FetchMsg::Done` below
+                // is the canonical terminal transition.
+                if !matches!(ev, aegis_fetch::FetchEvent::Done(_)) {
+                    let _ = tx_inner.send(FetchMsg::Event(ev));
+                }
+            },
+            &cancelled,
+        );
         let _ = tx.send(FetchMsg::Done(result.map_err(|e| e.to_string())));
     });
     rx


### PR DESCRIPTION
## Summary

- Plumb a `cancelled: &AtomicBool` through the fetch pipeline (download + sha256 + signed-chain verify). New `FetchError::Cancelled` variant.
- Cancel checks fire between 1 MiB chunks (matches existing progress cadence). Cancel mid-download leaves the `<iso>.partial` on disk so the next attempt resumes via the slice-2 Range path; only verify-failures drop the partial.
- `rescue-tui`: `spawn_fetch_worker` now takes an `Arc<AtomicBool>`; `active_fetch` slot holds the receiver + the flag. Esc on `CatalogConfirm` during a non-terminal fetch flips the flag (previously the screen rejected the press because the fetch was uncancellable).
- `aegis-cli`: passes a permanently-false `AtomicBool` since the CLI has no Esc handler.

## Test plan

- [x] `cargo test -p aegis-fetch` — 39 passed (incl. 2 new pump tests + 1 new hash test for pre-set flag)
- [x] `cargo test --workspace` — all green (779/30/8/39/...)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all`
- [ ] Manual rescue-tui Esc-during-fetch verification (deferred — covered by the unit tests at the pump boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)