### PR TITLE
chore(security): mirror RUSTSEC-2023-0071 ignore into osv-scanner.toml

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,23 @@
+# osv-scanner.toml — ignore-list for OSV-Scanner / Scorecard's
+# `Vulnerabilities` (RUSTSEC) check.
+#
+# Why this file exists separately from `deny.toml`:
+# `cargo-deny` reads `deny.toml`; the OSSF Scorecard
+# `VulnerabilitiesID` check shells out to OSV-Scanner, which has its
+# own ignore format. We mirror the same set of advisories + rationale
+# here so the two tools stay in sync. If you're adding/removing an
+# advisory, edit BOTH files in the same commit.
+#
+# Format reference:
+#   https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+# Mirrors the rationale in deny.toml. RustCrypto/rsa Marvin Attack —
+# timing sidechannel on private-key operations. Pulled in transitively
+# via pgp (rpgp) -> aegis-fetch (#655 Phase 2B). aegis-fetch is
+# verify-only: we hold no RSA private keys and never decrypt or sign,
+# so the sidechannel is not exploitable in our threat model.
+# Re-evaluate if rpgp ever gains a signing-side consumer here, or if a
+# constant-time rsa fix ships upstream.
+reason = "transitive via pgp/rpgp; aegis-fetch is verify-only and holds no RSA private keys, so the timing sidechannel on private-key operations is not exploitable in our threat model"


### PR DESCRIPTION
## Summary

- Scorecard alert #171 (\`VulnerabilitiesID\`) flags RUSTSEC-2023-0071 (rsa / Marvin Attack) because OSV-Scanner reads \`osv-scanner.toml\`, not \`deny.toml\` — the rationale we already have for cargo-deny was invisible to it.
- This PR adds a tiny \`osv-scanner.toml\` mirroring the same ignore + same reason.

## Why the advisory is not exploitable here

aegis-fetch is verify-only: no RSA private keys held, no decryption, no signing. The Marvin Attack extracts private-key bits from observed timing of private-key operations — there are no such operations in our process.

## Test plan

- [x] No code change — affects only Scorecard's OSV-Scanner integration
- [ ] Confirm Scorecard re-scan closes alert #171 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)