### PR TITLE
feat(rescue-tui): rolling-window ETA on catalog fetch (#655 Phase 3 slice 4)

### DIFF
--- a/crates/rescue-tui/src/render.rs
+++ b/crates/rescue-tui/src/render.rs
@@ -2397,6 +2397,23 @@ fn draw_catalog_confirm_overlay(
             progress_text,
             Style::default().fg(Color::DarkGray),
         )));
+        // Rolling-window rate + ETA, only when the tracker has
+        // crossed its minimum-sample threshold (#655 Phase 3
+        // slice 4). One operator-readable line: `42 KB/s — ETA 2m18s`.
+        if let Some(stats) = state.download_rate.stats(*total) {
+            let rate_text = format!(
+                "         {}/s{}",
+                humanize_bytes(stats.bytes_per_sec),
+                stats
+                    .eta_seconds
+                    .map(|s| format!(" — ETA {}", humanize_duration(s)))
+                    .unwrap_or_default()
+            );
+            lines.push(Line::from(Span::styled(
+                rate_text,
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
     }
 
     lines.push(Line::from(""));
@@ -2405,7 +2422,7 @@ fn draw_catalog_confirm_overlay(
         crate::state::CatalogOp::Connecting
         | crate::state::CatalogOp::Downloading { .. }
         | crate::state::CatalogOp::VerifyingHash
-        | crate::state::CatalogOp::VerifyingSig => "[fetch in flight — Esc locked]",
+        | crate::state::CatalogOp::VerifyingSig => "[Esc] cancel fetch",
         crate::state::CatalogOp::Success(_) | crate::state::CatalogOp::Failed(_) => {
             "[Esc] back to catalog"
         }
@@ -2493,6 +2510,24 @@ fn draw_consent_network_use_overlay(frame: &mut Frame<'_>, area: Rect, state: &A
     frame.render_widget(para, panel);
 }
 
+/// Render an elapsed-seconds count as a compact duration string
+/// (`< 1s`, `42s`, `5m13s`, `1h05m`). Used by the catalog-fetch ETA
+/// line (#655 Phase 3 slice 4); keeps the format short enough to fit
+/// in the existing single-line progress band.
+fn humanize_duration(seconds: u64) -> String {
+    if seconds < 60 {
+        return format!("{seconds}s");
+    }
+    let minutes = seconds / 60;
+    let secs = seconds % 60;
+    if minutes < 60 {
+        return format!("{minutes}m{secs:02}s");
+    }
+    let hours = minutes / 60;
+    let mins = minutes % 60;
+    format!("{hours}h{mins:02}m")
+}
+
 /// Render `n` bytes as a humane size string (B / KiB / MiB / GiB).
 fn humanize_bytes(n: u64) -> String {
     const KIB: u64 = 1024;
@@ -2522,6 +2557,29 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use std::path::PathBuf;
+
+    // ---- #655 Phase 3 slice 4: humanize_duration --------------------------
+
+    #[test]
+    fn humanize_duration_sub_minute() {
+        assert_eq!(humanize_duration(0), "0s");
+        assert_eq!(humanize_duration(1), "1s");
+        assert_eq!(humanize_duration(59), "59s");
+    }
+
+    #[test]
+    fn humanize_duration_minutes_zero_pads_seconds() {
+        assert_eq!(humanize_duration(60), "1m00s");
+        assert_eq!(humanize_duration(73), "1m13s");
+        assert_eq!(humanize_duration(3599), "59m59s");
+    }
+
+    #[test]
+    fn humanize_duration_hours_zero_pads_minutes() {
+        assert_eq!(humanize_duration(3600), "1h00m");
+        assert_eq!(humanize_duration(3660), "1h01m");
+        assert_eq!(humanize_duration(7320), "2h02m");
+    }
 
     // ---- #274 Phase 6c: subfolder-prefix rendering ------------------------
 

--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -421,6 +421,12 @@ pub struct AppState {
     /// to true via [`Self::grant_consent_network_use`]. Once true,
     /// `n` opens [`Screen::Network`] directly without re-prompting.
     pub session_network_consent: bool,
+    /// Rolling-window byte-rate tracker for the active catalog
+    /// download (#655 Phase 3 slice 4). Empty when no fetch is in
+    /// flight or the operator hasn't crossed the first sample
+    /// boundary yet. Read by the renderer to compute `KB/s` + ETA
+    /// on the [`Screen::CatalogConfirm`] progress line.
+    pub download_rate: DownloadRateTracker,
     /// Most recent successful DHCP lease, if any. Set by
     /// [`Self::network_finish_dhcp`] on the Ok branch and consumed
     /// by `Screen::Catalog` to gate fetch availability + by the
@@ -622,6 +628,101 @@ impl TpmStatus {
     }
 }
 
+/// Rolling-window byte-rate tracker (#655 Phase 3 slice 4).
+///
+/// Holds up to [`Self::WINDOW`]-seconds of `(timestamp, bytes_so_far)`
+/// samples and exposes a `bytes_per_sec` + `eta_seconds` derivative.
+/// Single-window EMA was tempting (smoother) but a fixed-window
+/// linear regression is what an operator actually expects to see —
+/// "in the last 30 s I've moved X bytes" — and it self-corrects when
+/// a vendor mirror bursts then stalls.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DownloadRateTracker {
+    samples: std::collections::VecDeque<(std::time::Instant, u64)>,
+}
+
+/// Snapshot of the live download rate. Returned by
+/// [`DownloadRateTracker::stats`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DownloadStats {
+    /// Average rate over the rolling window.
+    pub bytes_per_sec: u64,
+    /// Estimated seconds remaining, only Some when `total` is known
+    /// AND the rate is non-zero.
+    pub eta_seconds: Option<u64>,
+}
+
+impl DownloadRateTracker {
+    /// Window length over which the rate is averaged. 30 s is long
+    /// enough to absorb chunk-level jitter (a 1 MiB read on a fast
+    /// link is sub-second; on a slow link it's seconds) and short
+    /// enough that a stall is reflected in the displayed ETA within
+    /// half a window.
+    pub const WINDOW: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Record a `bytes_so_far` sample. Wall-clock variant used by
+    /// the worker; see [`Self::record_at`] for tests.
+    pub fn record(&mut self, bytes: u64) {
+        self.record_at(std::time::Instant::now(), bytes);
+    }
+
+    /// Test-injectable variant of [`Self::record`]. Drops samples
+    /// older than [`Self::WINDOW`] before pushing the new one.
+    pub fn record_at(&mut self, now: std::time::Instant, bytes: u64) {
+        while let Some(&(t, _)) = self.samples.front() {
+            if now.duration_since(t) > Self::WINDOW {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.samples.push_back((now, bytes));
+    }
+
+    /// Drop all samples. Called when the fetch transitions out of
+    /// the Downloading state (success, failure, or a fresh restart)
+    /// so the next download starts with a clean window.
+    pub fn reset(&mut self) {
+        self.samples.clear();
+    }
+
+    /// Compute live rate + ETA. Returns `None` if there are fewer
+    /// than 2 samples or the elapsed window is < 1 s — both cases
+    /// produce noisy estimates that would flicker in the UI.
+    #[must_use]
+    pub fn stats(&self, total: Option<u64>) -> Option<DownloadStats> {
+        if self.samples.len() < 2 {
+            return None;
+        }
+        let (t_first, b_first) = *self.samples.front()?;
+        let (t_last, b_last) = *self.samples.back()?;
+        let dt = t_last.duration_since(t_first).as_secs_f64();
+        if dt < 1.0 {
+            return None;
+        }
+        let db = b_last.saturating_sub(b_first);
+        // Cast through f64 for the divide; round down on the way back
+        // to u64 so a sub-1 B/s rate reports as 0 (and the ETA call
+        // below falls through to None).
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let bps = (db as f64 / dt) as u64;
+        if bps == 0 {
+            return None;
+        }
+        let eta_seconds = total
+            .and_then(|t| t.checked_sub(b_last))
+            .map(|remaining| remaining / bps);
+        Some(DownloadStats {
+            bytes_per_sec: bps,
+            eta_seconds,
+        })
+    }
+}
+
 impl AppState {
     /// Build a fresh state from a discovery result.
     #[must_use]
@@ -645,6 +746,7 @@ impl AppState {
             audit_warning: None,
             session_consent: false,
             session_network_consent: false,
+            download_rate: DownloadRateTracker::default(),
             network_lease: None,
         }
     }
@@ -1617,6 +1719,17 @@ impl AppState {
     /// with the typed result, and that's the canonical path to
     /// Success/Failed.
     pub fn catalog_progress(&mut self, ev: &aegis_fetch::FetchEvent) {
+        // Feed / reset the rolling-window rate tracker so the
+        // renderer can compute KB/s + ETA on the progress line
+        // (#655 Phase 3 slice 4). Done before the screen-mutation
+        // borrow to keep the partial-borrow simple.
+        match ev {
+            aegis_fetch::FetchEvent::Downloading(p) => self.download_rate.record(p.bytes),
+            aegis_fetch::FetchEvent::Connecting
+            | aegis_fetch::FetchEvent::VerifyingHash
+            | aegis_fetch::FetchEvent::VerifyingSig => self.download_rate.reset(),
+            aegis_fetch::FetchEvent::Done(_) => {}
+        }
         let Screen::CatalogConfirm { op, .. } = &mut self.screen else {
             return;
         };
@@ -1638,6 +1751,7 @@ impl AppState {
     /// Apply the worker's terminal `FetchMsg::Done` result. Flips
     /// the op state to Success or Failed.
     pub fn catalog_finish_fetch(&mut self, result: Result<aegis_fetch::FetchOutcome, String>) {
+        self.download_rate.reset();
         let Screen::CatalogConfirm { op, .. } = &mut self.screen else {
             return;
         };
@@ -2079,6 +2193,88 @@ mod tests {
     use super::*;
     use iso_probe::Distribution;
     use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    // ---- #655 Phase 3 slice 4: DownloadRateTracker ------------------------
+
+    #[test]
+    fn rate_tracker_returns_none_with_one_sample() {
+        let mut t = DownloadRateTracker::default();
+        t.record_at(Instant::now(), 1024);
+        assert!(t.stats(Some(2048)).is_none());
+    }
+
+    #[test]
+    fn rate_tracker_returns_none_when_window_too_narrow() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        t.record_at(t0, 0);
+        // 200 ms apart — under the 1 s threshold so the rate would
+        // be noisy. Tracker correctly returns None.
+        t.record_at(t0 + Duration::from_millis(200), 1024 * 100);
+        assert!(t.stats(Some(1_000_000)).is_none());
+    }
+
+    #[test]
+    fn rate_tracker_computes_rate_and_eta() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        t.record_at(t0, 0);
+        t.record_at(t0 + Duration::from_secs(2), 200_000); // 100 KB/s
+        let stats = t.stats(Some(1_000_000)).unwrap_or_else(|| panic!("stats"));
+        assert_eq!(stats.bytes_per_sec, 100_000);
+        // Remaining = 1_000_000 - 200_000 = 800_000 / 100_000 = 8 s
+        assert_eq!(stats.eta_seconds, Some(8));
+    }
+
+    #[test]
+    fn rate_tracker_no_eta_when_total_unknown() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        t.record_at(t0, 0);
+        t.record_at(t0 + Duration::from_secs(2), 200_000);
+        let stats = t.stats(None).unwrap_or_else(|| panic!("stats"));
+        assert_eq!(stats.bytes_per_sec, 100_000);
+        assert!(stats.eta_seconds.is_none());
+    }
+
+    #[test]
+    fn rate_tracker_drops_samples_outside_window() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        // Stale sample 60 s in the past.
+        t.record_at(t0, 0);
+        // Two fresh samples 2 s apart at the current time.
+        let now = t0 + Duration::from_secs(60);
+        t.record_at(now, 5_000_000); // first stale-prune purges t0
+        t.record_at(now + Duration::from_secs(2), 5_200_000);
+        let stats = t.stats(None).unwrap_or_else(|| panic!("stats"));
+        // Window is the two fresh samples: 200_000 B / 2 s = 100 KB/s.
+        // (If the stale t0 had leaked in, rate would be ~86 KB/s.)
+        assert_eq!(stats.bytes_per_sec, 100_000);
+    }
+
+    #[test]
+    fn rate_tracker_reset_clears_window() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        t.record_at(t0, 0);
+        t.record_at(t0 + Duration::from_secs(2), 200_000);
+        assert!(t.stats(Some(1_000_000)).is_some());
+        t.reset();
+        assert!(t.stats(Some(1_000_000)).is_none());
+    }
+
+    #[test]
+    fn rate_tracker_zero_byte_progress_returns_none() {
+        let mut t = DownloadRateTracker::default();
+        let t0 = Instant::now();
+        // Two samples but no bytes moved → 0 B/s rate → stats None
+        // (avoids divide-by-zero in the ETA calc).
+        t.record_at(t0, 5000);
+        t.record_at(t0 + Duration::from_secs(2), 5000);
+        assert!(t.stats(Some(1_000_000)).is_none());
+    }
 
     fn fake_iso(label: &str) -> DiscoveredIso {
         DiscoveredIso {


### PR DESCRIPTION
## Summary

- 30-second rolling-window byte-rate tracker fed by `catalog_progress` on `FetchEvent::Downloading`. Renderer reads it via `state.download_rate.stats(total)` and displays `42 KB/s — ETA 2m18s` under the existing bytes/total line on the CatalogConfirm screen.
- Fixed-window linear regression over `(Instant, bytes)` samples. Returns `None` until ≥ 2 samples span ≥ 1 s, so the first chunk doesn't flicker a meaningless ETA.
- Fix stale footer: with slice 3 cancellation in place, `[fetch in flight — Esc locked]` no longer reflects reality. Footer now reads `[Esc] cancel fetch` for all in-flight states.

## Test plan

- [x] `cargo test -p rescue-tui` — 260 passed (up from 250: 7 new tracker tests + 3 humanize_duration tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)