### PR TITLE
feat(rescue-tui): mok-enroll test mode (closes #676)

### DIFF
--- a/crates/rescue-tui/src/state.rs
+++ b/crates/rescue-tui/src/state.rs
@@ -2006,7 +2006,12 @@ fn prev_char_boundary(buffer: &str, cursor: usize) -> usize {
 /// When the ISO has a discoverable sibling key file, step 1 becomes a
 /// literal copy-paste `mokutil --import` command. When it doesn't, step 1
 /// tells the operator how to place the key so the next run will name it.
-fn build_mokutil_remedy(iso: Option<&DiscoveredIso>) -> String {
+///
+/// `pub(crate)` so the harness-driven `mok-enroll` test mode (#676)
+/// can print the canonical walkthrough without the kexec-failure
+/// detour. Keeping the body in one place means the harness, the
+/// kexec-failure path, and #202's docstring can never drift apart.
+pub(crate) fn build_mokutil_remedy(iso: Option<&DiscoveredIso>) -> String {
     let key_hint = iso.and_then(|iso| find_sibling_key(&iso.iso_path));
     let step_one = match key_hint {
         Some(ref key_path) => format!(

--- a/crates/rescue-tui/src/test_mode.rs
+++ b/crates/rescue-tui/src/test_mode.rs
@@ -43,6 +43,7 @@ pub fn dispatch_from_env() -> Option<i32> {
     let mode = std::env::var("AEGIS_TEST").ok()?;
     match mode.as_str() {
         "kexec-unsigned" => Some(run_kexec_unsigned()),
+        "mok-enroll" => Some(run_mok_enroll()),
         // Unknown / future test modes — log + treat as "no test
         // matched" so a stale aegis.test= cmdline against a newer
         // stick doesn't silently disable the TUI.
@@ -131,6 +132,33 @@ fn real_kexec(blob_path: &Path) -> Result<(), KexecError> {
     })
 }
 
+/// Print the canonical MOK enrollment walkthrough (#202) so
+/// aegis-hwsim's `mok_enroll_alpine` scenario (#676 companion to E5.4)
+/// can grep-pin the load-bearing strings without a real
+/// unsigned-kernel kexec failure.
+///
+/// The walkthrough body comes from [`crate::state::build_mokutil_remedy`]
+/// — the same function the kexec-failure path uses — so the harness
+/// assertion is checking the actual operator-visible text. Drift
+/// here would surface as a failed harness assertion, which is the
+/// whole point of the contract.
+///
+/// Always returns 0: this mode renders a static walkthrough; there's
+/// no failure path to assert against. The harness only validates the
+/// landmarks are present.
+#[must_use]
+pub fn run_mok_enroll() -> i32 {
+    println!("aegis-boot-test: MOK enrollment walkthrough starting");
+    // No-key variant — harness drives this without a real ISO on
+    // disk, so build_mokutil_remedy(None) gives the prose-step-1
+    // form. The substring `sudo mokutil --import` still appears in
+    // step 1's body.
+    let walkthrough = crate::state::build_mokutil_remedy(None);
+    println!("{walkthrough}");
+    println!("aegis-boot-test: MOK enrollment walkthrough complete");
+    0
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
@@ -174,6 +202,33 @@ mod tests {
         // kernel accepted an unsigned blob.
         let rc = run_with_kexec(|_| Ok(()));
         assert_eq!(rc, 1);
+    }
+
+    // ---- #676 mok-enroll landmarks ----------------------------------
+
+    #[test]
+    fn mok_enroll_walkthrough_contains_required_landmarks() {
+        // Render the same body the test mode prints so we don't
+        // depend on stdout capture. If aegis-hwsim's TEST_LANDMARKS
+        // ever drifts from these, the harness assertion fails and
+        // we land here.
+        let body = crate::state::build_mokutil_remedy(None);
+        assert!(
+            body.contains("STEP 1/3"),
+            "mok-enroll walkthrough missing STEP 1/3: {body}"
+        );
+        assert!(
+            body.contains("sudo mokutil --import"),
+            "mok-enroll walkthrough missing 'sudo mokutil --import': {body}"
+        );
+    }
+
+    #[test]
+    fn mok_enroll_returns_zero() {
+        // Static walkthrough has no failure path; should always
+        // exit 0 so the harness records a Pass when it grep-finds
+        // the landmarks.
+        assert_eq!(run_mok_enroll(), 0);
     }
 
     // dispatch_from_env() is intentionally not unit-tested: it reads

--- a/docs/rescue-tui-serial-format.md
+++ b/docs/rescue-tui-serial-format.md
@@ -31,6 +31,30 @@ Companion to [aegis-hwsim `scenarios/kexec_refuses_unsigned.rs`](https://github.
 
 **Why this isn't a real bzImage**: under `lockdown=integrity`, the signature check fires before the format parser. A real (signed) bzImage isn't necessary — and synthesising one would defeat the test, since we want the path that asserts "unsigned content gets rejected." The harness only cares that one of the rejection landmarks fires.
 
+### `aegis.test=mok-enroll`
+
+Companion to [aegis-hwsim `scenarios/mok_enroll_alpine.rs`](https://github.com/aegis-boot/aegis-hwsim/pull/79) (epic E5.4). Asserts that the operator-facing MOK enrollment walkthrough (#202) is intact and emits the load-bearing copy-paste command without drift.
+
+**What it does**:
+
+1. Prints a `MOK enrollment walkthrough starting` header.
+2. Prints the canonical 3-step walkthrough body — same text the rescue-tui kexec-failure path renders, sourced from `crate::state::build_mokutil_remedy`.
+3. Prints a `MOK enrollment walkthrough complete` footer + exits 0.
+
+This is a static-text mode; there's no kexec, no ISO, no kernel — just the operator-visible recovery prose, so the harness can verify the contract without driving a real unsigned-kernel boot.
+
+**Serial landmarks (exact substrings)**:
+
+| Stage | Landmark | Meaning |
+|---|---|---|
+| Walkthrough fired | `MOK enrollment walkthrough` | Confirms the stick has the test mode (not Skip). |
+| Step marker | `STEP 1/3` | Confirms the walkthrough body printed. |
+| **Load-bearing command** | `sudo mokutil --import` | The verbatim copy-paste payload from #202. Drift here leaves an operator at 2 AM with a non-working command line — the harness exists to catch exactly this. |
+
+**Process exit code**: always `0`. The harness validates by grep, not exit status.
+
+**Why we render the no-key variant**: with no real ISO at hand, `build_mokutil_remedy(None)` gives the prose-step-1 form which still contains the load-bearing `sudo mokutil --import` substring (under "aegis-boot will then generate the exact `sudo mokutil --import <path>` command for you"). Operators in the field hit the with-key variant when they have a sibling `.pub`/`.key`/`.der` on the stick; the substring contract holds in both.
+
 ## Stability policy
 
 Strings in the **Serial landmarks** tables are part of aegis-boot's published external contract. They follow these rules:


### PR DESCRIPTION
## Summary

Companion to [aegis-hwsim PR #79](https://github.com/aegis-boot/aegis-hwsim/pull/79). Converts \`scenarios/mok_enroll_alpine.rs\` from Skip → Pass.

- **\`aegis.test=mok-enroll\` cmdline trigger.** Reuses the #675 dispatch harness — /init's existing \`aegis.test=*\` parser already handles this; only test_mode.rs needs to extend.
- **Walkthrough body comes from \`crate::state::build_mokutil_remedy\`** (made \`pub(crate)\`). Same text the kexec-failure path renders, so the harness assertion is checking the actual operator-visible recovery prose. Drift in #202's text now surfaces as a failed harness assertion.
- **Three landmarks** documented in \`docs/rescue-tui-serial-format.md\`: header \`MOK enrollment walkthrough\`, step marker \`STEP 1/3\`, load-bearing payload \`sudo mokutil --import\`.
- **2 hermetic unit tests** asserting the walkthrough body contains the load-bearing landmarks + the mode exits 0.

## Why this matters

The MOK walkthrough is the operator-facing recovery story for "you tried to boot a third-party (unsigned) kernel under MS-enrolled SB". Without automated coverage, #202's docstring could drift silently and the next operator hits a non-working \`mokutil --import\` line at 2 AM.

## Test plan

- [x] \`cargo test -p rescue-tui\` — 266 passed (up from 264)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all\`
- [ ] aegis-hwsim follow-up PR tightens TEST_LANDMARKS to the documented strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)