### PR TITLE
chore(ci): paths-ignore on initramfs/integration/machete (#580 Phase 1 finish)

### DIFF
--- a/.github/workflows/initramfs.yml
+++ b/.github/workflows/initramfs.yml
@@ -1,10 +1,16 @@
 name: Initramfs Build
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. The reproducible-initramfs
+  # build doesn't depend on markdown content (the binary is built from
+  # the rescue-tui Rust source); skipping saves ~3 CPU min per docs PR.
+  # See kexec-e2e.yml for the rationale + dummy-pass policy.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # Top-level permissions: read-only default. Jobs that need write

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,15 @@
 name: Integration
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. The iso-probe loop-mount
+  # integration test exercises Rust source against a real kernel mount
+  # path; markdown changes can't affect it. Saves ~2 CPU min per docs PR.
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 # Top-level permissions: read-only default. Jobs that need write

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -20,10 +20,15 @@
 name: cargo-machete
 
 on:
+  # #580 Phase 1: skip on docs-only PRs. cargo-machete reads Cargo.toml
+  # to detect unused deps; markdown changes can't introduce or hide
+  # unused-dep findings.
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', '.github/ISSUE_TEMPLATE/**', 'LICENSE*']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Three workflows still triggered on docs-only PRs but can't be affected by markdown changes. Add the same \`paths-ignore\` block as the 6 already-filtered QEMU jobs + reproducible-build.

| Workflow | Why safe | Savings |
|---|---|---|
| \`initramfs.yml\` | Builds rescue-tui-bearing initramfs from Rust source | ~3 CPU min |
| \`integration.yml\` | iso-probe loop-mount integration on Rust source | ~2 CPU min |
| \`machete.yml\` | cargo-machete reads Cargo.toml, not markdown | <1 CPU min |

After this PR, only \`ci.yml\` remains unfiltered — and that one MUST run on docs changes because clippy doc_markdown lints fire on .md content pulled in via \`#[doc = include_str!(...)]\`.

## Test plan

- [ ] CI on this PR (a code change, so all the newly-filtered workflows still run)
- [ ] Next docs-only PR demonstrates the skip — should drop ~5-6 CPU min wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)