### PR TITLE
feat(ci): update-rotate canary on shared-build (#580 Phase 2f)

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -497,3 +497,147 @@ jobs:
             echo "direct-install boot smoke FAILED"
             exit 1
           fi
+
+  # Phase 2f canary — update --rotate end-to-end on shared rescue-tui +
+  # aegis-bootctl + initramfs. Tests the post-#444 rotation path:
+  # baseline verify → drift injection → update detects → --apply →
+  # post-rotation verify clean → doctor reports bumped sequence →
+  # SB boot proves signed chain survives.
+  #
+  # Runs alongside .github/workflows/update-rotate-e2e.yml until
+  # 5 PRs of green-parity.
+  update-rotate-shared:
+    name: update — rotate + verify + boot under SB (shared-build canary)
+    needs: build-shared
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install deps (QEMU + OVMF + signed boot chain + tooling)
+        # Mirror of update-rotate-e2e.yml's deps. linux-image-virtual
+        # still needed: mkusb.sh / direct-install read /boot/vmlinuz-*.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools exfatprogs gdisk \
+            util-linux
+          sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
+
+      - name: Download shared artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: e2e-shared-build
+          path: shared/
+
+      - name: Reposition artifacts to expected paths
+        run: |
+          mkdir -p target/release out
+          mv shared/rescue-tui                  target/release/rescue-tui
+          mv shared/aegis-boot                  target/release/aegis-boot
+          mv shared/initramfs.cpio.gz           out/initramfs.cpio.gz
+          mv shared/initramfs.cpio.gz.sha256    out/initramfs.cpio.gz.sha256
+          chmod +x target/release/rescue-tui target/release/aegis-boot
+
+      - name: Create blank loop image + flash via --direct-install
+        env:
+          MKUSB_GRUB_DEFAULT: "1"
+          AEGIS_ALLOW_LOOP_DEVICE: "1"
+        run: |
+          dd if=/dev/zero of=/tmp/update-rotate.img bs=1M count=1024 status=none
+          sudo losetup --find --partscan --show /tmp/update-rotate.img \
+            > /tmp/update-rotate.loop
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo -E ./target/release/aegis-boot flash --direct-install --yes \
+            --out-dir ./out "$LOOP"
+          sudo partprobe "$LOOP"
+
+      - name: "Baseline verify --stick (must be 0 drift)"
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo ./target/release/aegis-boot verify --stick "$LOOP" \
+            | tee /tmp/verify-baseline.out
+          grep -q '0 drift, 0 unreadable' /tmp/verify-baseline.out \
+            || { echo "Baseline verify should be clean"; exit 1; }
+
+      - name: Inject drift into /vmlinuz on the ESP
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          mkdir -p /tmp/esp-rotate
+          sudo mount "${LOOP}p1" /tmp/esp-rotate
+          sudo dd if=/dev/urandom of=/tmp/esp-rotate/vmlinuz bs=1 count=16 \
+            conv=notrunc status=none
+          sudo umount /tmp/esp-rotate
+          sudo sync
+
+      - name: "update must report CHANGED on vmlinuz"
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo ./target/release/aegis-boot update "$LOOP" \
+            | tee /tmp/update-diff.out
+          grep -q 'CHANGED */vmlinuz' /tmp/update-diff.out \
+            || { echo "update should detect vmlinuz drift"; exit 1; }
+
+      - name: "--apply --experimental-apply must complete + refresh manifest"
+        env:
+          MKUSB_GRUB_DEFAULT: "1"
+          AEGIS_ALLOW_LOOP_DEVICE: "1"
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo -E ./target/release/aegis-boot update "$LOOP" \
+            --apply --experimental-apply \
+            | tee /tmp/update-apply.out
+          grep -q 'Rotation complete' /tmp/update-apply.out \
+            || { echo "rotation did not report complete"; exit 1; }
+          grep -q 'Manifest refreshed' /tmp/update-apply.out \
+            || { echo "manifest was not refreshed"; exit 1; }
+
+      - name: "Post-rotation verify --stick (must be 0 drift)"
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo ./target/release/aegis-boot verify --stick "$LOOP" \
+            | tee /tmp/verify-post.out
+          grep -q '0 drift, 0 unreadable' /tmp/verify-post.out \
+            || { echo "post-rotation verify should be clean"; exit 1; }
+
+      - name: "Post-rotation doctor --stick surfaces bumped sequence"
+        run: |
+          LOOP=$(cat /tmp/update-rotate.loop)
+          sudo ./target/release/aegis-boot doctor --stick "$LOOP" \
+            | tee /tmp/doctor-post.out
+          grep -qE 'manifest sequence.*sequence=[0-9]+' /tmp/doctor-post.out \
+            || { echo "doctor --stick missing manifest sequence row"; exit 1; }
+
+      - name: Boot the rotated image under OVMF SecBoot
+        env:
+          TIMEOUT_SECONDS: "120"
+        run: |
+          sudo losetup -d "$(cat /tmp/update-rotate.loop)" || true
+          cp /usr/share/OVMF/OVMF_VARS_4M.ms.fd /tmp/vars.fd
+          chmod 0644 /tmp/vars.fd
+          timeout "$TIMEOUT_SECONDS" qemu-system-x86_64 \
+            -nographic \
+            -no-reboot \
+            -machine q35,smm=on \
+            -global driver=cfi.pflash01,property=secure,value=on \
+            -m 1024M \
+            -drive if=pflash,format=raw,unit=0,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd,readonly=on \
+            -drive if=pflash,format=raw,unit=1,file=/tmp/vars.fd \
+            -drive if=ide,format=raw,file=/tmp/update-rotate.img \
+            -boot order=c \
+            -serial mon:stdio </dev/null > /tmp/update-rotate-boot.log 2>&1 || true
+          echo "--- QEMU serial output (last 60 lines) ---"
+          tail -60 /tmp/update-rotate-boot.log
+          echo "--- end ---"
+          if grep -qiE 'secure boot (is )?enabled|secureboot.*enabled' /tmp/update-rotate-boot.log \
+             && grep -q 'aegis-boot rescue-tui starting' /tmp/update-rotate-boot.log; then
+            echo "Rotated image boots under SB + rescue-tui runs: PASS"
+          else
+            echo "Post-rotation boot smoke FAILED"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Add \`update-rotate-shared\` canary alongside the existing standalone \`.github/workflows/update-rotate-e2e.yml\`. Same pattern as Phases 2a-2e.

Reuses the rescue-tui + aegis-bootctl + initramfs already produced by \`build-shared\` (no new artifacts needed — Phase 2e extended the producer with aegis-bootctl).

## Test sequence

Mirrors update-rotate-e2e.yml verbatim:
- flash via \`--direct-install\` onto a loop image
- baseline \`verify --stick\` (must report 0 drift)
- inject drift into \`/vmlinuz\` on the ESP
- \`update\` detects CHANGED /vmlinuz
- \`--apply --experimental-apply\` rotates + refreshes manifest
- post-rotation \`verify --stick\` (must report 0 drift)
- \`doctor --stick\` surfaces the bumped manifest sequence
- SB boot proves the rotated signed chain still boots

## Savings (post-retirement)

~120s wallclock + ~120s CPU per PR.

## Test plan

- [ ] CI on this PR — both standalone and canary pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)