### PR TITLE
feat(ci): ovmf-secboot canary on shared-build (#580 Phase 2g)

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -641,3 +641,57 @@ jobs:
             echo "Post-rotation boot smoke FAILED"
             exit 1
           fi
+
+  # Phase 2g canary — OVMF SecBoot E2E on shared rescue-tui +
+  # initramfs. Mirrors ovmf-secboot-e2e.yml's `ovmf-secboot-e2e` job
+  # (the one that builds rescue-tui + initramfs); the workflow's other
+  # job — `ovmf-secboot-foundation` — has no shared deps and stays in
+  # the standalone file.
+  #
+  # Runs alongside .github/workflows/ovmf-secboot.yml until 5 PRs of
+  # green-parity, then a follow-up retires the standalone E2E job
+  # (foundation stays).
+  ovmf-secboot-shared:
+    name: OVMF SecBoot E2E (shared-build canary)
+    needs: build-shared
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install signed boot chain + tooling
+        # Mirror of ovmf-secboot.yml's `ovmf-secboot-e2e` deps minus
+        # busybox-static + cpio (initramfs is consumed pre-built).
+        # ovmf-secboot-e2e.sh accepts both -generic and -virtual
+        # kernels so linux-image-virtual is fine here (consistent with
+        # build-shared's choice).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 ovmf \
+            shim-signed grub-efi-amd64-signed linux-image-virtual \
+            mtools dosfstools exfatprogs gdisk
+          sudo chmod 0644 /boot/vmlinuz-* /boot/initrd.img-* 2>/dev/null || true
+
+      - name: Download shared artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: e2e-shared-build
+          path: shared/
+
+      - name: Reposition artifacts to expected paths
+        run: |
+          mkdir -p target/release out
+          mv shared/rescue-tui                  target/release/rescue-tui
+          mv shared/initramfs.cpio.gz           out/initramfs.cpio.gz
+          mv shared/initramfs.cpio.gz.sha256    out/initramfs.cpio.gz.sha256
+          chmod +x target/release/rescue-tui
+          ls -lh target/release/rescue-tui out/initramfs.cpio.gz
+
+      - name: Run OVMF SecBoot E2E
+        env:
+          TIMEOUT_SECONDS: "120"
+        run: ./scripts/ovmf-secboot-e2e.sh


### PR DESCRIPTION
## Summary

Add \`ovmf-secboot-shared\` canary alongside the standalone \`.github/workflows/ovmf-secboot.yml\`'s \`ovmf-secboot-e2e\` job. **Final canary in the Phase 2 rollout** — after this lands, all 5 remaining QEMU E2E workflows have green-pair canaries on the shared-build pattern:

| Phase | Standalone | Canary |
|---|---|---|
| 2a (PR #614) | qemu-smoke.yml | qemu-smoke-shared (RETIRED in 2b) |
| 2b (PR #685) | — | — |
| 2c (PR #686) | kexec-e2e.yml | kexec-e2e-shared |
| 2d (PR #687) | mkusb.yml | mkusb-shared |
| 2e (PR #688) | direct-install-e2e.yml | direct-install-shared |
| 2f (PR #689) | update-rotate-e2e.yml | update-rotate-shared |
| **2g (this PR)** | **ovmf-secboot.yml (e2e job)** | **ovmf-secboot-shared** |

The standalone's other job, \`ovmf-secboot-foundation\`, has no shared deps (it only smokes the OVMF firmware itself, not rescue-tui) and stays in the standalone file unchanged.

\`ovmf-secboot-e2e.sh\` accepts both \`-generic\` and \`-virtual\` kernel paths, so \`linux-image-virtual\` (consistent with \`build-shared\`) works.

## Savings (post-retirement)

~150-180s wallclock + ~150s CPU per PR.

**Combined Phase 2 retirement savings** (once 5 PRs of green-parity is observed across all canaries): a coordinated PR drops kexec-e2e.yml + mkusb.yml + direct-install-e2e.yml + update-rotate-e2e.yml + the e2e job in ovmf-secboot.yml. **Total ~7.5 CPU min saved per PR.**

## Test plan

- [ ] CI on this PR — both standalone \`OVMF SecBoot E2E\` and the shared-build canary pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)