### PR TITLE
chore(deps): bump windows 0.58 → 0.62; drop unused similar-asserts dev-dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,17 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "buffer-redux"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,18 +382,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1108,7 +1085,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.3",
+ "console",
  "portable-atomic",
  "unit-prefix",
 ]
@@ -1150,7 +1127,6 @@ version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
- "similar-asserts",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2378,26 +2354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console 0.15.11",
- "similar",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,32 +2915,54 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3009,22 +2987,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -3068,6 +3055,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/aegis-cli/Cargo.toml
+++ b/crates/aegis-cli/Cargo.toml
@@ -120,7 +120,7 @@ minisign = { version = "0.9", default-features = false }
 # already validates the version pin + feature list — no surprise-
 # feature-flip in the wiring PR.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
     "Win32_Foundation",
     # Win32_Security pulls in the SECURITY_ATTRIBUTES type that
     # CreateFileW's signature references. The signature compiles

--- a/crates/aegis-cli/src/windows_direct_install/raw_write.rs
+++ b/crates/aegis-cli/src/windows_direct_install/raw_write.rs
@@ -535,8 +535,10 @@ mod sys {
     }
 
     fn last_error_message(op: &str) -> String {
-        // windows::core::Error::from_win32() reads GetLastError.
-        let err = windows::core::Error::from_win32();
+        // windows-rs 0.59+ renamed `from_win32` → `from_thread`. Same
+        // semantics: reads `GetLastError()` from the current thread
+        // and wraps as a `windows::core::Error`.
+        let err = windows::core::Error::from_thread();
         let code = u32::try_from(err.code().0).unwrap_or(u32::MAX);
         format!("{op}: {}", translate_win32_error(code))
     }

--- a/crates/iso-parser/Cargo.toml
+++ b/crates/iso-parser/Cargo.toml
@@ -23,7 +23,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3.14"
-similar-asserts = "1.5"
 tokio = { version = "1", features = ["rt", "macros"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
## Summary

Two dep hygiene changes per maintainer direction ("keep all dependencies on the latest LTS release").

### \`windows\` 0.58 → 0.62 (Windows direct-install adapter)

4-major bump. One API migration: \`windows::core::Error::from_win32()\` was renamed to \`from_thread()\` in 0.59 (same semantics — reads \`GetLastError()\` from the current thread). Single call site in \`windows_direct_install/raw_write.rs::last_error_message\`.

| Check | Result |
|---|---|
| \`cargo check -p aegis-bootctl --target x86_64-pc-windows-gnu\` | clean |
| \`cargo clippy -p aegis-bootctl --target x86_64-pc-windows-gnu --all-targets -- -D warnings\` | clean |
| \`cargo clippy --workspace --all-targets -- -D warnings\` | clean |
| \`cargo test --workspace\` | all 779+260+... green |

### \`similar-asserts\` dev-dep removal

\`crates/iso-parser\` declared \`similar-asserts = "1.5"\` as a dev-dep but nothing in the source actually imports it. Confirmed via grep + a removal-then-\`cargo test -p iso-parser\` round-trip — all 52 iso-parser tests still pass without it. \`cargo-machete\` doesn't flag it because it's a macro-only crate (no explicit \`use\` lines even when actively used), but in this case we genuinely don't use any of its assertion macros.

## Other deps NOT bumped (and why)

| Dep | Latest | Reason |
|---|---|---|
| \`sha2\` | 0.10 → 0.11 | Coupled to rpgp 0.19's transitive sha2 0.10 + ring + rustls; bumping ours alone creates dual-version skew without benefit. Wait for rpgp's next major. |
| \`rand\` | 0.8 → 0.10 | aegis-fetch's verify-test code uses rpgp's \`SecretKeyParamsBuilder::generate(rng)\` which expects rand 0.8's \`RngCore\`. Coupled to rpgp; same as sha2. |
| \`digest\` / \`block-buffer\` / \`crypto-common\` | 0.10 → 0.11+ | Same coupling — RustCrypto crate releases tend to cascade together. |
| \`console\` 0.15 → 0.16 | — | Transitive only; no direct dep declared. |

## Test plan

- [x] Cross-compile + clippy + workspace tests all green locally
- [ ] CI macOS smoke + Windows cargo-check confirm the API migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)