### PR TITLE
feat(rescue-tui): aegis.test=manifest-roundtrip mode (closes #695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to aegis-boot are recorded here. Format: [Keep a Changelog](
 
 ### `MKUSB_TEST_MODE` env var bakes `aegis.test=<NAME>` into grub.cfg (closes #694)
 
-Aegis-hwsim's E5.3 / E5.4 / E6 scenarios depend on the rescue-tui test modes shipped in PRs #680 / #681 / (forthcoming for #695). The harness side grep-pins the serial landmarks correctly, but a default-flashed stick doesn't carry `aegis.test=<NAME>` on the kernel cmdline — so the test mode never fires and the harness reports Skip.
+Aegis-hwsim's E5.3 / E5.4 / E6 scenarios depend on the rescue-tui test modes shipped in PRs #680 / #681 / #697. The harness side grep-pins the serial landmarks correctly, but a default-flashed stick doesn't carry `aegis.test=<NAME>` on the kernel cmdline — so the test mode never fires and the harness reports Skip.
 
 This release adds `MKUSB_TEST_MODE=<NAME>` (env var honored by both `scripts/mkusb.sh` and `aegis-boot flash --direct-install`'s `render_grub_cfg`). Set to one of `kexec-unsigned`, `mok-enroll`, or `manifest-roundtrip` and the cmdline marker is baked onto every menuentry in the resulting grub.cfg. Unknown slugs are rejected with an operator-readable error before any disk write happens.
 
@@ -17,6 +17,22 @@ MKUSB_TEST_MODE=mok-enroll aegis-boot flash --direct-install /dev/sdX
 ```
 
 The byte-parity invariant between `mkusb.sh` and `direct_install::build_grub_cfg_body` (asserted by `e2e-suite.yml::direct-install-shared`) is preserved — both paths produce identical bytes when no test mode is set, and identical bytes when the same test mode is set.
+
+### `aegis.test=manifest-roundtrip` rescue-tui test mode (closes #695)
+
+Companion to [aegis-hwsim's E6 attestation-roundtrip scenario](https://github.com/aegis-boot/aegis-hwsim/issues/6). Added alongside the existing `kexec-unsigned` (#675) and `mok-enroll` (#676) modes.
+
+When the kernel cmdline carries `aegis.test=manifest-roundtrip` (typically baked in via the `MKUSB_TEST_MODE` env var from #694), rescue-tui short-circuits the TUI and:
+
+1. Resolves `/dev/disk/by-label/AEGIS_ESP` → mounts read-only at `/run/aegis-test-esp`.
+2. Reads `aegis-boot-manifest.json` from the ESP root, parses via `aegis-wire-formats::Manifest`.
+3. Emits a `parsed (schema_version=N, esp_files=N, expected_pcrs=N)` landmark.
+4. If `expected_pcrs[]` is empty (current shipped state — see `docs/attestation-manifest.md` contract), emits the `empty-pcrs` landmark and exits 0 (harness counts as Pass-via-fail-open).
+5. If populated, iterates each entry: reads live `/sys/class/tpm/tpm0/pcr-<bank>/<idx>` and emits MATCH or MISMATCH per entry. Exits 0 only if every entry matches.
+
+The mode flips automatically from skip-via-fail-open to active comparison the moment aegis-boot starts emitting populated `expected_pcrs[]` — no harness-side change required, by design of the manifest contract pinned in PR #682.
+
+6 new hermetic unit tests via injectable PCR-reader fn (rescue-tui test count 266 → 272).
 
 ### CI feedback-loop speedup — paths-ignore + shared-artifact pattern (#580 Phases 1+2)
 

--- a/crates/rescue-tui/src/test_mode.rs
+++ b/crates/rescue-tui/src/test_mode.rs
@@ -44,6 +44,7 @@ pub fn dispatch_from_env() -> Option<i32> {
     match mode.as_str() {
         "kexec-unsigned" => Some(run_kexec_unsigned()),
         "mok-enroll" => Some(run_mok_enroll()),
+        "manifest-roundtrip" => Some(run_manifest_roundtrip()),
         // Unknown / future test modes — log + treat as "no test
         // matched" so a stale aegis.test= cmdline against a newer
         // stick doesn't silently disable the TUI.
@@ -159,6 +160,150 @@ pub fn run_mok_enroll() -> i32 {
     0
 }
 
+/// Mount the ESP, parse the on-stick attestation manifest, and (when
+/// `expected_pcrs` is non-empty) compare each entry to the live PCR
+/// value. Used by aegis-hwsim's E6 attestation-roundtrip scenario
+/// (#695).
+///
+/// In shipped releases through 0.17.x, `expected_pcrs` is always
+/// empty by design (the manifest contract is pinned but the PCR
+/// selection is gated on the E6 epic itself). In that PR3-era state,
+/// the test mode prints a `parsed (...)` landmark to confirm the
+/// manifest was read + parsed cleanly, then a `empty-pcrs` landmark
+/// and exits 0 — the harness counts that as Pass-via-fail-open per
+/// `docs/attestation-manifest.md`.
+///
+/// When `expected_pcrs` starts being populated, this function
+/// iterates each entry, reads the live PCR via the kernel's sysfs
+/// interface (`/sys/class/tpm/tpm0/pcr-<bank>/<idx>`), and emits a
+/// MATCH or MISMATCH landmark per PCR. The harness pins on the
+/// per-entry landmarks so a mid-release schema change surfaces as
+/// a failed assertion rather than a silent regression.
+#[must_use]
+pub fn run_manifest_roundtrip() -> i32 {
+    println!("aegis-boot-test: manifest-roundtrip starting");
+    let esp_mount = std::path::Path::new("/run/aegis-test-esp");
+    let esp_dev = match find_esp_device() {
+        Ok(d) => d,
+        Err(e) => {
+            println!("aegis-boot-test: manifest-roundtrip FAILED (esp-find: {e})");
+            return 1;
+        }
+    };
+    if let Err(e) = mount_esp_ro(&esp_dev, esp_mount) {
+        println!("aegis-boot-test: manifest-roundtrip FAILED (esp-mount: {e})");
+        return 1;
+    }
+    let rc = run_manifest_roundtrip_at(esp_mount, &mut read_pcr_sysfs);
+    let _ = std::process::Command::new("umount").arg(esp_mount).status();
+    rc
+}
+
+/// Test-injectable variant: caller supplies the ESP mount point + a
+/// PCR-reader fn so unit tests can drive the parse + comparison
+/// branches without needing root or a real TPM.
+fn run_manifest_roundtrip_at(
+    esp_mount: &std::path::Path,
+    read_pcr: &mut dyn FnMut(&str, u32) -> Result<String, String>,
+) -> i32 {
+    let path = esp_mount.join("aegis-boot-manifest.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            println!(
+                "aegis-boot-test: manifest-roundtrip FAILED (read {}: {e})",
+                path.display()
+            );
+            return 1;
+        }
+    };
+    let manifest: aegis_wire_formats::Manifest = match serde_json::from_slice(&bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("aegis-boot-test: manifest-roundtrip FAILED (parse: {e})");
+            return 1;
+        }
+    };
+    println!(
+        "aegis-boot-test: manifest-roundtrip parsed (schema_version={}, esp_files={}, expected_pcrs={})",
+        manifest.schema_version,
+        manifest.esp_files.len(),
+        manifest.expected_pcrs.len()
+    );
+    if manifest.expected_pcrs.is_empty() {
+        println!(
+            "aegis-boot-test: manifest-roundtrip empty-pcrs (PR3-era; harness fail-opens per attestation-manifest.md contract)"
+        );
+        return 0;
+    }
+    let mut all_pass = true;
+    for entry in &manifest.expected_pcrs {
+        match read_pcr(&entry.bank, entry.pcr_index) {
+            Ok(live) if live.eq_ignore_ascii_case(&entry.digest_hex) => {
+                println!(
+                    "aegis-boot-test: manifest-roundtrip pcr_index={} bank={} MATCH",
+                    entry.pcr_index, entry.bank
+                );
+            }
+            Ok(live) => {
+                println!(
+                    "aegis-boot-test: manifest-roundtrip pcr_index={} bank={} MISMATCH (expected={} live={})",
+                    entry.pcr_index, entry.bank, entry.digest_hex, live
+                );
+                all_pass = false;
+            }
+            Err(e) => {
+                println!(
+                    "aegis-boot-test: manifest-roundtrip pcr_index={} bank={} READ-FAILED ({e})",
+                    entry.pcr_index, entry.bank
+                );
+                all_pass = false;
+            }
+        }
+    }
+    i32::from(!all_pass)
+}
+
+/// Locate the ESP block device. `/dev/disk/by-label/AEGIS_ESP` is the
+/// canonical symlink set up by mkusb.sh + direct-install (label set
+/// at format time via `mkfs.fat -n AEGIS_ESP`). udev populates the
+/// `by-label` tree on every block-device discovery in the rescue env.
+fn find_esp_device() -> Result<std::path::PathBuf, String> {
+    let by_label = std::path::Path::new("/dev/disk/by-label/AEGIS_ESP");
+    if by_label.exists() {
+        return Ok(by_label.to_path_buf());
+    }
+    Err(format!("not found: {}", by_label.display()))
+}
+
+/// Mount `dev` read-only at `mount_point` as vfat. Read-only protects
+/// the ESP against accidental writes from the test mode itself.
+fn mount_esp_ro(dev: &std::path::Path, mount_point: &std::path::Path) -> Result<(), String> {
+    std::fs::create_dir_all(mount_point)
+        .map_err(|e| format!("mkdir {}: {e}", mount_point.display()))?;
+    let status = std::process::Command::new("mount")
+        .args(["-t", "vfat", "-o", "ro"])
+        .arg(dev)
+        .arg(mount_point)
+        .status()
+        .map_err(|e| format!("spawn mount: {e}"))?;
+    if !status.success() {
+        return Err(format!("mount returned {status}"));
+    }
+    Ok(())
+}
+
+/// Read the live PCR digest from the kernel's TPM sysfs interface.
+/// Modern kernels (5.5+) expose `/sys/class/tpm/tpm0/pcr-<bank>/<idx>`
+/// which yields the digest as a hex string. Banks: `sha256`, `sha384`,
+/// `sha1`. The path is read-only — no privileges escalation needed
+/// inside the rescue env.
+fn read_pcr_sysfs(bank: &str, pcr: u32) -> Result<String, String> {
+    let path = format!("/sys/class/tpm/tpm0/pcr-{bank}/{pcr}");
+    let raw = std::fs::read_to_string(&path).map_err(|e| format!("read {path}: {e}"))?;
+    Ok(raw.trim().to_lowercase())
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
@@ -229,6 +374,136 @@ mod tests {
         // exit 0 so the harness records a Pass when it grep-finds
         // the landmarks.
         assert_eq!(run_mok_enroll(), 0);
+    }
+
+    // ---- #695 manifest-roundtrip ------------------------------------
+
+    fn write_test_manifest(dir: &std::path::Path, body: &str) {
+        std::fs::write(dir.join("aegis-boot-manifest.json"), body).expect("write");
+    }
+
+    fn empty_pcrs_manifest() -> String {
+        r#"{
+  "schema_version": 1,
+  "tool_version": "aegis-boot 0.17.0",
+  "manifest_sequence": 1,
+  "device": {
+    "disk_guid": "00000000-0000-0000-0000-000000000001",
+    "partition_count": 2,
+    "esp": {
+      "partuuid": "00000000-0000-0000-0000-0000000000a1",
+      "type_guid": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+      "fs_uuid": "AAAA-AAAA",
+      "first_lba": 2048,
+      "last_lba": 821247
+    },
+    "data": {
+      "partuuid": "00000000-0000-0000-0000-0000000000a2",
+      "type_guid": "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7",
+      "fs_uuid": "BBBB-BBBB",
+      "label": "AEGIS_ISOS"
+    }
+  },
+  "esp_files": [],
+  "allowed_files_closed_set": true,
+  "expected_pcrs": []
+}"#
+        .to_string()
+    }
+
+    fn populated_pcrs_manifest(pcr12_digest: &str) -> String {
+        format!(
+            r#"{{
+  "schema_version": 1,
+  "tool_version": "aegis-boot 0.18.0",
+  "manifest_sequence": 1,
+  "device": {{
+    "disk_guid": "00000000-0000-0000-0000-000000000001",
+    "partition_count": 2,
+    "esp": {{ "partuuid": "00000000-0000-0000-0000-0000000000a1", "type_guid": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B", "fs_uuid": "AAAA-AAAA", "first_lba": 2048, "last_lba": 821247 }},
+    "data": {{ "partuuid": "00000000-0000-0000-0000-0000000000a2", "type_guid": "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7", "fs_uuid": "BBBB-BBBB", "label": "AEGIS_ISOS" }}
+  }},
+  "esp_files": [],
+  "allowed_files_closed_set": true,
+  "expected_pcrs": [
+    {{ "pcr_index": 12, "bank": "sha256", "digest_hex": "{pcr12_digest}" }}
+  ]
+}}"#
+        )
+    }
+
+    #[test]
+    fn manifest_roundtrip_empty_pcrs_returns_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_test_manifest(dir.path(), &empty_pcrs_manifest());
+        let mut never_called = |_: &str, _: u32| -> Result<String, String> {
+            unreachable!("read_pcr must not be called when expected_pcrs is empty");
+        };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut never_called);
+        assert_eq!(rc, 0, "empty expected_pcrs should be Pass-via-fail-open");
+    }
+
+    #[test]
+    fn manifest_roundtrip_pcr_match_returns_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let digest = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+        write_test_manifest(dir.path(), &populated_pcrs_manifest(digest));
+        let owned = digest.to_string();
+        let mut reader = move |bank: &str, pcr: u32| -> Result<String, String> {
+            assert_eq!(bank, "sha256");
+            assert_eq!(pcr, 12);
+            Ok(owned.clone())
+        };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut reader);
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn manifest_roundtrip_pcr_mismatch_returns_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let expected = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1";
+        write_test_manifest(dir.path(), &populated_pcrs_manifest(expected));
+        let mut reader = |_: &str, _: u32| -> Result<String, String> {
+            // Drift digest — proves comparison fires + flags MISMATCH.
+            Ok("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string())
+        };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut reader);
+        assert_eq!(rc, 1, "drifted PCR should surface as a non-zero exit");
+    }
+
+    #[test]
+    fn manifest_roundtrip_pcr_read_failure_returns_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_test_manifest(
+            dir.path(),
+            &populated_pcrs_manifest("ab".repeat(32).as_str()),
+        );
+        let mut reader =
+            |_: &str, _: u32| -> Result<String, String> { Err("no /sys/class/tpm".to_string()) };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut reader);
+        assert_eq!(rc, 1, "PCR-read failure must surface as a non-zero exit");
+    }
+
+    #[test]
+    fn manifest_roundtrip_missing_manifest_returns_one() {
+        // Empty dir — no manifest.json. Should fail loudly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reader = |_: &str, _: u32| -> Result<String, String> {
+            unreachable!("no PCR read should happen if manifest read failed");
+        };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut reader);
+        assert_eq!(rc, 1);
+    }
+
+    #[test]
+    fn manifest_roundtrip_garbage_json_returns_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_test_manifest(dir.path(), "this is not json");
+        let mut reader = |_: &str, _: u32| -> Result<String, String> {
+            unreachable!("no PCR read should happen on parse failure");
+        };
+        let rc = run_manifest_roundtrip_at(dir.path(), &mut reader);
+        assert_eq!(rc, 1);
     }
 
     // dispatch_from_env() is intentionally not unit-tested: it reads

--- a/docs/rescue-tui-serial-format.md
+++ b/docs/rescue-tui-serial-format.md
@@ -55,6 +55,34 @@ This is a static-text mode; there's no kexec, no ISO, no kernel — just the ope
 
 **Why we render the no-key variant**: with no real ISO at hand, `build_mokutil_remedy(None)` gives the prose-step-1 form which still contains the load-bearing `sudo mokutil --import` substring (under "aegis-boot will then generate the exact `sudo mokutil --import <path>` command for you"). Operators in the field hit the with-key variant when they have a sibling `.pub`/`.key`/`.der` on the stick; the substring contract holds in both.
 
+### `aegis.test=manifest-roundtrip`
+
+Companion to [aegis-hwsim's E6 attestation-roundtrip scenario](https://github.com/aegis-boot/aegis-hwsim/issues/6) (#695). Mounts the ESP, parses the on-stick attestation manifest via `aegis-wire-formats::Manifest`, and (when populated) compares each `expected_pcrs[]` entry to the live PCR.
+
+**What it does**:
+
+1. Resolves the ESP block device via `/dev/disk/by-label/AEGIS_ESP` (the canonical udev symlink).
+2. Mounts read-only at `/run/aegis-test-esp`.
+3. Reads `aegis-boot-manifest.json` from the ESP root, parses via the in-tree `Manifest` type.
+4. If `expected_pcrs[]` is empty (PR3-era; current shipped behavior per `docs/attestation-manifest.md`), prints the `empty-pcrs` landmark and exits 0. Harness fail-opens — counts as Pass.
+5. If populated, iterates each entry: reads `/sys/class/tpm/tpm0/pcr-<bank>/<idx>` and emits a MATCH or MISMATCH landmark. Exit 0 only if every entry matches.
+
+**Serial landmarks (exact substrings)**:
+
+| Stage | Landmark | Meaning |
+|---|---|---|
+| Test start | `aegis-boot-test: manifest-roundtrip starting` | Confirms the stick has the test mode (not Skip). |
+| Manifest parsed | `aegis-boot-test: manifest-roundtrip parsed (schema_version=N, esp_files=N, expected_pcrs=N)` | Manifest read + parsed cleanly. The numeric fields are operator-readable; the harness can grep on the "parsed" head string. |
+| **Empty PCRs (current shipped behavior)** | `aegis-boot-test: manifest-roundtrip empty-pcrs (PR3-era; harness fail-opens per attestation-manifest.md contract)` | Pass-via-fail-open — no PCRs to compare against yet. Stays valid until aegis-boot starts populating `expected_pcrs[]`. |
+| PCR match (post-population) | `aegis-boot-test: manifest-roundtrip pcr_index=N bank=sha256 MATCH` | One per matching entry. |
+| **PCR mismatch (regression)** | `aegis-boot-test: manifest-roundtrip pcr_index=N bank=sha256 MISMATCH (expected=... live=...)` | One per drifting entry. Either the manifest doesn't reflect the current measured boot, or the boot chain has regressed. |
+| PCR read failure | `aegis-boot-test: manifest-roundtrip pcr_index=N bank=sha256 READ-FAILED (...)` | Sysfs path unreadable — TPM driver problem, not a chain regression. |
+| Pre-comparison failure | `aegis-boot-test: manifest-roundtrip FAILED (esp-find: ...)` / `(esp-mount: ...)` / `(read ...: ...)` / `(parse: ...)` | Couldn't get to the comparison step. Distinct head string per error stage so the harness log is self-explanatory. |
+
+**Process exit code**: `0` for any Pass landmark (including empty-pcrs); `1` for any FAILED / MISMATCH / READ-FAILED.
+
+**Why the empty-pcrs landmark exists**: the attestation-manifest contract pinned in [docs/attestation-manifest.md](attestation-manifest.md) keeps `schema_version` at 1 even when `expected_pcrs[]` starts being populated. Consumers (including this test mode) fail-open on the empty case, so the test mode flips from skip-via-fail-open to active-comparison the moment aegis-boot starts emitting PCR entries — no harness-side change required.
+
 ## Stability policy
 
 Strings in the **Serial landmarks** tables are part of aegis-boot's published external contract. They follow these rules:


### PR DESCRIPTION
## Summary

Companion to [aegis-hwsim's E6 attestation-roundtrip scenario](https://github.com/aegis-boot/aegis-hwsim/issues/6). Adds the third \`aegis.test=<NAME>\` mode (parallel to \`kexec-unsigned\` from PR #680 + \`mok-enroll\` from PR #681).

When the kernel cmdline carries \`aegis.test=manifest-roundtrip\` (typically baked in via \`MKUSB_TEST_MODE\` from PR #696), rescue-tui short-circuits the TUI to:

1. Resolve \`/dev/disk/by-label/AEGIS_ESP\` → mount read-only at \`/run/aegis-test-esp\`.
2. Read \`aegis-boot-manifest.json\` from the ESP root, parse via \`aegis-wire-formats::Manifest\`.
3. Emit a \`parsed (schema_version=N, esp_files=N, expected_pcrs=N)\` landmark.
4. If \`expected_pcrs[]\` is empty (current shipped state per [docs/attestation-manifest.md](https://github.com/aegis-boot/aegis-boot/blob/main/docs/attestation-manifest.md)), emit \`empty-pcrs\` landmark and exit 0.
5. If populated, iterate each entry: read live \`/sys/class/tpm/tpm0/pcr-<bank>/<idx>\` and emit MATCH / MISMATCH per entry.

## Why empty-pcrs is a deliberate Pass

The attestation-manifest contract pinned in PR #682 commits to keeping \`schema_version\` at 1 even when \`expected_pcrs[]\` starts being populated (additive change). Consumers (this test mode included) fail-open on the empty case. The mode flips from skip-via-fail-open to active comparison the moment aegis-boot starts populating PCR entries — no coordinated harness change needed.

## Test plan

- [x] \`cargo test -p rescue-tui\` — 272 passed (up from 266: 6 new manifest_roundtrip_*)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean (one bool_to_int_with_if fix; \`i32::from(!all_pass)\`)
- [x] \`cargo fmt --all\`
- [ ] CI workspace green
- [ ] Hardware E2E: \`MKUSB_TEST_MODE=manifest-roundtrip ./scripts/mkusb.sh\` → flash → \`aegis-hwsim run X attestation-roundtrip <stick>\` → Pass

## Followup

Lands on the same dispatcher-extension pattern as #680 / #681. With #696 (MKUSB_TEST_MODE) + this PR, all three of aegis-hwsim's testing-harness scenarios (E5.3 kexec, E5.4 mok-enroll, E6 attestation) have the full stick-side support to convert Skip → Pass on operator runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)