### PR TITLE
feat(tooling): tools/local-ci.sh test-mode <NAME> for aegis-hwsim harness smoke

### DIFF
--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -16,6 +16,9 @@ tools/local-ci.sh kexec        # rescue-tui → target-kernel kexec under QEMU (
 tools/local-ci.sh ovmf-secboot # SB-enforcing signed chain → rescue-tui (~4 min)
 tools/local-ci.sh mkusb        # build USB image + boot smoke (~4 min)
 tools/local-ci.sh qemu-smoke   # minimal initramfs boot (~2 min)
+tools/local-ci.sh test-mode kexec-unsigned    # smoke aegis-hwsim test mode (~2 min)
+tools/local-ci.sh test-mode mok-enroll        # smoke aegis-hwsim test mode (~2 min)
+tools/local-ci.sh test-mode manifest-roundtrip # smoke aegis-hwsim test mode (~2 min)
 tools/local-ci.sh thumb-drive --confirm-write /dev/sdX  # real USB (operator-only)
 tools/local-ci.sh all          # full suite sans thumb-drive (~12 min)
 ```

--- a/scripts/qemu-smoke.sh
+++ b/scripts/qemu-smoke.sh
@@ -82,6 +82,38 @@ if [[ ! -r "$KERNEL" ]]; then
     log "copied kernel to $tmp_kernel for read access"
 fi
 
+# QEMU_SMOKE_TEST_MODE (optional) — when set to one of the closed-set
+# dispatcher slugs, append `aegis.test=<NAME>` to the kernel cmdline so
+# /init's grep-and-export hook (PR #680) flips rescue-tui into the
+# named scripted mode. Default success grep also switches to the
+# test-mode start landmark instead of the rescue-tui banner.
+#
+# Used by tools/local-ci.sh test-mode <NAME> to smoke each test mode
+# locally without a full aegis-hwsim run.
+QEMU_SMOKE_TEST_MODE="${QEMU_SMOKE_TEST_MODE:-}"
+EXTRA_CMDLINE=""
+SUCCESS_GREP='aegis-boot rescue-tui starting|No bootable ISOs|aegis-boot — pick an ISO'
+case "$QEMU_SMOKE_TEST_MODE" in
+    "")
+        ;;
+    kexec-unsigned|mok-enroll|manifest-roundtrip)
+        EXTRA_CMDLINE=" aegis.test=${QEMU_SMOKE_TEST_MODE}"
+        # Grep for the per-mode start landmark (substring-stable per
+        # docs/rescue-tui-serial-format.md). All three modes emit
+        # `aegis-boot-test: <NAME> starting` (kexec-unsigned) or a
+        # close variant (`MOK enrollment walkthrough starting`,
+        # `manifest-roundtrip starting`); the broad regex below
+        # covers all three.
+        SUCCESS_GREP="aegis-boot-test: ${QEMU_SMOKE_TEST_MODE}|MOK enrollment walkthrough starting|manifest-roundtrip starting"
+        log "test-mode smoke: ${QEMU_SMOKE_TEST_MODE} (cmdline gets aegis.test=${QEMU_SMOKE_TEST_MODE})"
+        ;;
+    *)
+        echo "qemu-smoke: ERROR — unknown QEMU_SMOKE_TEST_MODE '$QEMU_SMOKE_TEST_MODE'" >&2
+        echo "  valid: kexec-unsigned, mok-enroll, manifest-roundtrip" >&2
+        exit 2
+        ;;
+esac
+
 log "booting under QEMU (timeout ${TIMEOUT_SECONDS}s)"
 output_file="$(mktemp --tmpdir qemu-smoke-out-XXXXXX.log)"
 trap '[[ -n "${output_file:-}" ]] && rm -f -- "$output_file"' EXIT
@@ -97,7 +129,7 @@ timeout "$TIMEOUT_SECONDS" qemu-system-x86_64 \
     -m 512M \
     -kernel "$KERNEL" \
     -initrd "$OUT_DIR/initramfs.cpio.gz" \
-    -append 'console=ttyS0 panic=5 rdinit=/init quiet loglevel=3' \
+    -append "console=ttyS0 panic=5 rdinit=/init quiet loglevel=3${EXTRA_CMDLINE}" \
     </dev/null \
     >"$output_file" 2>&1
 qemu_exit=$?
@@ -108,12 +140,21 @@ echo "--- QEMU serial output ---"
 cat "$output_file"
 echo "--- end QEMU serial output ---"
 
-# Look for our startup banner (stderr → serial console) — reliable even
-# when the serial TTY doesn't report a size and ratatui renders blank.
-if grep -qE 'aegis-boot rescue-tui starting|No bootable ISOs|aegis-boot — pick an ISO' "$output_file"; then
-    log "rescue-tui rendered — boot smoke PASSED"
+# Look for the success landmark. Default: rescue-tui banner. Test-mode:
+# the per-mode start landmark.
+if grep -qE "$SUCCESS_GREP" "$output_file"; then
+    if [[ -n "$QEMU_SMOKE_TEST_MODE" ]]; then
+        log "test-mode '${QEMU_SMOKE_TEST_MODE}' dispatched — start landmark detected"
+    else
+        log "rescue-tui rendered — boot smoke PASSED"
+    fi
     exit 0
 fi
 
-echo "rescue-tui output not detected; qemu exit=$qemu_exit" >&2
+if [[ -n "$QEMU_SMOKE_TEST_MODE" ]]; then
+    echo "test-mode '${QEMU_SMOKE_TEST_MODE}' did not fire; qemu exit=$qemu_exit" >&2
+    echo "  expected substring: $SUCCESS_GREP" >&2
+else
+    echo "rescue-tui output not detected; qemu exit=$qemu_exit" >&2
+fi
 exit 1

--- a/tools/local-ci.sh
+++ b/tools/local-ci.sh
@@ -200,6 +200,56 @@ cmd_qemu_smoke() {
     echo "✓ QEMU smoke passed"
 }
 
+cmd_test_mode() {
+    # Local QEMU smoke for the aegis-hwsim test modes (#675/#676/#695).
+    # Builds rescue-tui + initramfs, boots under QEMU with
+    # `aegis.test=<NAME>` injected via QEMU_SMOKE_TEST_MODE, asserts
+    # the per-mode start landmark fires.
+    #
+    # Use to verify the dispatcher + landmark wording locally without
+    # running a full aegis-hwsim scenario over real hardware. ~2-3 min
+    # per mode on a moderate dev host.
+    local mode="${1:-}"
+    case "$mode" in
+        kexec-unsigned|mok-enroll|manifest-roundtrip)
+            ;;
+        ""|--help|-h)
+            cat >&2 <<EOF
+error: test-mode subcommand requires a mode name
+
+Usage:
+  tools/local-ci.sh test-mode <NAME>
+
+Where <NAME> is one of:
+  kexec-unsigned        attempt unsigned kexec; expect EKEYREJECTED (#675)
+  mok-enroll            print MOK enrollment walkthrough (#676)
+  manifest-roundtrip    parse on-stick manifest, compare PCRs (#695)
+
+See docs/rescue-tui-serial-format.md for the landmarks each mode emits.
+EOF
+            exit 2
+            ;;
+        *)
+            echo "error: unknown test-mode '$mode'" >&2
+            echo "  valid: kexec-unsigned, mok-enroll, manifest-roundtrip" >&2
+            exit 2
+            ;;
+    esac
+    require_qemu
+    require_rust
+    warn_about_toolchain_once
+    require_file ./scripts/qemu-smoke.sh "expected at scripts/qemu-smoke.sh"
+    echo "==> Building rescue-tui (release)"
+    SOURCE_DATE_EPOCH=1700000000 cargo_run build --release -p rescue-tui
+    echo "==> Building initramfs"
+    SOURCE_DATE_EPOCH=1700000000 ./scripts/build-initramfs.sh
+    echo "==> Running QEMU smoke with aegis.test=$mode"
+    QEMU_SMOKE_TEST_MODE="$mode" \
+        TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-60}" \
+        ./scripts/qemu-smoke.sh
+    echo "✓ test-mode '$mode' smoke passed"
+}
+
 cmd_thumb_drive() {
     # Real-hardware E2E against the operator's attached USB stick. Writes to
     # the device — gated behind --confirm-write so a typo can't nuke /dev/sda.
@@ -284,6 +334,8 @@ Subcommands:
   ovmf-secboot    SB-enforcing signed chain → rescue-tui under QEMU (~4min)
   mkusb           build bootable image + boot smoke under QEMU (~4min)
   qemu-smoke      minimal initramfs boot smoke (~2min)
+  test-mode <NAME>  smoke an aegis-hwsim test mode (kexec-unsigned, mok-enroll,
+                    manifest-roundtrip) — ~2min per mode
   thumb-drive     write to attached USB stick (requires --confirm-write /dev/sdX)
   all             run the full suite (sans thumb-drive), fail-fast (~12min)
   --help          this help
@@ -321,10 +373,11 @@ main() {
         ovmf-secboot)  cmd_ovmf_secboot "$@" ;;
         mkusb)         cmd_mkusb "$@" ;;
         qemu-smoke)    cmd_qemu_smoke "$@" ;;
+        test-mode)     cmd_test_mode "$@" ;;
         thumb-drive)   cmd_thumb_drive "$@" ;;
         all)           cmd_all "$@" ;;
         --help|-h)     print_help ;;
-        --list)        echo "quick kexec ovmf-secboot mkusb qemu-smoke thumb-drive all" ;;
+        --list)        echo "quick kexec ovmf-secboot mkusb qemu-smoke test-mode thumb-drive all" ;;
         *)
             echo "error: unknown subcommand '$sub'" >&2
             echo "       run 'tools/local-ci.sh --help' for usage" >&2


### PR DESCRIPTION
## Summary

Adds local-iteration coverage for the 3 aegis-hwsim test modes (kexec-unsigned, mok-enroll, manifest-roundtrip). Boots under QEMU with \`aegis.test=<NAME>\` injected on the kernel cmdline + asserts the per-mode start landmark fires.

\`\`\`bash
tools/local-ci.sh test-mode kexec-unsigned       # ~2 min
tools/local-ci.sh test-mode mok-enroll           # ~2 min
tools/local-ci.sh test-mode manifest-roundtrip   # ~2 min
\`\`\`

## Why

The 3 test-mode dispatchers + their landmarks are aegis-boot's published external contract with aegis-hwsim. Without local smoke, drift surfaces only when aegis-hwsim's next CI run (or a maintainer's manual scenario) catches it — slow feedback loop. This subcommand lets a maintainer verify the dispatcher + landmark wording in 2 min on a libvirt-attached dev host before pushing.

## Implementation

- \`scripts/qemu-smoke.sh\` honors a new \`QEMU_SMOKE_TEST_MODE\` env var: appends \`aegis.test=<NAME>\` to the kernel cmdline + flips the success-grep to the per-mode start landmark from \`docs/rescue-tui-serial-format.md\`.
- \`tools/local-ci.sh\` adds \`cmd_test_mode\` + closed-set validation rejecting unknown slugs before any QEMU spawn.
- \`docs/LOCAL_TESTING.md\` TL;DR adds the 3 new invocations.

## What this does NOT replace

The full SB-enforcing rejection assertions (real \`EKEYREJECTED\` on kexec; MOK walkthrough text drift; PCR-roundtrip MATCH/MISMATCH semantics) stay in aegis-hwsim's QEMU+OVMF+swtpm harness. This is a dispatcher-level smoke — proves the test mode ENTERS, not that the full assertion path is correct.

## Test plan

- [x] \`bash -n scripts/qemu-smoke.sh\` + \`bash -n tools/local-ci.sh\` — clean
- [x] \`tools/local-ci.sh test-mode\` (no arg) — usage error
- [x] \`tools/local-ci.sh test-mode bad-slug\` — closed-set rejection
- [ ] CI workspace green
- [ ] Maintainer hardware verification: each of the 3 modes fires the start landmark on the local libvirt host

🤖 Generated with [Claude Code](https://claude.com/claude-code)