### PR TITLE
feat(ci): test-mode dispatcher verification matrix in e2e-suite.yml

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -694,3 +694,59 @@ jobs:
         env:
           TIMEOUT_SECONDS: "120"
         run: ./scripts/ovmf-secboot-e2e.sh
+
+  # Test-mode dispatcher verification (#698 follow-up).
+  # Boots QEMU once per harness test mode (kexec-unsigned, mok-enroll,
+  # manifest-roundtrip) with `aegis.test=<NAME>` injected via
+  # QEMU_SMOKE_TEST_MODE. Asserts the per-mode start landmark fires —
+  # catches dispatcher / landmark drift in aegis-boot's own CI instead
+  # of waiting for aegis-hwsim's next sweep.
+  #
+  # This proves the test mode ENTERS — not the full assertion path
+  # (real EKEYREJECTED on kexec, MOK walkthrough text, PCR roundtrip).
+  # Those stay in aegis-hwsim's QEMU+OVMF+swtpm harness which boots
+  # under enforcing SB + lockdown.
+  test-mode-dispatcher-shared:
+    name: Test-mode dispatcher smoke (shared-build)
+    needs: build-shared
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [kexec-unsigned, mok-enroll, manifest-roundtrip]
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Install QEMU + kernel runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 \
+            linux-image-generic \
+            busybox-static \
+            cpio
+          sudo chmod 0644 /boot/vmlinuz-* 2>/dev/null || true
+
+      - name: Download shared artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: e2e-shared-build
+          path: shared/
+
+      - name: Reposition artifacts to expected paths
+        run: |
+          mkdir -p target/release out
+          mv shared/rescue-tui                  target/release/rescue-tui
+          mv shared/initramfs.cpio.gz           out/initramfs.cpio.gz
+          mv shared/initramfs.cpio.gz.sha256    out/initramfs.cpio.gz.sha256
+          chmod +x target/release/rescue-tui
+
+      - name: Smoke ${{ matrix.mode }} dispatcher
+        env:
+          QEMU_SMOKE_TEST_MODE: ${{ matrix.mode }}
+          TIMEOUT_SECONDS: "60"
+        run: ./scripts/qemu-smoke.sh


### PR DESCRIPTION
## Summary

Adds a 3-cell matrix job in \`e2e-suite.yml\` (one cell per harness test mode: \`kexec-unsigned\`, \`mok-enroll\`, \`manifest-roundtrip\`) that boots QEMU with \`aegis.test=<NAME>\` injected via the \`QEMU_SMOKE_TEST_MODE\` env var landed in [PR #698](https://github.com/aegis-boot/aegis-boot/pull/698). Each cell asserts the per-mode start landmark fires.

The dispatcher contract is now self-verifying in aegis-boot's own CI instead of waiting for aegis-hwsim's next sweep to surface drift.

## What this catches

- Refactor accidentally drops a slug from \`test_mode::dispatch_from_env\`
- Landmark wording changes that aegis-hwsim's \`TEST_LANDMARKS\` grep-pins against
- \`scripts/build-initramfs.sh\` \`aegis.test=*\` cmdline-parsing regression
- \`rescue-tui::main()\` short-circuit hook accidentally removed in a refactor

## What this does NOT catch

These stay in [aegis-hwsim](https://github.com/aegis-boot/aegis-hwsim)'s QEMU+OVMF+swtpm harness which boots under enforcing SB + lockdown:

- Real \`EKEYREJECTED\` on kexec under lockdown=integrity
- MOK walkthrough body drift (the #202 prose itself)
- Manifest-roundtrip PCR MATCH/MISMATCH semantics

The smoke proves the test mode ENTERS — not that the full assertion path works.

## CI cost

~3 min added to e2e-suite (3 cells × ~1 min each, parallel runners).

\`fail-fast: false\` so all three modes run even when one fails — the per-mode failure tells the maintainer which dispatcher broke.

## Test plan

- [ ] CI on this PR — all 3 matrix cells green
- [ ] Subsequent PRs see all 3 cells in their statusCheckRollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)