### PR TITLE
docs(readme): link rescue-tui-serial-format + attestation-manifest contract docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Full developer loop: [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md).
 - [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — one-page mental model
 - [BUILDING.md](./BUILDING.md) — reproducible build setup (Docker + Nix)
 - [docs/LOCAL_TESTING.md](./docs/LOCAL_TESTING.md) — 8-stage local CI equivalent
+- [docs/rescue-tui-serial-format.md](./docs/rescue-tui-serial-format.md) — serial-output contract + the `aegis.test=<NAME>` harness modes that [aegis-hwsim](https://github.com/aegis-boot/aegis-hwsim) drives
+- [docs/attestation-manifest.md](./docs/attestation-manifest.md) — on-ESP attestation-manifest wire format
 - [docs/adr/](./docs/adr/) — Architecture Decision Records
 - [docs/compatibility/iso-matrix.md](./docs/compatibility/iso-matrix.md) — per-distro kexec compatibility
 


### PR DESCRIPTION
## Summary

Two contract docs hadn't made it into the README's "For contributors" section:

- \`docs/rescue-tui-serial-format.md\` — landmark contract aegis-hwsim grep-pins against (added in PR #680, extended in #681/#697)
- \`docs/attestation-manifest.md\` — on-ESP wire format aegis-hwsim's E6 scenario consumes (added in PR #682)

These are load-bearing for cross-repo coordination — a contributor touching \`test_mode.rs\` or \`aegis-wire-formats::Manifest\` needs to see the operator-facing contract before changing wording. Surfacing them in README is the lowest-friction discovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)