### PR TITLE
fix(ci/release): install musl-tools to unblock v0.18.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             busybox-static cpio \
             shim-signed grub-efi-amd64-signed linux-image-virtual \
-            mtools dosfstools exfatprogs gdisk
+            mtools dosfstools exfatprogs gdisk \
+            musl-tools
+          # musl-tools provides /usr/bin/musl-gcc, which ring's cc-rs
+          # build script needs when compiling for the
+          # x86_64-unknown-linux-musl target. Surfaces as soon as
+          # any transitive dep (rustls / aws-lc / etc.) pulls ring
+          # into the dependency graph — first hit was the v0.18.0
+          # release after #655's aegis-fetch + pgp deps merged.
           # Kernels ship mode 0600 on Ubuntu; mcopy needs them readable.
           # Conservative chmod across all matching files matches
           # mkusb.yml. Silenced errors for the case where one of the


### PR DESCRIPTION
## Summary

Hotfix to unblock the v0.18.0 release. The Linux release leg failed at:

\`\`\`
error: failed to run custom build command for \`ring v0.17.14\`
error occurred in cc-rs: failed to find tool \`x86_64-linux-musl-gcc\`
\`\`\`

\`ring\` was pulled into the dependency graph by #655's \`aegis-fetch\` + \`pgp\` additions that landed in v0.18.0. Previous releases didn't transitively need a C compiler for the musl target.

\`musl-tools\` provides \`/usr/bin/musl-gcc\`, which cc-rs picks up via its standard PATH-walk.

## Test plan

- [x] Local: `apt search musl-tools` — confirms package exists on ubuntu-22.04
- [ ] CI: this PR's checks pass (workflow file change is no-op for non-release CI)
- [ ] Once merged: re-trigger release.yml via \`workflow_dispatch\` with \`tag=v0.18.0\` + verify Linux + macOS arm64 jobs both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)