### PR TITLE
chore(brew): bump formula to v0.18.0

### DIFF
--- a/Formula/aegis-boot.rb
+++ b/Formula/aegis-boot.rb
@@ -44,8 +44,8 @@ class AegisBoot < Formula
       # macOS arm64 binary ships with every release (#365 Phase A1).
       # The sha256 below is bumped per-release by the bump-brew-formula
       # job in release.yml.
-      url "https://github.com/aegis-boot/aegis-boot/releases/download/v0.17.0/aegis-boot-aarch64-apple-darwin"
-      sha256 "ceea2b35d966bfe73387f3bf86f61e2a93f320d17430e61ba747dbc5ddd415a1"
+      url "https://github.com/aegis-boot/aegis-boot/releases/download/v0.18.0/aegis-boot-aarch64-apple-darwin"
+      sha256 "7e445fcdf9798fc948898965ecd4a4b6ff7acfceebcdf22c5d73a8368f47da36"
     end
   end
 


### PR DESCRIPTION
## Summary

Manual Homebrew formula bump. \`release.yml\`'s \`bump-brew-formula\` job is gated on \`if: github.event_name == 'push'\` — the v0.18.0 release shipped via \`workflow_dispatch\` (after #705's musl-tools hotfix re-triggered the build), so the auto-bump path didn't run.

URL + sha sourced from the v0.18.0 release's \`aegis-boot-aarch64-apple-darwin.sha256\` sidecar.

## Follow-up

\`bump-brew-formula\` should also fire on \`workflow_dispatch\` when an \`inputs.tag\` is supplied — would prevent this manual step on future re-triggered releases.

## Test plan

- [ ] CI green (Formula change is no-op for non-brew checks)
- [ ] After merge: brew-test.yml's \`push: paths: [Formula/**]\` trigger validates the new sha against the release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)