### PR TITLE
fix(release-please): switch to simple release-type for cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ exclude = ["crates/iso-parser/fuzz"]
 [workspace.package]
 # Single source of truth for the release version (Phase 1a of #286).
 # Each member crate references this via `version.workspace = true`.
-# Release-cut flow: bump this one line + amend CHANGELOG, tag.
+# Release-cut flow: release-please opens a "chore: release" PR with
+# this line bumped; merging that PR tags + cuts the GitHub release.
 # CI's doc-version drift-check (Phase 1c) greps an allowlist of
 # user-facing doc files and fails if any version literal diverges.
-version = "0.18.0"
+version = "0.18.0" # x-release-please-version
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
@@ -25,8 +25,9 @@
   "packages": {
     ".": {
       "package-name": "aegis-boot",
-      "release-type": "rust",
+      "release-type": "simple",
       "extra-files": [
+        "Cargo.toml",
         "flake.nix",
         "docs/INSTALL.md",
         "docs/CLI.md",

--- a/scripts/check-doc-version.sh
+++ b/scripts/check-doc-version.sh
@@ -35,9 +35,13 @@ CANONICAL_VERSION="$(
     awk '
         /^\[workspace\.package\]/ { f=1; next }
         f && /^\[/                 { exit }
-        f && /^version = /         {
-            gsub(/^version = "|"$/, "", $0)
-            print
+        f && /^version = "/        {
+            # Match: version = "X.Y.Z" [# trailing comment]
+            # release-please uses an `# x-release-please-version`
+            # annotation after the value; extract just the quoted
+            # version literal so the trailing comment is ignored.
+            match($0, /"[^"]+"/)
+            print substr($0, RSTART + 1, RLENGTH - 2)
             exit
         }
     ' Cargo.toml


### PR DESCRIPTION
## Summary

The initial release-please config (#707) used \`release-type: rust\`, which expects \`[package].version\` in Cargo.toml. Aegis-boot is a cargo workspace with \`[workspace.package].version\`, so the first release-please run errored:

\`\`\`
release-please failed: value at path package.version is not tagged
\`\`\`

Fix: switch to \`release-type: simple\` — release-please's no-strategy mode that just bumps annotated lines in \`extra-files\`. Adds \`Cargo.toml\` to extra-files with an \`x-release-please-version\` annotation on the \`[workspace.package].version\` line.

Also patches \`scripts/check-doc-version.sh\` so its awk version-parser handles the trailing annotation comment.

## Test plan

- [x] \`bash scripts/check-doc-version.sh\` green after annotation + parser fix
- [x] \`cargo check --workspace\` clean
- [ ] CI green
- [ ] After merge: release-please workflow opens the v0.18.1 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)