### PR TITLE
fix(release-please): inline annotations on docs/CLI.md + docs/INSTALL.md

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -946,8 +946,7 @@ aegis-boot tour --help
 
 ## Versioning
 
-<!-- x-release-please-version -->
-`aegis-boot --version` reports the workspace version (currently `0.18.0`). The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
+`aegis-boot --version` reports the workspace version (currently `0.18.0`). <!-- x-release-please-version --> The CLI ships in lockstep with the rest of the workspace; `cargo install --path crates/aegis-cli` (or downloading a release binary) will give you a CLI that matches the on-stick rescue-tui.
 
 `aegis-boot --version --json` emits the same info as a stable envelope for scripted install verification or Homebrew-style version matching:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -130,9 +130,8 @@ The flake pins to `nixos-unstable`; downgrade to a specific channel in your own 
 
 Sanity check:
 
-<!-- x-release-please-version -->
 ```bash
-aegis-boot --version       # → aegis-boot v0.18.0
+aegis-boot --version       # → aegis-boot v0.18.0  # x-release-please-version
 aegis-boot doctor          # 0–100 health score for host + stick
 ```
 
@@ -237,7 +236,6 @@ If the firmware refuses to show the USB entry, your boot mode might be CSM/Legac
 
 `rescue-tui` shows your ISOs with verification status:
 
-<!-- x-release-please-version -->
 ```
 aegis-boot v0.18.0    SB:enforcing  TPM:available
 


### PR DESCRIPTION
## Summary

The first release-please run (PR #709, proposing v0.18.1) correctly bumped the workspace version + intra-workspace pins + flake.nix + CLI.md JSON-envelope annotations, but missed 2 doc lines because their \`<!-- x-release-please-version -->\` annotations sat on the line ABOVE the version literal.

release-please's annotation parser only matches annotations on the **same line** as the version.

## Fixes

- \`docs/CLI.md\` § Versioning prose: HTML-comment annotation moved inline.
- \`docs/INSTALL.md\` § Sanity check code block: switched to inline \`# x-release-please-version\` bash-style trailing comment on the \`aegis-boot --version\` example line.
- \`docs/INSTALL.md\` § rescue-tui banner: removed the failed prev-line annotation (no inline equivalent works without implying rescue-tui literally prints the annotation comment — misleading). This line is illustrative-only + not drift-checked.

After merge, release-please will re-process and PR #709's diff will also cover these doc lines.

## Test plan

- [x] \`bash scripts/check-doc-version.sh\` green
- [ ] CI green
- [ ] After merge: PR #709 release-please re-run picks up the new annotations on its next refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)