### PR TITLE
fix(update): read ESP-side manifest via mtype + skip gracefully when absent

### DIFF
--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -634,7 +634,10 @@ mod tests {
 
     #[test]
     fn build_mtype_argv_starts_with_mtype_and_minus_i() {
-        let argv = build_mtype_argv("/dev/sda1", crate::direct_install_manifest::MANIFEST_ESP_PATH);
+        let argv = build_mtype_argv(
+            "/dev/sda1",
+            crate::direct_install_manifest::MANIFEST_ESP_PATH,
+        );
         assert_eq!(argv.first().map(String::as_str), Some("mtype"));
         assert_eq!(argv.get(1).map(String::as_str), Some("-i"));
         assert_eq!(argv.get(2).map(String::as_str), Some("/dev/sda1"));

--- a/crates/aegis-cli/src/direct_install.rs
+++ b/crates/aegis-cli/src/direct_install.rs
@@ -329,6 +329,27 @@ pub(crate) fn build_mcopy_argv(image_or_dev: &str, src: &Path, dest: &str) -> Ve
     ]
 }
 
+/// Build the argv for `mtype` — read a file from a FAT image to
+/// stdout. Used by the `aegis-boot update` manifest-refresh path
+/// (#181 follow-up) to read the on-ESP `aegis-boot-manifest.json`
+/// before bumping its sequence + writing it back via `mcopy`.
+///
+/// `--` separates flag parsing from positional args, same defense
+/// pattern as `build_mcopy_argv`. mtype's exit code is non-zero when
+/// the path doesn't exist on the image — callers distinguish "absent
+/// manifest" (older sticks predating the ESP-side manifest) from
+/// genuine read errors via stderr inspection rather than exit code
+/// alone.
+pub(crate) fn build_mtype_argv(image_or_dev: &str, src: &str) -> Vec<String> {
+    vec![
+        "mtype".to_string(),
+        "-i".to_string(),
+        image_or_dev.to_string(),
+        "--".to_string(),
+        src.to_string(),
+    ]
+}
+
 /// Build the argv for `mmd` — creates directories on a FAT image
 /// without failing if they already exist (via `-D s` = skip existing).
 pub(crate) fn build_mmd_argv(image_or_dev: &str, dirs: &[&str]) -> Vec<String> {
@@ -609,6 +630,22 @@ mod tests {
         let argv = build_mcopy_argv("/dev/sda1", Path::new("/tmp/x"), "::/x");
         let d_idx = argv.iter().position(|a| a == "-D").expect("-D flag");
         assert_eq!(argv.get(d_idx + 1).map(String::as_str), Some("o"));
+    }
+
+    #[test]
+    fn build_mtype_argv_starts_with_mtype_and_minus_i() {
+        let argv = build_mtype_argv("/dev/sda1", crate::direct_install_manifest::MANIFEST_ESP_PATH);
+        assert_eq!(argv.first().map(String::as_str), Some("mtype"));
+        assert_eq!(argv.get(1).map(String::as_str), Some("-i"));
+        assert_eq!(argv.get(2).map(String::as_str), Some("/dev/sda1"));
+    }
+
+    #[test]
+    fn build_mtype_argv_inserts_double_dash_before_positional() {
+        let argv = build_mtype_argv("/dev/sda1", "::/-rogue");
+        let dd_idx = argv.iter().position(|a| a == "--").expect("-- delimiter");
+        let src_idx = argv.iter().position(|a| a == "::/-rogue").expect("src");
+        assert!(dd_idx < src_idx, "`--` must precede the src path: {argv:?}");
     }
 
     #[test]

--- a/crates/aegis-cli/src/update.rs
+++ b/crates/aegis-cli/src/update.rs
@@ -192,7 +192,7 @@ fn handle_eligible(
         print_rotation_plan(&diff);
         println!();
         #[cfg(target_os = "linux")]
-        return apply_rotation(dev, &esp_part, &diff, attestation_path);
+        return apply_rotation(dev, &esp_part, &diff);
         #[cfg(not(target_os = "linux"))]
         {
             println!(
@@ -1186,12 +1186,7 @@ pub(crate) fn attestation_dir() -> PathBuf {
 /// 5. On failure, invoke `execute_rollback` with the progress trace +
 ///    surface both the original error and any rollback errors.
 #[cfg(target_os = "linux")]
-fn apply_rotation(
-    dev: &Path,
-    part1_dev: &Path,
-    diff: &[EspFileDiff],
-    attestation_path: &Path,
-) -> Result<(), u8> {
+fn apply_rotation(dev: &Path, part1_dev: &Path, diff: &[EspFileDiff]) -> Result<(), u8> {
     use crate::update_apply::plan_rotation;
 
     let plan = plan_rotation(diff);
@@ -1214,12 +1209,14 @@ fn apply_rotation(
     );
     let rotation_result = dispatch_rotation(dev, part1_dev, &plan, &sources);
 
-    // On successful rotation: refresh the attestation manifest (both
-    // host-side + ESP-side copies). Failure warns but doesn't fail —
-    // the rotation already landed; a stale manifest causes
+    // On successful rotation: refresh the ESP-side attestation
+    // manifest at `::/aegis-boot-manifest.json` (the wire-format
+    // file, NOT the host-side `~/.local/share/.../<guid>-<ts>.json`
+    // — those are different schemas). Failure warns but doesn't
+    // fail — the rotation already landed; a stale manifest causes
     // `verify --stick` drift on rotated slots, which is recoverable.
     if rotation_result.is_ok()
-        && let Err(e) = refresh_manifest_after_rotate(attestation_path, part1_dev, &plan, &sources)
+        && let Err(e) = refresh_manifest_after_rotate(part1_dev, &plan, &sources)
     {
         eprintln!("warning: manifest refresh after rotation failed: {e}");
         eprintln!(
@@ -1230,23 +1227,63 @@ fn apply_rotation(
     rotation_result
 }
 
-/// Read the current attestation manifest, update `esp_files[]` entries
-/// for rotated slots with their new sha256 + size, bump `sequence`,
-/// update `tool_version`, and write the manifest back to both the
-/// host-side attestations dir AND the ESP's canonical
-/// `::/aegis-boot-manifest.json`. Linux-only.
+/// Read the on-ESP wire-format manifest at
+/// `::/aegis-boot-manifest.json` via `mtype`, update `esp_files[]`
+/// entries for rotated slots with their new sha256 + size, bump
+/// `sequence`, update `tool_version`, and write the manifest back
+/// via `mcopy`.
+///
+/// Sticks flashed before #386 (Phase 3b of #349) — and any stick
+/// flashed via plain `aegis-boot flash` instead of `--direct-install`
+/// — don't carry an ESP-side manifest. We detect "absent" via mtype
+/// stderr ("File ... not found") and treat it as a graceful skip
+/// rather than an error: the rotation succeeded; the operator can
+/// re-flash with `--direct-install` to get a fresh ESP-side
+/// manifest, or live with the missing file (no functional impact
+/// on boot — only on `verify --stick`'s drift report).
+///
+/// The host-side attestation at
+/// `~/.local/share/aegis-boot/attestations/<guid>-<ts>.json` is a
+/// SEPARATE schema (the `Attestation` struct in `attest.rs`, not
+/// the wire-format `Manifest` here) — it's a flash-time record,
+/// not a verifier input, so we deliberately don't touch it from
+/// the rotation path.
+///
+/// Linux-only.
 #[cfg(target_os = "linux")]
 fn refresh_manifest_after_rotate(
-    attestation_path: &Path,
     part1_dev: &Path,
     plan: &[crate::update_apply::RotationStep],
     sources: &crate::update_apply::RotationSources<'_>,
 ) -> Result<(), String> {
-    // 1. Read + parse existing manifest.
-    let body = std::fs::read_to_string(attestation_path)
-        .map_err(|e| format!("read {}: {e}", attestation_path.display()))?;
+    // 1. Read existing ESP-side manifest via mtype. Absent → graceful skip.
+    let dev_str = part1_dev.display().to_string();
+    let read_argv = crate::direct_install::build_mtype_argv(
+        &dev_str,
+        crate::direct_install_manifest::MANIFEST_ESP_PATH,
+    );
+    let read_argv_refs: Vec<&str> = read_argv.iter().map(String::as_str).collect();
+    let read_out = std::process::Command::new("sudo")
+        .args(&read_argv_refs)
+        .output()
+        .map_err(|e| format!("mtype exec: {e}"))?;
+    if !read_out.status.success() {
+        let stderr = String::from_utf8_lossy(&read_out.stderr);
+        // mtype prints "File "::/<path>" not found" to stderr when
+        // the file doesn't exist on the FAT image. That's the
+        // older-stick case — graceful skip, not error.
+        if stderr.contains("not found") {
+            println!(
+                "ESP-side manifest absent (stick predates #386 ESP-side attestation; rotation landed successfully without manifest refresh). Re-flash with `aegis-boot flash --direct-install` to enable manifest tracking on this stick."
+            );
+            return Ok(());
+        }
+        return Err(format!("mtype ESP manifest: {}", stderr.trim()));
+    }
+    let body = String::from_utf8(read_out.stdout)
+        .map_err(|e| format!("ESP manifest body not valid UTF-8: {e}"))?;
     let mut manifest: aegis_wire_formats::Manifest =
-        serde_json::from_str(&body).map_err(|e| format!("parse manifest: {e}"))?;
+        serde_json::from_str(&body).map_err(|e| format!("parse ESP manifest: {e}"))?;
 
     // 2. For each rotated step, find the matching EspFileEntry and
     //    update sha256 + size. Manifest paths are `::/`-prefixed;
@@ -1278,24 +1315,20 @@ fn refresh_manifest_after_rotate(
     manifest.sequence = manifest.sequence.saturating_add(1);
     manifest.tool_version = format!("aegis-boot {}", env!("CARGO_PKG_VERSION"));
 
-    // 4. Serialize + write both copies.
+    // 4. Serialize + write back to ESP via mcopy.
     let new_body =
         serde_json::to_string_pretty(&manifest).map_err(|e| format!("serialize manifest: {e}"))?;
-    std::fs::write(attestation_path, &new_body)
-        .map_err(|e| format!("write host-side {}: {e}", attestation_path.display()))?;
-
     let tmp =
         tempfile::NamedTempFile::new().map_err(|e| format!("tempfile for ESP manifest: {e}"))?;
     std::fs::write(tmp.path(), &new_body).map_err(|e| format!("stage ESP manifest body: {e}"))?;
-    let dev_str = part1_dev.display().to_string();
-    let argv = crate::direct_install::build_mcopy_argv(
+    let write_argv = crate::direct_install::build_mcopy_argv(
         &dev_str,
         tmp.path(),
         crate::direct_install_manifest::MANIFEST_ESP_PATH,
     );
-    let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let write_argv_refs: Vec<&str> = write_argv.iter().map(String::as_str).collect();
     let out = std::process::Command::new("sudo")
-        .args(&argv_refs)
+        .args(&write_argv_refs)
         .output()
         .map_err(|e| format!("mcopy exec: {e}"))?;
     if !out.status.success() {


### PR DESCRIPTION
## Summary

Fixes the \`manifest refresh after rotation failed: parse manifest: missing field \`manifest_sequence\`\` warning that fired on every \`aegis-boot update --apply\` against sticks flashed without \`--direct-install\` (i.e., any stick from plain \`flash\` / mkusb / dd-of-the-img). Verified end-to-end on a real v0.16.0-flashed Cruzer.

## Two layered bugs

### 1. Wrong file read

\`refresh_manifest_after_rotate\` read the **host-side attestation record** at \`~/.local/share/aegis-boot/attestations/<guid>-<ts>.json\` and parsed it as \`aegis_wire_formats::Manifest\`. Those are two completely different schemas. Parsing always failed regardless of stick age — the "missing field" message was misleading.

**Fix:** read from the ESP at \`::/aegis-boot-manifest.json\` via mtype (same path mcopy already wrote to).

### 2. Sticks predating the ESP-side manifest

\`::/aegis-boot-manifest.json\` only started shipping in PR #386 (Phase 3b of #349) and only via \`--direct-install\`. Plain-\`flash\` sticks don't have it. mtype returns "File not found" on stderr.

**Fix:** detect "not found" stderr → graceful skip with operator-facing message pointing at \`--direct-install\` for re-flash.

## Verified on real hardware

Tested on grenlan@'s SanDisk Cruzer, flashed at v0.16.0, plain \`flash\`. Forced a rotation by bumping \`SOURCE_DATE_EPOCH\` for the initramfs build. Old behavior would have logged the parse error; new behavior prints:

\`\`\`
ESP-side manifest absent (stick predates #386 ESP-side attestation;
rotation landed successfully without manifest refresh). Re-flash with
\`aegis-boot flash --direct-install\` to enable manifest tracking on
this stick.
\`\`\`

Stick restored to canonical initramfs sha256 afterward.

## Test plan

- [x] \`cargo check --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p aegis-bootctl --bins build_mtype\` — 2/2 pass
- [x] Real-hardware: rotation against v0.16.0 stick — graceful-skip message instead of parse error
- [ ] CI green
- [ ] release-please picks this up as \`fix:\` → patch bump for v0.18.2

## Out of scope (follow-ups)

- Standalone \`aegis-boot manifest --refresh /dev/sda\` subcommand for refresh-only (no rotation)
- Re-flash UX so plain-\`flash\` sticks retroactively get an ESP-side manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)