### PR TITLE
fix(initramfs): symlink missing busybox applets (tail/head/sort/basename/dd/mkfifo)

### DIFF
--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -475,6 +475,7 @@ fi
 for applet in sh mount umount mkdir ls cat dmesg switch_root losetup \
               mdev blkid lsblk modprobe sleep echo ln readlink rmdir \
               findfs uname grep sed cp rm tee date \
+              tail head sort basename dd mkfifo wait \
               udhcpc ip kill route nslookup hostname; do
     ln -sf /bin/busybox "$STAGE_DIR/bin/$applet"
 done


### PR DESCRIPTION
## Summary

Real-hardware boot log from #718 (AMD micro-PC + Wooting 80HE, 2026-05-03 04:29 UTC) revealed the post-modprobe diagnostic block bombed on missing busybox applets — including \`mkfifo\`, which silently broke #718's tee discipline + dropped the rescue-tui stderr capture.

## What was missing

| Applet | Used by | Symptom |
|---|---|---|
| \`tail\` | dmesg pipe | \`dmesg cmd produced no output\` (false negative) |
| \`sort\` | /proc/modules fallback | lsmod section empty |
| \`basename\` | /sys/class/input loop | device names with prefix mangled |
| \`head\` | dd /dev/kmsg fallback | path silently skipped |
| \`dd\` | /dev/kmsg read | path silently skipped |
| \`mkfifo\` | **tee discipline on rescue-tui stderr** | **rescue-tui logs never persisted** |

## Verified on real hardware

Same boot also confirmed #713 worked end-to-end: Wooting 80HE keyboard fully enumerated (event2-event4: kbd + System Control + Consumer Control), USB topology fully visible (Wooting + Asmedia hubs + VIA hubs + Realtek BT radio), 6 input event devices live.

Stick re-rotated with the applet-fixed initramfs (sha256 \`e7487e04...\`); operator booting on AMD micro-PC will get the full diagnostic capture next try.

## Test plan

- [x] Local: \`bash -n\` syntax check
- [x] Local: rebuild initramfs + ship to stick via \`update --apply\`
- [ ] CI green
- [ ] Operator boot test confirms \`-rescue-tui.log\` + \`-rescue-tui-exit.log\` land on AEGIS_ISOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)