### PR TITLE
feat(rescue-tui): defer ISO hashing via AEGIS_LAZY_HASH for snappy TUI startup

### DIFF
--- a/crates/iso-probe/src/lib.rs
+++ b/crates/iso-probe/src/lib.rs
@@ -344,6 +344,22 @@ fn find_iso_size(root: &Path, filename: &str) -> Option<u64> {
 /// of the file (so a 3 GB ISO emits ~8 progress ticks ≈ every 12 s on
 /// USB 2.0). Cheap; no impact on hash throughput.
 fn verify_iso_hash_with_console_progress(iso_path: &Path) -> HashVerification {
+    // Lazy-hash escape hatch (operator-set, real-hardware UX request
+    // 2026-05-03): hashing 3 GB on USB 2.0 takes ~90 s of blank
+    // screen before the TUI alt-screen takeover. With AEGIS_LAZY_HASH
+    // set, discover() returns NotPresent for every ISO + the operator
+    // verifies on demand via the `v` key (existing #548 feature).
+    // Trade-off: no proactive verdict colors at TUI startup; operator
+    // explicitly opts into verification per-ISO. /init exports this
+    // by default for snappy startup; operators or environments that
+    // want eager hashing can `unset AEGIS_LAZY_HASH` before exec.
+    if std::env::var_os("AEGIS_LAZY_HASH").is_some() {
+        tracing::info!(
+            iso = %iso_path.display(),
+            "iso-probe: skipping eager hash (AEGIS_LAZY_HASH set — operator must press 'v' to verify)"
+        );
+        return HashVerification::NotPresent;
+    }
     let total_bytes = std::fs::metadata(iso_path).map_or(0, |m| m.len());
     let total_mib = total_bytes / (1024 * 1024);
     tracing::info!(

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -1029,6 +1029,21 @@ if [ -z "${RUST_LOG:-}" ]; then
     export RUST_LOG="rescue_tui=trace,iso_probe=debug,kexec_loader=debug,aegis_fetch=info,info"
 fi
 
+# Lazy-hash by default for snappy TUI startup. Without this,
+# rescue-tui's discover() eager-hashes every ISO before the alt-
+# screen takeover — ~90 s blank screen for a 3 GB Ubuntu ISO on
+# USB 2.0 (real-hardware UX report 2026-05-03). With AEGIS_LAZY_HASH
+# set, discover() returns NotPresent for every ISO + the operator
+# verifies on demand via the `v` key (existing #548 feature).
+# Operators / environments that want eager hashing back can
+# `unset AEGIS_LAZY_HASH` before the rescue-tui exec — handy for
+# lab benches where startup latency is fine and proactive trust
+# verdicts are preferred.
+if [ -z "${AEGIS_LAZY_HASH+x}" ]; then
+    export AEGIS_LAZY_HASH=1
+    /bin/echo "init: AEGIS_LAZY_HASH=1 (defer hash to operator demand — press 'v' in TUI)"
+fi
+
 # Persist rescue-tui stderr to AEGIS_ISOS so the operator-reported
 # "screen full of artifacts, dialogs sort of worked, typing 'boot'
 # did nothing" symptoms (2026-05-03) leave a forensic trail. Without


### PR DESCRIPTION
## Summary

Operator UX request 2026-05-03: "do we need to hash before getting into the tui? the lag sucks and is a bad user experience."

Answer: no. With \`AEGIS_LAZY_HASH=1\`, \`iso_probe::discover()\` returns \`NotPresent\` for every ISO instead of computing sha256 eagerly. TUI renders **immediately** on startup. Operator verifies on demand:

- \`v\` key → verify the highlighted ISO (existing #548 \`spawn_verify_worker\` flow — progress in info pane, verdict updates in real-time)
- \`Enter\` to boot still hits the existing verify-then-kexec gate for tier-2 ISOs (typed-confirm "boot")

\`/init\` exports \`AEGIS_LAZY_HASH=1\` by default. Operators who want eager hashing back can \`unset AEGIS_LAZY_HASH\` before the rescue-tui exec.

## Trade-off

We lose proactive verdict colors at startup. The common operator flow ("I'm picking ONE — verify just that one") was already paying for N hashes when only 1 mattered. Lazy is the right default for an operator-driven rescue tool.

## Out of scope (file as follow-up)

The strictly-better long-term UX: render TUI immediately + background-verify all ISOs sequentially via one worker thread + a queue of pending indices, updating each row as hashes complete. Existing \`spawn_verify_worker\` + \`active_verify\` plumbing supports a single-slot worker; generalizing to a queue is ~50-100 lines of event-loop refactor.

## Stick state

Built locally (sha256 \`0433a305...\`); operator's stick wasn't plugged in at push time, will ship via \`update --apply\` next time it's connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)