### PR TITLE
fix(release-please): drop package-name + explicit title pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
   "draft": false,
   "prerelease": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore${scope}: release ${version}",
   "changelog-path": "CHANGELOG.md",
   "changelog-sections": [
     { "type": "feat",     "section": "Features",            "hidden": false },
@@ -24,7 +25,6 @@
   ],
   "packages": {
     ".": {
-      "package-name": "aegis-boot",
       "release-type": "simple",
       "extra-files": [
         "Cargo.toml",


### PR DESCRIPTION
## Summary

v0.19.0 had to be shipped manually (gh release create + label flip to `autorelease: tagged`) because release-please's tagger silently no-op'd. Workflow log:

```
⚠ PR component: undefined does not match configured component: aegis-boot
⚠ pullRequestTitlePattern miss the part of '${scope}'
⚠ pullRequestTitlePattern miss the part of '${component}'
⚠ pullRequestTitlePattern miss the part of '${version}'
⚠ There are untagged, merged release PRs outstanding - aborting
```

The PR opener generated `chore: release main` (manifest mode + `separate-pull-requests=false` defaults to `chore${scope}: release ${branch}`), which contains no component or version. The tagger then extracted `component=undefined` from that title and rejected the PR because the package config declared `package-name=aegis-boot`.

## Two changes to make open + match consistent

1. **Drop `package-name: aegis-boot`** from `.packages."."`. The `include-component-in-tag: false` setting already meant the component never appeared in tags (`v0.19.0`, not `aegis-boot-v0.19.0`); removing `package-name` aligns the declared-component (now also undefined) with the title-extracted component the tagger sees.

2. **Add explicit `pull-request-title-pattern`** at the top level: `chore${scope}: release ${version}`. The next release PR's title becomes `chore: release 0.20.0` instead of `chore: release main`, and the tagger can extract the version from the title.

## Verification path

After this merges, the next conventional commit on main will trigger release-please to open a fresh release PR. Expected title: `chore: release 0.20.0`. When that PR is merged, release-please should auto-tag + create the release without manual intervention.

If the tagger ever logs `untagged, merged release PRs outstanding` again, fall back to the manual ship recipe saved in `memory/project_release_please_tagging_bug.md`.

## Test plan

- [x] `release-please-config.json` parses as valid JSON (`jq .`)
- [x] No code changes — pure config tweak
- [ ] Real-world verification: next push to main with a conventional commit must produce a release PR titled `chore: release X.Y.Z` (not `chore: release main`)
- [ ] When that release PR is merged, release-please auto-tags + creates the GitHub release (no manual intervention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)