### PR TITLE
fix(initramfs): silence kernel printk + drop startup-banner fifo race

### DIFF
--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -284,10 +284,27 @@ fn run(roots: &[PathBuf]) -> Result<u8, Box<dyn std::error::Error>> {
     let counted_but_not_attempted = on_disk_iso_count.saturating_sub(isos.len() + failed.len());
     let skipped = failed.len() + counted_but_not_attempted;
     persist_tier_b_log(&failed);
-    // Startup banner to stderr — mirrored via tracing::info! so structured
-    // consumers (journald, CI smoke greps) see the same signal as humans
-    // reading the serial console directly.
-    eprintln!(
+    // Startup banner via println! (fd 1), NOT eprintln! (fd 2).
+    //
+    // /init runs us as `/usr/bin/rescue-tui 2>"$TUI_FIFO"` — fd 2
+    // goes through a fifo + background tee that fans out to the
+    // log file AND back to /dev/console at tee's leisure. Three
+    // lines below we issue crossterm Clear (which writes directly
+    // to fd 1 = /dev/console). When the banner used eprintln, the
+    // tee could flush it AFTER the Clear had already run, leaving
+    // a stray row above the TUI grid that accumulated visible
+    // scroll over redraw cycles (operator-real-hardware report
+    // 2026-05-03: "TUI was scrolled up off the screen").
+    //
+    // Switching to println! keeps the banner on fd 1, the same path
+    // as the Clear escape — ordering is deterministic, no fifo race,
+    // and CI consumers that grep the serial log for the literal
+    // "aegis-boot rescue-tui starting" still match (serial.log
+    // captures both the print AND the Clear escape; the print is
+    // wiped from the visible framebuffer by Clear but the captured
+    // bytes remain). Mirror via tracing::info! so the structured
+    // log file gets it too.
+    println!(
         "aegis-boot rescue-tui starting: discovered {} ISO(s){}",
         isos.len(),
         if skipped > 0 {

--- a/scripts/build-initramfs.sh
+++ b/scripts/build-initramfs.sh
@@ -1186,6 +1186,27 @@ fi
 if [ -n "$RESCUE_TUI_LOG" ]; then
     /bin/echo "init: rescue-tui stderr → $RESCUE_TUI_LOG (RUST_LOG=$RUST_LOG)"
 fi
+
+# Silence kernel printk -> /dev/console while rescue-tui owns the
+# screen. Without this, late driver loads (USB enumeration, modprobe
+# of detached devices, hotplug events) write dmesg lines to the
+# framebuffer console AT THE CURRENT CURSOR POSITION, scrolling the
+# TUI grid up off the screen. Operator-real-hardware report
+# 2026-05-03: "TUI was scrolled up off the screen and the bottom
+# third of the screens were log outputs." Save current value (default
+# is something like "4 4 1 7"), set to "1" (only EMERG prints to
+# console), restore on exit so the emergency shell still sees real-
+# time WARN/ERR. The kernel ring buffer + /dev/kmsg + dmesg(1) all
+# stay populated regardless — silenced messages are still recoverable
+# post-mortem via the dmesg-tail block above + the on-stick log.
+PRINTK_SAVED=""
+if [ -r /proc/sys/kernel/printk ] && [ -w /proc/sys/kernel/printk ]; then
+    PRINTK_SAVED=$(/bin/cat /proc/sys/kernel/printk 2>/dev/null)
+    if /bin/echo 1 > /proc/sys/kernel/printk 2>/dev/null; then
+        /bin/echo "init: silenced kernel printk -> console (saved=$PRINTK_SAVED; restored on rescue-tui exit)"
+    fi
+fi
+
 checkpoint "pre-rescue-tui-exec"
 
 # Hand off. Exit code semantics (#90):
@@ -1244,6 +1265,13 @@ case "$rc" in
     42)  /bin/echo "init: rescue shell requested by operator (#90)" ;;
     *)   /bin/echo "init: rescue-tui exited unexpectedly (rc=$rc); dropping to emergency shell" ;;
 esac
+
+# Restore kernel printk console verbosity now that the TUI is gone.
+# Emergency shell + post-TUI diagnostics need real-time WARN/ERR.
+if [ -n "$PRINTK_SAVED" ] && [ -w /proc/sys/kernel/printk ]; then
+    /bin/echo "$PRINTK_SAVED" > /proc/sys/kernel/printk 2>/dev/null && \
+        /bin/echo "init: restored kernel printk -> console ($PRINTK_SAVED)"
+fi
 # Persist rc + a tail of the captured stderr so the post-boot operator
 # (or me, on a future stick inspection) can see the exit cause without
 # re-rebooting. Best-effort, doesn't fail the init.


### PR DESCRIPTION
## Summary

Operator real-hardware report 2026-05-03 (after #729 merged):
> the TUI was scrolled up off the screen and the bottom third of the screens were log outputs.

#729 redirected `tracing::*!()` to `/run/aegis-rescue-tui.log` so structured logs no longer leaked. But two other writers were still painting underneath the TUI grid:

### 1. Late kernel dmesg

Modalias coldplug + USB enumeration continue emitting kernel printk lines AFTER /init has exec'd rescue-tui (`usb 1-1: new high-speed USB device`, driver init NOTICE/INFO, etc.). The rescue env never lowered console_loglevel below default — each line scrolled the framebuffer up by one row.

**Fix**: /init saves `/proc/sys/kernel/printk` before exec'ing rescue-tui, sets it to `"1"` (only EMERG prints to console), restores the saved value on rescue-tui exit so the emergency shell still sees real-time WARN/ERR. Kernel ring buffer + `/dev/kmsg` + `dmesg(1)` are unaffected — silenced messages remain recoverable via the dmesg-tail block + on-stick log.

### 2. Startup banner fifo race

rescue-tui's startup `eprintln!` went to fd 2, which /init pipes through a fifo + background tee. The tee fan-out can flush AFTER crossterm `Clear` has already wiped the framebuffer, leaving a stray row above the TUI grid that compounds the scroll.

**Fix**: switch `eprintln!` → `println!`. fd 1 goes directly to /dev/console (same path as crossterm's Clear), so ordering is deterministic — no fifo race. CI consumers that grep serial for `aegis-boot rescue-tui starting` (six callsites: e2e-suite.yml × 3, qemu-smoke.sh, ovmf-secboot-e2e.sh, dev-test.sh) still match — the line is captured in serial.log on its way through, even though Clear visually wipes it microseconds later.

## Test plan

- [x] `cargo test -p rescue-tui --lib` — 289 pass
- [x] `cargo clippy -p rescue-tui --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p rescue-tui` clean
- [ ] CI E2E canaries — verify all six "rescue-tui starting" greps still match
- [ ] Real hardware retry — operator AMD micro-PC: TUI should now sit at top of framebuffer, no log scroll, no stray row

## Files

- `scripts/build-initramfs.sh` — printk save/silence/restore pair around `/usr/bin/rescue-tui` exec
- `crates/rescue-tui/src/main.rs` — `eprintln!` → `println!` for startup banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)