### PR TITLE
fix(rescue-tui): inject nomodeset + pre-kexec forensic dump for casper boots

### DIFF
--- a/crates/rescue-tui/src/kexec_cmdline.rs
+++ b/crates/rescue-tui/src/kexec_cmdline.rs
@@ -11,7 +11,7 @@
 //! squashfs from inside. Our static iso-parser doesn't substitute
 //! the GRUB variable, so the arg gets dropped — casper boots blind.
 //!
-//! This module adds two enrichments to the cmdline before it's
+//! This module adds three enrichments to the cmdline before it's
 //! handed to `kexec_file_load`:
 //!
 //!   1. **`iso-scan/filename=<path>`** for casper-style ISOs
@@ -23,6 +23,24 @@
 //!      grub.cfg-in-ISO usually includes `quiet splash ---` with
 //!      no console hint; without one, the kexec'd kernel may print
 //!      to a serial port the operator can't see.
+//!
+//!   3. **`nomodeset`** for Debian distros if not already present.
+//!      Operator real-hardware report 2026-05-03 (post-#732):
+//!      kexec'ing Ubuntu Server on an AMD micro-PC printed the
+//!      handoff banner then went silent for 30+ seconds — the
+//!      kexec'd kernel WAS running (no kexec error returned), but
+//!      its dmesg never reached the framebuffer. Root cause: the
+//!      kernel's amdgpu driver init takes seconds to set up KMS
+//!      (kernel mode setting); during that window, all kernel
+//!      output queues to a buffer that flushes to the framebuffer
+//!      ONLY after KMS is up. If KMS hits a snag (firmware load,
+//!      hotplug race), the buffer never flushes — operator sees
+//!      a black screen. `nomodeset` skips KMS entirely; the kernel
+//!      uses basic VGA from boot, dmesg is visible immediately.
+//!      Trade-off: GPU acceleration is disabled in the booted
+//!      live system. Acceptable for live-installer use cases;
+//!      operator can remove `nomodeset` from the cmdline override
+//!      if they're booting on Intel/Nvidia and want acceleration.
 //!
 //! Other distros (Arch, Fedora, openSUSE, Alpine, NixOS) need
 //! their own per-distro injection — tracked as follow-up to #728.
@@ -65,6 +83,17 @@ pub fn enrich_cmdline_for_kexec(
             out.push(' ');
         }
         out.push_str("console=tty0");
+    }
+
+    // Force basic VGA + visible early dmesg for Debian distros that
+    // would otherwise queue output behind a KMS init that may never
+    // complete on operator-real-hardware. See module-doc #3 for
+    // rationale.
+    if distribution == Distribution::Debian && !cmdline_has_arg(&out, "nomodeset") {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str("nomodeset");
     }
 
     out
@@ -312,5 +341,51 @@ mod tests {
             &p("/run/media/aegis-isos/x.iso"),
         );
         assert_eq!(once, twice, "enrich should be idempotent");
+    }
+
+    // ---- nomodeset injection (post-#732 operator real-hardware fix) ----
+
+    #[test]
+    fn enrich_adds_nomodeset_for_debian() {
+        let base = "boot=casper";
+        let out = enrich_cmdline_for_kexec(
+            base,
+            Distribution::Debian,
+            &p("/run/media/aegis-isos/x.iso"),
+        );
+        assert!(
+            out.contains("nomodeset"),
+            "expected nomodeset for Debian: {out}"
+        );
+    }
+
+    #[test]
+    fn enrich_skips_nomodeset_when_already_present() {
+        let base = "boot=casper nomodeset";
+        let out = enrich_cmdline_for_kexec(
+            base,
+            Distribution::Debian,
+            &p("/run/media/aegis-isos/x.iso"),
+        );
+        let count = out.split_whitespace().filter(|t| *t == "nomodeset").count();
+        assert_eq!(count, 1, "nomodeset should appear exactly once: {out}");
+    }
+
+    #[test]
+    fn enrich_skips_nomodeset_for_non_debian_distros() {
+        // nomodeset is Debian-specific until per-distro AMD-GPU triage
+        // is done for Fedora/Arch/openSUSE (each has its own KMS
+        // semantics and may not have the same casper-style early-boot
+        // hang). Conservative: only inject where we have evidence.
+        let base = "rd.live.image";
+        let out = enrich_cmdline_for_kexec(
+            base,
+            Distribution::Fedora,
+            &p("/run/media/aegis-isos/fedora.iso"),
+        );
+        assert!(
+            !out.contains("nomodeset"),
+            "nomodeset is Debian-specific, not added for Fedora: {out}"
+        );
     }
 }

--- a/crates/rescue-tui/src/main.rs
+++ b/crates/rescue-tui/src/main.rs
@@ -1753,6 +1753,19 @@ fn attempt_kexec(state: &mut AppState, idx: usize) {
         "invoking kexec_file_load"
     );
 
+    // Pre-kexec forensic dump: write the FINAL request (paths +
+    // enriched cmdline) to AEGIS_ISOS BEFORE handing off. Operator
+    // real-hardware report 2026-05-03 (post-#732): Ubuntu Server
+    // kexec succeeded but the new kernel went silent for 30+
+    // seconds, then the operator power-cycled. Without this dump,
+    // we have no record of what cmdline was actually passed —
+    // /run/aegis-rescue-tui.log is on tmpfs and gone after reboot,
+    // and the AEGIS_ISOS-side rescue-tui.log only reflects writes
+    // that flushed before the power button. Writing + sync'ing this
+    // file BEFORE load_and_exec gives every future post-mortem a
+    // ground-truth `kexec-attempt-<ts>.log` that survives.
+    persist_kexec_attempt(&iso.label, &req);
+
     // #127: post-kexec handoff banner. Print to stderr (which the
     // terminal still has when the TUI exits alt-screen) so the
     // operator isn't staring at a black screen wondering if the
@@ -1767,6 +1780,102 @@ fn attempt_kexec(state: &mut AppState, idx: usize) {
         Err(e) => {
             tracing::error!(error = %e, "kexec failed");
             state.record_kexec_error(&e);
+        }
+    }
+}
+
+/// Best-effort forensic dump of the pending kexec request to
+/// `AEGIS_ISOS`. Writes a single timestamped file with the ISO
+/// label, kernel/initrd paths, and final enriched cmdline, then
+/// sync's so the data is on physical media before `kexec_file_load`
+/// runs.
+///
+/// Failures are logged at WARN and otherwise ignored — this is a
+/// diagnostic, not a precondition. If the partition isn't mounted
+/// or is read-only, the kexec proceeds without the file.
+fn persist_kexec_attempt(label: &str, req: &kexec_loader::KexecRequest) {
+    use std::fmt::Write as FmtWrite;
+    use std::io::Write as IoWrite;
+
+    let dir = std::path::Path::new("/run/media/aegis-isos");
+    if !dir.is_dir() {
+        tracing::debug!("persist_kexec_attempt: AEGIS_ISOS not mounted; skipping forensic dump");
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let path = dir.join(format!("aegis-boot-{now}-kexec-attempt.log"));
+
+    let mut buf = String::new();
+    let _ = FmtWrite::write_fmt(
+        &mut buf,
+        format_args!("aegis-boot — pre-kexec forensic dump\n"),
+    );
+    let _ = FmtWrite::write_fmt(
+        &mut buf,
+        format_args!("version: {}\n", env!("CARGO_PKG_VERSION")),
+    );
+    let _ = FmtWrite::write_fmt(&mut buf, format_args!("unix_ts: {now}\n\n"));
+    let _ = FmtWrite::write_fmt(&mut buf, format_args!("label:   {label}\n"));
+    let _ = FmtWrite::write_fmt(
+        &mut buf,
+        format_args!("kernel:  {}\n", req.kernel.display()),
+    );
+    if let Some(ref initrd) = req.initrd {
+        let _ = FmtWrite::write_fmt(&mut buf, format_args!("initrd:  {}\n", initrd.display()));
+    } else {
+        buf.push_str("initrd:  (none)\n");
+    }
+    buf.push_str("\ncmdline (final, post-enrichment):\n");
+    let _ = FmtWrite::write_fmt(&mut buf, format_args!("  {}\n\n", req.cmdline));
+    buf.push_str("Read this file after a power-cycled boot to confirm\n");
+    buf.push_str("what cmdline rescue-tui actually passed to\n");
+    buf.push_str("kexec_file_load(2). If the kernel went silent or\n");
+    buf.push_str("stalled, this is the ground-truth handoff.\n");
+
+    // Use OpenOptions + write + sync_all to land the bytes on disk.
+    // sync_all() flushes both content + metadata for THIS file, which
+    // is the strongest guarantee a portable Rust process can give for
+    // its own write. To drain the partition-level write-back queue
+    // (#721 / exfat is async-by-default), then shell out to /bin/sync
+    // — busybox ships it; ignore failures since this is best-effort.
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)
+    {
+        Ok(mut f) => {
+            let write_result =
+                IoWrite::write_all(&mut f, buf.as_bytes()).and_then(|()| f.sync_all());
+            drop(f);
+            match write_result {
+                Ok(()) => {
+                    let _ = std::process::Command::new("/bin/sync")
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status();
+                    tracing::info!(
+                        path = %path.display(),
+                        "persist_kexec_attempt: forensic dump written + sync'd"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %path.display(),
+                        "persist_kexec_attempt: write/sync_all failed mid-flush"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "persist_kexec_attempt: failed to open forensic dump file"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the Ubuntu casper kexec stall reported on operator real-hardware (AMD micro-PC, post-#732):

> [after kexec] it stalled out at the screen saying it would either output an error or boot in ten seconds. I waited 30 seconds and then power cycled

## Diagnosis

`kexec_file_load(2)` DID succeed — otherwise rescue-tui's TUI would have come back with `state.record_kexec_error` rendering the failure. The new kernel was running but its dmesg never reached the framebuffer. Most likely cause on AMD hardware: amdgpu KMS init takes seconds to set up the modesetting framebuffer, and during that window all kernel output queues to a buffer that flushes ONLY when KMS is up. Snag during KMS init → buffer never flushes → operator sees a black screen → power-cycle.

## Fix — two layers

### 1. `nomodeset` for Debian distros

`enrich_cmdline_for_kexec` now injects `nomodeset` alongside the existing `iso-scan/filename=` and `console=tty0` for casper-style boots. `nomodeset` skips KMS entirely — kernel uses basic VGA from boot, dmesg is visible immediately. GPU acceleration is disabled in the booted live system; acceptable trade-off for live-installer use cases (operator can remove `nomodeset` via the cmdline edit screen if they want acceleration on Intel/Nvidia). Idempotent + word-boundary matched.

3 new tests:
- `enrich_adds_nomodeset_for_debian`
- `enrich_skips_nomodeset_when_already_present`
- `enrich_skips_nomodeset_for_non_debian_distros`

### 2. Pre-kexec forensic dump

`attempt_kexec` writes `/run/media/aegis-isos/aegis-boot-<unix_ts>-kexec-attempt.log` BEFORE calling `load_and_exec`. Contents:

```
aegis-boot — pre-kexec forensic dump
version: 0.19.1
unix_ts: 1730643200

label:   Ubuntu Server 24.04
kernel:  /tmp/iso-parser-mounts/.../casper/vmlinuz
initrd:  /tmp/iso-parser-mounts/.../casper/initrd
cmdline (final, post-enrichment):
  boot=casper locale=… iso-scan/filename=/ubuntu.iso console=tty0 nomodeset

Read this file after a power-cycled boot to confirm what cmdline
rescue-tui actually passed to kexec_file_load(2). If the kernel
went silent or stalled, this is the ground-truth handoff.
```

`sync_all()` on the file handle + shell out to `/bin/sync` drains the exfat write-back queue (same-shape pattern as #721 hardened for the rescue-tui stderr capture) so an operator power-button reset between kexec-attempt and a hung kernel still leaves the file on physical media. Best-effort — missing AEGIS_ISOS or write failures log at WARN and don't block the kexec.

## Test plan

- [x] `cargo test -p rescue-tui --lib` — 292 pass (3 new)
- [x] `cargo clippy -p rescue-tui --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p rescue-tui` clean
- [ ] CI E2E + boot canaries
- [ ] Operator real-hardware retry: TUI no longer scrolls (post-#732), kexec'd Ubuntu Server should now print early dmesg via VGA without depending on amdgpu KMS init. The forensic file gives a post-mortem trail if it still fails.

## Operator note

After this merges + a fresh stick is reflashed, on the AMD micro-PC:
1. Plug stick → boot. TUI should be readable + not scrolled (post-#732).
2. Pick Ubuntu Server, press Enter.
3. Watch handoff banner. With nomodeset, the kexec'd kernel should now print `Linux version 6.x ...` to the framebuffer within seconds. If it doesn't, the file at `/run/media/aegis-isos/aegis-boot-<ts>-kexec-attempt.log` (readable from any computer that can mount the stick's exfat partition) shows the exact cmdline + paths attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)