### PR TITLE
fix(ci): regen Cargo.lock + CLI_SYNOPSIS for v0.19.2 (release.yml --locked drift)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-bootctl"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aegis-catalog",
  "aegis-core",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-catalog"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aegis-catalog-data",
 ]
@@ -57,11 +57,11 @@ dependencies = [
 
 [[package]]
 name = "aegis-core"
-version = "0.19.1"
+version = "0.19.2"
 
 [[package]]
 name = "aegis-fetch"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aegis-catalog",
  "pgp",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-fitness"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-trust"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "minisign",
  "serde",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "aegis-wire-formats"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "schemars",
  "serde",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "iso-parser"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "iso-probe"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "hex",
  "iso-parser",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "kexec-loader"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "libc",
  "thiserror",
@@ -1927,7 +1927,7 @@ checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "rescue-tui"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "aegis-catalog",
  "aegis-core",

--- a/docs/reference/CLI_SYNOPSIS.md
+++ b/docs/reference/CLI_SYNOPSIS.md
@@ -112,7 +112,7 @@ EXAMPLES:
   aegis-boot bug-report --output report.json --format json
   aegis-boot bug-report --include-stick /media/$USER/AEGIS_ISOS
 
-(aegis-boot v0.19.1)
+(aegis-boot v0.19.2)
 ```
 
 ## `aegis-boot compat`
@@ -233,11 +233,11 @@ aegis-boot fetch-image — download + verify a pre-built aegis-boot image
 
 USAGE:
   aegis-boot fetch-image                               # latest release, cosign auto-verify
-  aegis-boot fetch-image --version v0.19.1             # pin to a specific release
+  aegis-boot fetch-image --version v0.19.2             # pin to a specific release
   aegis-boot fetch-image --url URL [--sha256 HEX]      # arbitrary URL
 
   --url URL       HTTPS URL of the aegis-boot.img to download (overrides --version)
-  --version TAG   Pin to a specific release tag (e.g. v0.19.1)
+  --version TAG   Pin to a specific release tag (e.g. v0.19.2)
   --out PATH      Where to write the image (default: $XDG_CACHE_HOME/aegis-boot/)
   --sha256 HEX    Required sha256; mismatch deletes the download + exits 1
   --no-cosign     Skip the cosign keyless signature check (air-gap, offline)


### PR DESCRIPTION
## Summary

PR #740 (the v0.19.2 release-please PR) merged BEFORE the workflow's `refresh-generated-files` job could push its Cargo.lock + CLI_SYNOPSIS regeneration commit. Auto-merge race condition: my monitor saw `MERGEABLE/CLEAN` after the first job (`Open or merge release PR`) completed and merged immediately, while the second job (`Refresh Cargo.lock + CLI_SYNOPSIS.md on release PR`) was still running.

Result on main: Cargo.toml at `0.19.2`, but Cargo.lock pinned to `0.19.1` for every workspace member. `release.yml`'s `cargo build --locked` failed with:

```
error: cannot update the lock file /home/runner/work/aegis-boot/aegis-boot/Cargo.lock because --locked was passed to prevent this
```

## Change

Cherry-picks the orphaned commit (`ba852fa`) from the release-please branch — the EXACT regeneration the refresh job had produced, just never landed:

- `Cargo.lock` — workspace member versions bumped 0.19.1 → 0.19.2
- `docs/reference/CLI_SYNOPSIS.md` — version literals embedded by `cli-docgen` synced

## Verification

- [x] `cargo build --workspace --locked` succeeds locally
- [x] No source-code changes; only generated-file deltas
- [ ] CI green
- [ ] After merge, release-please will open a v0.19.3 PR (this fix is conventional-commit `fix:`); when that's merged, release.yml should succeed because Cargo.lock is finally aligned

## Process follow-up

The auto-merge monitor needs to wait for the ENTIRE release-please workflow to finish (both the `release-please` job AND `refresh-generated-files`) before merging, not just check PR mergeability. Tracking as a follow-up after this lands; for now the safety check is "don't auto-merge release-please PRs until both workflow jobs are completed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)